### PR TITLE
Allow adding only constant (no schematic) symbols to a running theory

### DIFF
--- a/src/main/scala/lisa/kernel/Printer.scala
+++ b/src/main/scala/lisa/kernel/Printer.scala
@@ -36,7 +36,7 @@ object Printer {
     ConstantFunctionLabel("power_set", 1),
     ConstantFunctionLabel("union", 1)
   )
-  private val nonAtomicPredicates = Set(equality, membership, subsetOf, sameCardinality) // Predicates which require parentheses (for readability)
+  private val nonAtomicPredicates: Set[PredicateLabel] = Set(equality, membership, subsetOf, sameCardinality) // Predicates which require parentheses (for readability)
 
   private def prettyFormulaInternal(formula: Formula, isRightMost: Boolean, compact: Boolean): String = formula match {
     case PredicateFormula(label, args) =>

--- a/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
@@ -20,6 +20,11 @@ private[fol] trait CommonDefinitions {
     val id: String
   }
 
+  /**
+   * Marks classes that can represent symbols in a theory
+   */
+  trait TheorySymbol
+
   def freshId(taken: Set[String], base: String): String = {
     var i = 0;
     while (taken contains base + "_" + i) i += 1

--- a/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
@@ -21,9 +21,15 @@ private[fol] trait CommonDefinitions {
   }
 
   /**
-   * Marks classes that can represent symbols in a theory
+   * Constant label can represent a symbol of a theory
    */
-  trait TheorySymbol
+  trait ConstantLabel extends Label
+
+  /**
+   * Schematic label in a formula can be substituted by any constant label of the respective
+   * kind (predicate or function)
+   */
+  trait SchematicLabel extends Label
 
   def freshId(taken: Set[String], base: String): String = {
     var i = 0;

--- a/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
@@ -41,12 +41,12 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
   /**
    * A standard predicate symbol. Typical example are equality (=) and membership (∈)
    */
-  final case class ConstantPredicateLabel(id: String, arity: Int) extends PredicateLabel
+  final case class ConstantPredicateLabel(id: String, arity: Int) extends PredicateLabel with TheorySymbol
 
   /**
    * The equality symbol (=) for first order logic.
    */
-  val equality: PredicateLabel = ConstantPredicateLabel("=", 2)
+  val equality: ConstantPredicateLabel = ConstantPredicateLabel("=", 2)
 
   /**
    * A predicate symbol that can be instantiated with any formula.

--- a/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
@@ -41,7 +41,7 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
   /**
    * A standard predicate symbol. Typical example are equality (=) and membership (∈)
    */
-  final case class ConstantPredicateLabel(id: String, arity: Int) extends PredicateLabel with TheorySymbol
+  final case class ConstantPredicateLabel(id: String, arity: Int) extends PredicateLabel with ConstantLabel
 
   /**
    * The equality symbol (=) for first order logic.

--- a/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -54,7 +54,7 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    * @param id    The name of the function symbol.
    * @param arity The arity of the function symbol. A function symbol of arity 0 is a constant
    */
-  final case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel
+  final case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel with TheorySymbol
 
   /**
    * A schematic function symbol that can be substituted.

--- a/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -54,7 +54,7 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    * @param id    The name of the function symbol.
    * @param arity The arity of the function symbol. A function symbol of arity 0 is a constant
    */
-  final case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel with TheorySymbol
+  final case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel with ConstantLabel
 
   /**
    * A schematic function symbol that can be substituted.

--- a/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -62,12 +62,12 @@ class RunningTheory {
 
   private[proof] val theoryAxioms: mMap[String, Axiom] = mMap.empty
   private[proof] val theorems: mMap[String, Theorem] = mMap.empty
-  private[proof] val definitions: mMap[TheorySymbol, Option[Definition]] = mMap(equality -> None)
+  private[proof] val definitions: mMap[ConstantLabel, Option[Definition]] = mMap(equality -> None)
 
   /**
    * Check if a label is a symbol of the theory
    */
-  def isSymbol(label: TheorySymbol): Boolean = definitions.contains(label)
+  def isSymbol(label: ConstantLabel): Boolean = definitions.contains(label)
 
   /**
    * From a given proof, if it is true in the Running theory, add that theorem to the theory and returns it.
@@ -255,13 +255,13 @@ class RunningTheory {
    * For example, This function can add the empty set symbol to a theory, and then an axiom asserting
    * the it is empty can be introduced as well.
    */
-  def addSymbol(s: TheorySymbol): Unit = definitions.update(s, None)
+  def addSymbol(s: ConstantLabel): Unit = definitions.update(s, None)
 
   /**
    * Public accessor to the set of symbol currently in the theory's language.
    * @return the set of symbol currently in the theory's language.
    */
-  def language: List[(TheorySymbol, Option[Definition])] = definitions.toList
+  def language: List[(ConstantLabel, Option[Definition])] = definitions.toList
 
   /**
    * Public accessor to the current set of axioms of the theory

--- a/src/main/scala/lisa/settheory/SetTheoryDefinitions.scala
+++ b/src/main/scala/lisa/settheory/SetTheoryDefinitions.scala
@@ -16,20 +16,20 @@ private[settheory] trait SetTheoryDefinitions {
   final val sPhi = SchematicPredicateLabel("P", 2)
   final val sPsi = SchematicPredicateLabel("P", 3)
   // Predicates
-  final val in: PredicateLabel = ConstantPredicateLabel("set_membership", 2)
-  final val subset: PredicateLabel = ConstantPredicateLabel("subset_of", 2)
-  final val sim: PredicateLabel = ConstantPredicateLabel("same_cardinality", 2) // Equicardinality
+  final val in = ConstantPredicateLabel("set_membership", 2)
+  final val subset = ConstantPredicateLabel("subset_of", 2)
+  final val sim = ConstantPredicateLabel("same_cardinality", 2) // Equicardinality
   final val predicates = Set(in, subset, sim)
   // val application
   // val pick
 
   // Functions
-  final val emptySet: FunctionLabel = ConstantFunctionLabel("empty_set", 0)
-  final val pair: FunctionLabel = ConstantFunctionLabel("unordered_pair", 2)
-  final val singleton: FunctionLabel = ConstantFunctionLabel("singleton", 1)
-  final val powerSet: FunctionLabel = ConstantFunctionLabel("power_set", 1)
-  final val union: FunctionLabel = ConstantFunctionLabel("union", 1)
-  final val universe: FunctionLabel = ConstantFunctionLabel("universe", 1)
+  final val emptySet = ConstantFunctionLabel("empty_set", 0)
+  final val pair = ConstantFunctionLabel("unordered_pair", 2)
+  final val singleton = ConstantFunctionLabel("singleton", 1)
+  final val powerSet = ConstantFunctionLabel("power_set", 1)
+  final val union = ConstantFunctionLabel("union", 1)
+  final val universe = ConstantFunctionLabel("universe", 1)
   final val functions = Set(emptySet, pair, singleton, powerSet, union, universe)
 
   val runningSetTheory: RunningTheory = new RunningTheory()


### PR DESCRIPTION
Highlight the separation between Function/Predicate labels and possible symbols by marking constant function and predicate labels with TheorySymbol.