### PR TITLE
Make proof tactics always return correct proofs given correct components

### DIFF
--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -4,9 +4,8 @@ import lisa.kernel.proof.RunningTheory
 import lisa.kernel.proof.RunningTheoryJudgement
 import lisa.kernel.proof.RunningTheoryJudgement.InvalidJustification
 import lisa.kernel.proof.SCProof
-import lisa.kernel.proof.SequentCalculus
-import lisa.kernel.proof.SequentCalculus.Rewrite
-import lisa.kernel.proof.SequentCalculus.isSameSequent
+import lisa.kernel.proof.SCProofCheckerJudgement.SCInvalidProof
+import lisa.kernel.proof.SequentCalculus._
 
 /**
  * A helper file that provides various syntactic sugars for LISA's FOL and proofs. Best imported through utilities.Helpers
@@ -157,4 +156,7 @@ trait KernelHelpers {
     s.left.map(phi => instantiateTermSchemas(phi, m)) |- s.right.map(phi => instantiateTermSchemas(phi, m))
   }
 
+  extension (sp: SCSubproof) {
+    def withPremises(premises: IndexedSeq[Int]): SCSubproof = SCSubproof(sp.sp, premises)
+  }
 }

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -100,17 +100,21 @@ trait KernelHelpers {
 
   val emptySeq: Sequent = Sequent(Set.empty, Set.empty)
 
+  private def removeFormula(s: Set[Formula], f: Formula): Set[Formula] = {
+    if (s.contains(f)) s - f else s.filterNot(isSame(_, f))
+  }
+
   extension (s: Sequent) {
     infix def +<(f: Formula): Sequent = s.copy(left = s.left + f)
-    infix def -<(f: Formula): Sequent = s.copy(left = s.left - f)
+    infix def -<(f: Formula): Sequent = s.copy(left = removeFormula(s.left, f))
     infix def +>(f: Formula): Sequent = s.copy(right = s.right + f)
-    infix def ->(f: Formula): Sequent = s.copy(right = s.right - f)
+    infix def ->(f: Formula): Sequent = s.copy(right = removeFormula(s.right, f))
     infix def ++<(s1: Sequent): Sequent = s.copy(left = s.left ++ s1.left)
-    infix def --<(s1: Sequent): Sequent = s.copy(left = s.left -- s1.left)
+    infix def --<(s1: Sequent): Sequent = s.copy(left = s1.left.foldLeft(s.left)(removeFormula))
     infix def ++>(s1: Sequent): Sequent = s.copy(right = s.right ++ s1.right)
-    infix def -->(s1: Sequent): Sequent = s.copy(right = s.right -- s1.right)
+    infix def -->(s1: Sequent): Sequent = s.copy(right = s1.right.foldLeft(s.right)(removeFormula))
     infix def ++(s1: Sequent): Sequent = s.copy(left = s.left ++ s1.left, right = s.right ++ s1.right)
-    infix def --(s1: Sequent): Sequent = s.copy(left = s.left -- s1.left, right = s.right -- s1.right)
+    infix def --(s1: Sequent): Sequent = s.copy(left = s1.left.foldLeft(s.left)(removeFormula), right = s1.right.foldLeft(s.right)(removeFormula))
   }
 
   /**

--- a/lisa-utils/src/test/scala/lisa/utils/SequentUtilsTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/SequentUtilsTest.scala
@@ -1,0 +1,56 @@
+package lisa.utils
+
+import lisa.kernel.fol.FOL.*
+import lisa.kernel.proof.SequentCalculus.Sequent
+import lisa.kernel.proof.SequentCalculus.isSameSequent
+import lisa.test.ProofCheckerSuite
+import lisa.utils.Helpers.*
+
+import scala.collection.immutable.Set
+
+class SequentUtilsTest extends ProofCheckerSuite {
+  val simpleSequent: Sequent = s === t |- s === t
+  val sequent: Sequent = Set(s === t, t === u) |- Set(s === t, s === u)
+  val emptySequent: Sequent = () |- ()
+
+  test("left remove formula") {
+    val leftFormula = simpleSequent.left.head
+    // plain removal
+    assert((simpleSequent -< leftFormula) === (() |- simpleSequent.right))
+    // isSame removal
+    val sameFormula = leftFormula /\ (s === s)
+    assert(!(sameFormula == leftFormula))
+    assert(isSame(leftFormula, sameFormula))
+    assert((simpleSequent -< sameFormula) === (simpleSequent -< leftFormula))
+  }
+
+  test("right remove formula") {
+    val rightFormula = simpleSequent.right.head
+    // plain removal
+    assert((simpleSequent -> rightFormula) === (simpleSequent.left |- ()))
+    // isSame removal
+    val sameFormula = rightFormula /\ (s === s)
+    assert(!(sameFormula == rightFormula))
+    assert(isSame(rightFormula, sameFormula))
+    assert((simpleSequent -> sameFormula) === (simpleSequent -> rightFormula))
+  }
+
+  test("left remove set") {
+    assert(sequent --< sequent === (() |- sequent.right))
+    val sameLeft = Sequent(sequent.left.map(_ /\ (u === u)), sequent.right)
+    assert((sequent --< sameLeft) === (() |- sequent.right))
+  }
+
+  test("right remove set") {
+    assert((sequent --> sequent) === (sequent.left |- ()))
+    val sameRight = Sequent(sequent.left, sequent.right.map(_ /\ (u === u)))
+    assert(!(sequent.right === sameRight))
+    assert(isSameSet(sequent.right, sameRight.right))
+    assert(sequent --> sameRight === (sequent.left |- ()))
+  }
+
+  test("sequent remove sequent") {
+    val equivalentSequent = Set((s === t) /\ (s === s), t === u) |- Set(s === t, (s === u) /\ (u === u))
+    assert(sequent -- equivalentSequent === emptySequent)
+  }
+}

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -135,189 +135,186 @@ object SetTheory extends lisa.proven.Main {
 
       val p1 = SCSubproof(
         Proof(
-          byCase(x === x1)(
-            SCSubproof(
-              {
-                val pcm1 = p0
-                val pc0 = SCSubproof(
-                  Proof(
-                    byCase(y === x)(
-                      SCSubproof(
-                        {
-                          val pam1 = pcm1
-                          val pa0 = SCSubproof(
-                            {
-                              val f1 = z === x
-                              val pa0_m1 = pcm1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
-                              val pa0_0 = SCSubproof(
-                                {
-                                  val pa0_0_0 = hypothesis(f1)
-                                  val pa0_1_1 = RightOr(emptySeq +< f1 +> (f1 \/ f1), 0, f1, f1)
-                                  val pa0_1_2 = RightImplies(emptySeq +> (f1 ==> (f1 \/ f1)), 1, f1, f1 \/ f1)
-                                  val pa0_1_3 = LeftOr(emptySeq +< (f1 \/ f1) +> f1, Seq(0, 0), Seq(f1, f1))
-                                  val pa0_1_4 = RightImplies(emptySeq +> ((f1 \/ f1) ==> f1), 3, f1 \/ f1, f1)
-                                  val pa0_1_5 = RightIff(emptySeq +> ((f1 \/ f1) <=> f1), 2, 4, (f1 \/ f1), f1)
-                                  val r = Proof(pa0_0_0, pa0_1_1, pa0_1_2, pa0_1_3, pa0_1_4, pa0_1_5)
-                                  r
-                                },
-                                display = false
-                              ) //   |- (((z=x)∨(z=x))↔(z=x))
-                              val pa0_1 = RightSubstEq(
-                                emptySeq +< (pxy === pxy1) +< (x === y) +> ((f1 \/ f1) <=> (z === x1) \/ (z === y1)),
-                                -1,
-                                List((x, y)),
-                                LambdaTermFormula(Seq(g), (f1 \/ (z === g)) <=> ((z === x1) \/ (z === y1)))
-                              ) //  ({x,y}={x',y'}) y=x|- (z=x)\/(z=x) <=> (z=x' \/ z=y')
-                              val pa0_2 = RightSubstIff(
-                                emptySeq +< (pxy === pxy1) +< (x === y) +< (f1 <=> (f1 \/ f1)) +> (f1 <=> ((z === x1) \/ (z === y1))),
-                                1,
-                                List((f1, f1 \/ f1)),
-                                LambdaFormulaFormula(Seq(h), h <=> ((z === x1) \/ (z === y1)))
-                              )
-                              val pa0_3 =
-                                Cut(emptySeq +< (pxy === pxy1) +< (x === y) +> (f1 <=> ((z === x1) \/ (z === y1))), 0, 2, f1 <=> (f1 \/ f1)) //  (x=y), ({x,y}={x',y'}) |- ((z=x)↔((z=x')∨(z=y')))
-                              val pa0_4 = RightForall(emptySeq +< (pxy === pxy1) +< (x === y) +> forall(z, f1 <=> ((z === x1) \/ (z === y1))), 3, f1 <=> ((z === x1) \/ (z === y1)), z)
-                              val ra0_0 = instantiateForall(Proof(IndexedSeq(pa0_0, pa0_1, pa0_2, pa0_3, pa0_4), IndexedSeq(pa0_m1.bot)), y1) //  (x=y), ({x,y}={x',y'}) |- ((y'=x)↔((y'=x')∨(y'=y')))
-                              ra0_0
-                            },
-                            IndexedSeq(-1)
-                          ) //  ({x,y}={x',y'}) y=x|- ((y'=x)↔((y'=x')∨(y'=y')))
-                          val pa1 = SCSubproof(
-                            {
-                              val pa1_0 = RightRefl(emptySeq +> (y1 === y1), y1 === y1)
-                              val pa1_1 = RightOr(emptySeq +> ((y1 === y1) \/ (y1 === x1)), 0, y1 === y1, y1 === x1)
-                              Proof(pa1_0, pa1_1)
-                            },
-                            display = false
-                          ) //  |- (y'=x' \/ y'=y')
-                          val ra3 = byEquiv(pa0.bot.right.head, pa1.bot.right.head)(pa0, pa1) // ({x,y}={x',y'}) y=x|- ((y'=x)
-                          val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), 0, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
-                          Proof(IndexedSeq(ra3, pal), IndexedSeq(pam1.bot)) // (x=y), ({x,y}={x',y'}) |- (y'=y)
-                        },
-                        IndexedSeq(-1)
-                      ) //  (x=y), ({x,y}={x',y'}) |- (y'=y)
-                      ,
-                      SCSubproof(
-                        {
-                          val pbm1 = pcm1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
-                          val pb0_0 = SCSubproof(
-                            {
-                              val pb0_0 = RightForall(emptySeq ++< pcm1.bot +> forall(z, pcm1.bot.right.head), -1, pcm1.bot.right.head, z)
-                              instantiateForall(Proof(IndexedSeq(pb0_0), IndexedSeq(pcm1.bot)), y)
-                            },
-                            IndexedSeq(-1)
-                          ) //  ({x,y}={x',y'}) |- (((y=x)∨(y=y))↔((y=x')∨(y=y')))
-                          val pb0_1 = SCSubproof(
-                            {
-                              val pa1_0 = RightRefl(emptySeq +> (y === y), y === y)
-                              val pa1_1 = RightOr(emptySeq +> ((y === y) \/ (y === x)), 0, y === y, y === x)
-                              Proof(pa1_0, pa1_1)
-                            },
-                            display = false
-                          ) //  |- (y=x)∨(y=y)
-                          val rb0 = byEquiv(pb0_0.bot.right.head, pb0_1.bot.right.head)(pb0_0, pb0_1) //  ({x,y}={x',y'}) |- (y=x')∨(y=y')
-                          val pb1 =
-                            RightSubstEq(emptySeq ++< rb0.bot +< (x === x1) +> ((y === x) \/ (y === y1)), 0, List((x, x1)), LambdaTermFormula(Seq(g), (y === g) \/ (y === y1)))
-                          val rb1 = destructRightOr(
-                            Proof(IndexedSeq(rb0, pb1), IndexedSeq(pcm1.bot)), //  ({x,y}={x',y'}) , x=x'|- (y=x)∨(y=y')
-                            y === x,
-                            y === y1
-                          )
-                          val rb2 = rb1.appended(LeftNot(rb1.conclusion +< !(y === x) -> (y === x), rb1.length - 1, y === x)) //  (x=x'), ({x,y}={x',y'}), ¬(y=x) |- (y=y')
-                          Proof(rb2.steps, IndexedSeq(pbm1.bot))
+          IndexedSeq(
+            byCase(x === x1)(
+              SCSubproof(
+                {
+                  val pcm1 = p0
+                  val pc0 = byCase(y === x)(
+                    SCSubproof(
+                      {
+                        val pam1 = pcm1
+                        val pa0 = SCSubproof(
+                          {
+                            val f1 = z === x
+                            val pa0_m1 = pcm1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
+                            val pa0_0 = SCSubproof(
+                              {
+                                val pa0_0_0 = hypothesis(f1)
+                                val pa0_1_1 = RightOr(emptySeq +< f1 +> (f1 \/ f1), 0, f1, f1)
+                                val pa0_1_2 = RightImplies(emptySeq +> (f1 ==> (f1 \/ f1)), 1, f1, f1 \/ f1)
+                                val pa0_1_3 = LeftOr(emptySeq +< (f1 \/ f1) +> f1, Seq(0, 0), Seq(f1, f1))
+                                val pa0_1_4 = RightImplies(emptySeq +> ((f1 \/ f1) ==> f1), 3, f1 \/ f1, f1)
+                                val pa0_1_5 = RightIff(emptySeq +> ((f1 \/ f1) <=> f1), 2, 4, (f1 \/ f1), f1)
+                                val r = Proof(pa0_0_0, pa0_1_1, pa0_1_2, pa0_1_3, pa0_1_4, pa0_1_5)
+                                r
+                              },
+                              display = false
+                            ) //   |- (((z=x)∨(z=x))↔(z=x))
+                            val pa0_1 = RightSubstEq(
+                              emptySeq +< (pxy === pxy1) +< (x === y) +> ((f1 \/ f1) <=> (z === x1) \/ (z === y1)),
+                              -1,
+                              List((x, y)),
+                              LambdaTermFormula(Seq(g), (f1 \/ (z === g)) <=> ((z === x1) \/ (z === y1)))
+                            ) //  ({x,y}={x',y'}) y=x|- (z=x)\/(z=x) <=> (z=x' \/ z=y')
+                            val pa0_2 = RightSubstIff(
+                              emptySeq +< (pxy === pxy1) +< (x === y) +< (f1 <=> (f1 \/ f1)) +> (f1 <=> ((z === x1) \/ (z === y1))),
+                              1,
+                              List((f1, f1 \/ f1)),
+                              LambdaFormulaFormula(Seq(h), h <=> ((z === x1) \/ (z === y1)))
+                            )
+                            val pa0_3 =
+                              Cut(emptySeq +< (pxy === pxy1) +< (x === y) +> (f1 <=> ((z === x1) \/ (z === y1))), 0, 2, f1 <=> (f1 \/ f1)) //  (x=y), ({x,y}={x',y'}) |- ((z=x)↔((z=x')∨(z=y')))
+                            val pa0_4 = RightForall(emptySeq +< (pxy === pxy1) +< (x === y) +> forall(z, f1 <=> ((z === x1) \/ (z === y1))), 3, f1 <=> ((z === x1) \/ (z === y1)), z)
+                            val ra0_0 =
+                              instantiateForall(Proof(IndexedSeq(pa0_0, pa0_1, pa0_2, pa0_3, pa0_4), IndexedSeq(pa0_m1.bot)), y1) //  (x=y), ({x,y}={x',y'}) |- ((y'=x)↔((y'=x')∨(y'=y')))
+                            ra0_0
+                          },
+                          IndexedSeq(-1)
+                        ) //  ({x,y}={x',y'}) y=x|- ((y'=x)↔((y'=x')∨(y'=y')))
+                        val pa1 = SCSubproof(
+                          {
+                            val pa1_0 = RightRefl(emptySeq +> (y1 === y1), y1 === y1)
+                            val pa1_1 = RightOr(emptySeq +> ((y1 === y1) \/ (y1 === x1)), 0, y1 === y1, y1 === x1)
+                            Proof(pa1_0, pa1_1)
+                          },
+                          display = false
+                        ) //  |- (y'=x' \/ y'=y')
+                        val ra3 = byEquiv(pa0.bot.right.head, pa1.bot.right.head)(pa0, pa1) // ({x,y}={x',y'}) y=x|- ((y'=x)
+                        val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), 0, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
+                        Proof(IndexedSeq(ra3, pal), IndexedSeq(pam1.bot)) // (x=y), ({x,y}={x',y'}) |- (y'=y)
+                      },
+                      IndexedSeq(-1)
+                    ) //  (x=y), ({x,y}={x',y'}) |- (y'=y)
+                    ,
+                    SCSubproof(
+                      {
+                        val pbm1 = pcm1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
+                        val pb0_0 = SCSubproof(
+                          {
+                            val pb0_0 = RightForall(emptySeq ++< pcm1.bot +> forall(z, pcm1.bot.right.head), -1, pcm1.bot.right.head, z)
+                            instantiateForall(Proof(IndexedSeq(pb0_0), IndexedSeq(pcm1.bot)), y)
+                          },
+                          IndexedSeq(-1)
+                        ) //  ({x,y}={x',y'}) |- (((y=x)∨(y=y))↔((y=x')∨(y=y')))
+                        val pb0_1 = SCSubproof(
+                          {
+                            val pa1_0 = RightRefl(emptySeq +> (y === y), y === y)
+                            val pa1_1 = RightOr(emptySeq +> ((y === y) \/ (y === x)), 0, y === y, y === x)
+                            Proof(pa1_0, pa1_1)
+                          },
+                          display = false
+                        ) //  |- (y=x)∨(y=y)
+                        val rb0 = byEquiv(pb0_0.bot.right.head, pb0_1.bot.right.head)(pb0_0, pb0_1) //  ({x,y}={x',y'}) |- (y=x')∨(y=y')
+                        val pb1 =
+                          RightSubstEq(emptySeq ++< rb0.bot +< (x === x1) +> ((y === x) \/ (y === y1)), 0, List((x, x1)), LambdaTermFormula(Seq(g), (y === g) \/ (y === y1)))
+                        val rb1 = destructRightOr(
+                          Proof(IndexedSeq(rb0, pb1), IndexedSeq(pcm1.bot)), //  ({x,y}={x',y'}) , x=x'|- (y=x)∨(y=y')
+                          y === x,
+                          y === y1
+                        )
+                        val rb2 = rb1.appended(LeftNot(rb1.conclusion +< !(y === x) -> (y === x), rb1.length - 1, y === x)) //  (x=x'), ({x,y}={x',y'}), ¬(y=x) |- (y=y')
+                        Proof(rb2.steps, IndexedSeq(pbm1.bot))
 
+                      },
+                      IndexedSeq(-1)
+                    )
+                  ) // (x=x'), ({x,y}={x',y'}) |- (y'=y)
+                  val pc1 = RightRefl(emptySeq +> (x === x), x === x)
+                  val pc2 = RightAnd(emptySeq ++< pc0.bot +> ((y1 === y) /\ (x === x)), Seq(0, 1), Seq(y1 === y, x === x)) // ({x,y}={x',y'}), x=x' |- (x=x /\ y=y')
+                  val pc3 =
+                    RightSubstEq(emptySeq ++< pc2.bot +> ((y1 === y) /\ (x1 === x)), 2, List((x, x1)), LambdaTermFormula(Seq(g), (y1 === y) /\ (g === x))) // ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')
+                  val pc4 = RightOr(
+                    emptySeq ++< pc3.bot +> (pc3.bot.right.head \/ ((x === y1) /\ (y === x1))),
+                    3,
+                    pc3.bot.right.head,
+                    (x === y1) /\ (y === x1)
+                  ) //  ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
+                  val r = Proof(IndexedSeq(pc0, pc1, pc2, pc3, pc4), IndexedSeq(pcm1.bot))
+                  r
+                },
+                IndexedSeq(-1)
+              ) //  ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
+              ,
+              SCSubproof(
+                {
+                  val pdm1 = p0
+                  val pd0 = SCSubproof(
+                    {
+                      val pd0_m1 = pdm1
+                      val pd0_0 = SCSubproof {
+                        val ex1x1 = x1 === x1
+                        val pd0_0_0 = RightRefl(emptySeq +> ex1x1, ex1x1) //  |- x'=x'
+                        val pd0_0_1 = RightOr(emptySeq +> (ex1x1 \/ (x1 === y1)), 0, ex1x1, x1 === y1) //  |- (x'=x' \/ x'=y')
+                        Proof(IndexedSeq(pd0_0_0, pd0_0_1))
+                      } //  |- (x'=x' \/ x'=y')
+                      val pd0_1 = SCSubproof(
+                        {
+                          val pd0_1_m1 = pd0_m1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
+                          val pd0_1_0 = RightForall(emptySeq ++< pd0_1_m1.bot +> forall(z, pd0_1_m1.bot.right.head), -1, pd0_1_m1.bot.right.head, z)
+                          val rd0_1_1 = instantiateForall(Proof(IndexedSeq(pd0_1_0), IndexedSeq(pd0_m1.bot)), x1) //  ({x,y}={x',y'}) |- (x'=x \/ x'=y) <=> (x'=x' \/ x'=y')
+                          rd0_1_1
                         },
                         IndexedSeq(-1)
-                      ) //  ({x,y}={x',y'}), x=x', !y=x |- y=y'
-                    ).steps,
-                    IndexedSeq(pcm1.bot)
-                  ),
-                  IndexedSeq(-1)
-                ) // (x=x'), ({x,y}={x',y'}) |- (y'=y)
-                val pc1 = RightRefl(emptySeq +> (x === x), x === x)
-                val pc2 = RightAnd(emptySeq ++< pc0.bot +> ((y1 === y) /\ (x === x)), Seq(0, 1), Seq(y1 === y, x === x)) // ({x,y}={x',y'}), x=x' |- (x=x /\ y=y')
-                val pc3 =
-                  RightSubstEq(emptySeq ++< pc2.bot +> ((y1 === y) /\ (x1 === x)), 2, List((x, x1)), LambdaTermFormula(Seq(g), (y1 === y) /\ (g === x))) // ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')
-                val pc4 = RightOr(
-                  emptySeq ++< pc3.bot +> (pc3.bot.right.head \/ ((x === y1) /\ (y === x1))),
-                  3,
-                  pc3.bot.right.head,
-                  (x === y1) /\ (y === x1)
-                ) //  ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
-                val r = Proof(IndexedSeq(pc0, pc1, pc2, pc3, pc4), IndexedSeq(pcm1.bot))
-                r
-              },
-              IndexedSeq(-1)
-            ) //  ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
-            ,
-            SCSubproof(
-              {
-                val pdm1 = p0
-                val pd0 = SCSubproof(
-                  {
-                    val pd0_m1 = pdm1
-                    val pd0_0 = SCSubproof {
-                      val ex1x1 = x1 === x1
-                      val pd0_0_0 = RightRefl(emptySeq +> ex1x1, ex1x1) //  |- x'=x'
-                      val pd0_0_1 = RightOr(emptySeq +> (ex1x1 \/ (x1 === y1)), 0, ex1x1, x1 === y1) //  |- (x'=x' \/ x'=y')
-                      Proof(IndexedSeq(pd0_0_0, pd0_0_1))
-                    } //  |- (x'=x' \/ x'=y')
-                    val pd0_1 = SCSubproof(
-                      {
-                        val pd0_1_m1 = pd0_m1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
-                        val pd0_1_0 = RightForall(emptySeq ++< pd0_1_m1.bot +> forall(z, pd0_1_m1.bot.right.head), -1, pd0_1_m1.bot.right.head, z)
-                        val rd0_1_1 = instantiateForall(Proof(IndexedSeq(pd0_1_0), IndexedSeq(pd0_m1.bot)), x1) //  ({x,y}={x',y'}) |- (x'=x \/ x'=y) <=> (x'=x' \/ x'=y')
-                        rd0_1_1
-                      },
-                      IndexedSeq(-1)
-                    ) //  ({x,y}={x',y'}) |- (x'=x \/ x'=y) <=> (x'=x' \/ x'=y')
-                    val pd0_2 = RightSubstIff(
-                      pd0_1.bot.right |- ((x1 === x) \/ (x1 === y)),
-                      0,
-                      List(((x1 === x) \/ (x1 === y), (x1 === x1) \/ (x1 === y1))),
-                      LambdaFormulaFormula(Seq(h), h)
-                    ) // (x'=x \/ x'=y) <=> (x'=x' \/ x'=y') |- (x'=x \/ x'=y)
-                    val pd0_3 = Cut(pd0_1.bot.left |- pd0_2.bot.right, 1, 2, pd0_1.bot.right.head) //  ({x,y}={x',y'}) |- (x=x' \/ y=x')
-                    destructRightOr(Proof(IndexedSeq(pd0_0, pd0_1, pd0_2, pd0_3), IndexedSeq(pd0_m1.bot)), x === x1, y === x1) //  ({x,y}={x',y'}) |- x=x',  y=x'
-                  },
-                  IndexedSeq(-1)
-                ) //  ({x,y}={x',y'}) |- x=x',  y=x' --
-                val pd1 = SCSubproof(
-                  {
-                    val pd1_m1 = pdm1
-                    val pd1_0 = SCSubproof {
-                      val exx = x === x
-                      val pd1_0_0 = RightRefl(emptySeq +> exx, exx) //  |- x=x
-                      val pd1_0_1 = RightOr(emptySeq +> (exx \/ (x === y)), 0, exx, x === y) //  |- (x=x \/ x=y)
-                      Proof(IndexedSeq(pd1_0_0, pd1_0_1))
-                    } //  |- (x=x \/ x=y)
-                    val pd1_1 = SCSubproof(
-                      {
-                        val pd1_1_m1 = pd1_m1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
-                        val pd1_1_0 = RightForall(emptySeq ++< pd1_1_m1.bot +> forall(z, pd1_1_m1.bot.right.head), -1, pd1_1_m1.bot.right.head, z)
-                        val rd1_1_1 = instantiateForall(Proof(IndexedSeq(pd1_1_0), IndexedSeq(pd1_m1.bot)), x) //  ({x,y}={x',y'}) |- (x=x \/ x=y) <=> (x=x' \/ x=y')
-                        rd1_1_1
-                      },
-                      IndexedSeq(-1)
-                    ) //  //  ({x,y}={x',y'}) |- (x=x \/ x=y) <=> (x=x' \/ x=y')
-                    val rd1_2 = byEquiv(pd1_1.bot.right.head, pd1_0.bot.right.head)(pd1_1, pd1_0)
-                    destructRightOr(Proof(IndexedSeq(pd1_0, pd1_1, rd1_2), IndexedSeq(pd1_m1.bot)), x === x1, x === y1) //  ({x,y}={x',y'}) |- x=x',  x=y'
-                  },
-                  IndexedSeq(-1)
-                ) //  ({x,y}={x',y'}) |- x=x',  x=y' --
-                val pd2 = RightAnd(emptySeq ++< pd1.bot +> (x === x1) +> ((x === y1) /\ (y === x1)), Seq(0, 1), Seq(x === y1, y === x1)) //  ({x,y}={x',y'})  |- x=x', (x=y' /\ y=x') ---
-                val pd3 = LeftNot(emptySeq ++< pd2.bot +< !(x === x1) +> ((x === y1) /\ (y === x1)), 2, x === x1) //  ({x,y}={x',y'}), !x===x1 |- (x=y' /\ y=x')
-                val pd4 = RightOr(
-                  emptySeq ++< pd3.bot +> (pd3.bot.right.head \/ ((x === x1) /\ (y === y1))),
-                  3,
-                  pd3.bot.right.head,
-                  (x === x1) /\ (y === y1)
-                ) //  ({x,y}={x',y'}), !x===x1 |- (x=x' /\ y=y')\/(x=y' /\ y=x')
-                Proof(IndexedSeq(pd0, pd1, pd2, pd3, pd4), IndexedSeq(pdm1.bot))
-              },
-              IndexedSeq(-1)
-            ) //  ({x,y}={x',y'}), !x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
-          ).steps,
+                      ) //  ({x,y}={x',y'}) |- (x'=x \/ x'=y) <=> (x'=x' \/ x'=y')
+                      val pd0_2 = RightSubstIff(
+                        pd0_1.bot.right |- ((x1 === x) \/ (x1 === y)),
+                        0,
+                        List(((x1 === x) \/ (x1 === y), (x1 === x1) \/ (x1 === y1))),
+                        LambdaFormulaFormula(Seq(h), h)
+                      ) // (x'=x \/ x'=y) <=> (x'=x' \/ x'=y') |- (x'=x \/ x'=y)
+                      val pd0_3 = Cut(pd0_1.bot.left |- pd0_2.bot.right, 1, 2, pd0_1.bot.right.head) //  ({x,y}={x',y'}) |- (x=x' \/ y=x')
+                      destructRightOr(Proof(IndexedSeq(pd0_0, pd0_1, pd0_2, pd0_3), IndexedSeq(pd0_m1.bot)), x === x1, y === x1) //  ({x,y}={x',y'}) |- x=x',  y=x'
+                    },
+                    IndexedSeq(-1)
+                  ) //  ({x,y}={x',y'}) |- x=x',  y=x' --
+                  val pd1 = SCSubproof(
+                    {
+                      val pd1_m1 = pdm1
+                      val pd1_0 = SCSubproof {
+                        val exx = x === x
+                        val pd1_0_0 = RightRefl(emptySeq +> exx, exx) //  |- x=x
+                        val pd1_0_1 = RightOr(emptySeq +> (exx \/ (x === y)), 0, exx, x === y) //  |- (x=x \/ x=y)
+                        Proof(IndexedSeq(pd1_0_0, pd1_0_1))
+                      } //  |- (x=x \/ x=y)
+                      val pd1_1 = SCSubproof(
+                        {
+                          val pd1_1_m1 = pd1_m1 //  ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
+                          val pd1_1_0 = RightForall(emptySeq ++< pd1_1_m1.bot +> forall(z, pd1_1_m1.bot.right.head), -1, pd1_1_m1.bot.right.head, z)
+                          val rd1_1_1 = instantiateForall(Proof(IndexedSeq(pd1_1_0), IndexedSeq(pd1_m1.bot)), x) //  ({x,y}={x',y'}) |- (x=x \/ x=y) <=> (x=x' \/ x=y')
+                          rd1_1_1
+                        },
+                        IndexedSeq(-1)
+                      ) //  //  ({x,y}={x',y'}) |- (x=x \/ x=y) <=> (x=x' \/ x=y')
+                      val rd1_2 = byEquiv(pd1_1.bot.right.head, pd1_0.bot.right.head)(pd1_1, pd1_0)
+                      destructRightOr(Proof(IndexedSeq(pd1_0, pd1_1, rd1_2), IndexedSeq(pd1_m1.bot)), x === x1, x === y1) //  ({x,y}={x',y'}) |- x=x',  x=y'
+                    },
+                    IndexedSeq(-1)
+                  ) //  ({x,y}={x',y'}) |- x=x',  x=y' --
+                  val pd2 = RightAnd(emptySeq ++< pd1.bot +> (x === x1) +> ((x === y1) /\ (y === x1)), Seq(0, 1), Seq(x === y1, y === x1)) //  ({x,y}={x',y'})  |- x=x', (x=y' /\ y=x') ---
+                  val pd3 = LeftNot(emptySeq ++< pd2.bot +< !(x === x1) +> ((x === y1) /\ (y === x1)), 2, x === x1) //  ({x,y}={x',y'}), !x===x1 |- (x=y' /\ y=x')
+                  val pd4 = RightOr(
+                    emptySeq ++< pd3.bot +> (pd3.bot.right.head \/ ((x === x1) /\ (y === y1))),
+                    3,
+                    pd3.bot.right.head,
+                    (x === x1) /\ (y === y1)
+                  ) //  ({x,y}={x',y'}), !x===x1 |- (x=x' /\ y=y')\/(x=y' /\ y=x')
+                  Proof(IndexedSeq(pd0, pd1, pd2, pd3, pd4), IndexedSeq(pdm1.bot))
+                },
+                IndexedSeq(-1)
+              ) //  ({x,y}={x',y'}), !x=x' |- (x=x' /\ y=y')\/(x=y' /\ y=x')
+            )
+          ),
           IndexedSeq(p0.bot)
         ),
         IndexedSeq(0)

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -66,9 +66,9 @@ object SetTheory extends lisa.proven.Main {
         pairExt.bot.right.head,
         fin.bot.right.head
       )(pairExt, fin)
-      val fin3 = generalizeToForall(fin2, fin2.conclusion.right.head, x)
-      val fin4 = generalizeToForall(fin3, fin3.conclusion.right.head, y)
-      fin4.copy(imports = imports(ax"extensionalityAxiom", ax"pairAxiom"))
+      val fin3 = generalizeToForall(fin2, fin2.bot.right.head, x)
+      val fin4 = generalizeToForall(fin3, fin3.bot.right.head, y)
+      fin4.sp
     } using (ax"extensionalityAxiom", AxiomaticSetTheory.pairAxiom)
   show
 
@@ -191,8 +191,8 @@ object SetTheory extends lisa.proven.Main {
                             display = false
                           ) //  |- (y'=x' \/ y'=y')
                           val ra3 = byEquiv(pa0.bot.right.head, pa1.bot.right.head)(pa0, pa1) // ({x,y}={x',y'}) y=x|- ((y'=x)
-                          val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), ra3.length - 1, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
-                          Proof(ra3.steps, IndexedSeq(pam1.bot)).appended(pal) // (x=y), ({x,y}={x',y'}) |- (y'=y)
+                          val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), 0, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
+                          Proof(IndexedSeq(ra3, pal), IndexedSeq(pam1.bot)) // (x=y), ({x,y}={x',y'}) |- (y'=y)
                         },
                         IndexedSeq(-1)
                       ) //  (x=y), ({x,y}={x',y'}) |- (y'=y)
@@ -217,9 +217,9 @@ object SetTheory extends lisa.proven.Main {
                           ) //  |- (y=x)∨(y=y)
                           val rb0 = byEquiv(pb0_0.bot.right.head, pb0_1.bot.right.head)(pb0_0, pb0_1) //  ({x,y}={x',y'}) |- (y=x')∨(y=y')
                           val pb1 =
-                            RightSubstEq(emptySeq ++< rb0.conclusion +< (x === x1) +> ((y === x) \/ (y === y1)), rb0.length - 1, List((x, x1)), LambdaTermFormula(Seq(g), (y === g) \/ (y === y1)))
+                            RightSubstEq(emptySeq ++< rb0.bot +< (x === x1) +> ((y === x) \/ (y === y1)), 0, List((x, x1)), LambdaTermFormula(Seq(g), (y === g) \/ (y === y1)))
                           val rb1 = destructRightOr(
-                            rb0.appended(pb1), //  ({x,y}={x',y'}) , x=x'|- (y=x)∨(y=y')
+                            Proof(IndexedSeq(rb0, pb1), IndexedSeq(pcm1.bot)), //  ({x,y}={x',y'}) , x=x'|- (y=x)∨(y=y')
                             y === x,
                             y === y1
                           )
@@ -301,8 +301,7 @@ object SetTheory extends lisa.proven.Main {
                       IndexedSeq(-1)
                     ) //  //  ({x,y}={x',y'}) |- (x=x \/ x=y) <=> (x=x' \/ x=y')
                     val rd1_2 = byEquiv(pd1_1.bot.right.head, pd1_0.bot.right.head)(pd1_1, pd1_0)
-                    val pd1_3 = SCSubproof(Proof(rd1_2.steps, IndexedSeq(pd1_m1.bot)), IndexedSeq(-1)) //  //  ({x,y}={x',y'}) |- x=x' \/ x=y'
-                    destructRightOr(Proof(IndexedSeq(pd1_0, pd1_1, pd1_3), IndexedSeq(pd1_m1.bot)), x === x1, x === y1) //  ({x,y}={x',y'}) |- x=x',  x=y'
+                    destructRightOr(Proof(IndexedSeq(pd1_0, pd1_1, rd1_2), IndexedSeq(pd1_m1.bot)), x === x1, x === y1) //  ({x,y}={x',y'}) |- x=x',  x=y'
                   },
                   IndexedSeq(-1)
                 ) //  ({x,y}={x',y'}) |- x=x',  x=y' --

--- a/src/main/scala/lisa/proven/tactics/ProofTactics.scala
+++ b/src/main/scala/lisa/proven/tactics/ProofTactics.scala
@@ -4,8 +4,8 @@ import lisa.kernel.fol.FOL
 import lisa.kernel.fol.FOL.*
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SequentCalculus.*
-import lisa.utils.Helpers.{*, given}
-import lisa.utils.Printer.*
+import lisa.utils.Helpers.{_, given}
+import lisa.utils.Printer
 
 import scala.collection.immutable.Set
 
@@ -43,7 +43,7 @@ object ProofTactics {
         val p2 = LeftForall(Sequent(Set(b), Set(in)), p.length, instantiateBinder(b, tempVar), tempVar, t)
         val p3 = Cut(Sequent(c.left, c.right - phi + in), p.length - 1, p.length + 1, phi)
         p withNewSteps IndexedSeq(p1, p2, p3)
-      case _ => throw new Exception("not a forall")
+      case _ => throw TacticNotApplicable("given formula is not a forall")
     }
   }
   def instantiateForall(p: SCProof, phi: Formula, t: Term*): SCProof = { // given a proof with a formula quantified with \forall on the right, extend the proof to the same formula with something instantiated instead.
@@ -83,7 +83,10 @@ object ProofTactics {
       case ConnectorFormula(Iff, Seq(fl, fr)) => (fl, fr)
       case _ => throw TacticNotApplicable(s"$equiv is not an Iff on two arguments")
     }
-    val otherSide = if (isSame(equivSide, fl)) fr else if (isSame(equivSide, fr)) fl else throw new Error("not applicable")
+    val otherSide =
+      if (isSame(equivSide, fl)) fr
+      else if (isSame(equivSide, fr)) fl
+      else throw TacticNotApplicable(s"Given formula ${Printer.prettyFormula(equivSide)} does not appear on either side of the equivalence ${Printer.prettyFormula(equiv)}")
     val p2 = hypothesis(equivSide)
     val p3 = hypothesis(otherSide)
     val p4 = LeftImplies(Sequent(Set(equivSide, equivSide ==> otherSide), Set(otherSide)), 2, 3, equivSide, otherSide)

--- a/src/test/scala/lisa/proven/tactics/TacticsTest.scala
+++ b/src/test/scala/lisa/proven/tactics/TacticsTest.scala
@@ -1,0 +1,57 @@
+package lisa.proven.tactics
+
+import lisa.kernel.proof.SCProofChecker.checkSCProof
+import lisa.proven.tactics.ProofTactics.*
+import lisa.test.ProofCheckerSuite
+import lisa.test.TestTheoryLibrary
+import lisa.utils.Helpers._
+import lisa.utils.Helpers.emptySeq
+
+class TacticsTest extends ProofCheckerSuite {
+  export TestTheoryLibrary.*
+  /* A (overcomplicated for the sake of the test) proof that f1(fixedElement) = fixedElement in test theory
+   *
+   *
+   *                                                         -------------------------------------- hypothesis
+   *                                                         fixed point axiom |- fixed point axiom
+   *                                                  ------------------------------------------------------------------------------------ instantiate forall
+   *                                                  fixed point axiom |- f1(fixedElement) = fixedElement <-> fixedElement = fixedElement
+   * -------------------------------- RightRefl       ------------------------------------------------------------------------------------ weaken <-> to ->
+   *  |- fixedElement = fixedElement                  fixed point axiom |- fixedElement = fixedElement -> f1(fixedElement) = fixedElement
+   * ------------------------------------------------------------------------------------------------------------------------------------- modus ponens
+   *                                     fixed point axiom |- f1(fixedElement) = fixedElement
+   *
+   * */
+  test("modus ponens") {
+    val instantiate0: Proof = instantiateForall(Proof(IndexedSeq(hypothesis(fixed_point)), IndexedSeq(ax"fixed_point")), fixed_point, fixedElement())
+    val weakenIffToImplies = iffToImplies(
+      (f1(fixedElement()) === fixedElement()) <=> (fixedElement() === fixedElement()),
+      (fixedElement() === fixedElement()) ==> (f1(fixedElement()) === fixedElement())
+    )(
+      SCSubproof(instantiate0, IndexedSeq(-1))
+    )
+    val eq2 = RightRefl(() |- fixedElement() === fixedElement(), fixedElement() === fixedElement())
+    val proof = modusPonens(fixedElement() === fixedElement())(eq2, weakenIffToImplies)
+    assert(checkSCProof(proof).isValid, "application of modus ponens yields an invalid proof")
+  }
+
+  test("explicit modus ponens") {
+    val eq0 = RightRefl(() |- fixedElement() === fixedElement(), fixedElement() === fixedElement())
+    val instantiate1: Proof = instantiateForall(Proof(IndexedSeq(hypothesis(fixed_point)), IndexedSeq(ax"fixed_point")), fixed_point, fixedElement())
+    val weakenIffToImplies1 = iffToImplies(
+      (f1(fixedElement()) === fixedElement()) <=> (fixedElement() === fixedElement()),
+      (fixedElement() === fixedElement()) ==> (f1(fixedElement()) === fixedElement())
+    )(SCSubproof(instantiate1, IndexedSeq(-1)))
+    val pa = eq0
+    val pb = weakenIffToImplies1
+    val phi = fixedElement() === fixedElement()
+    val psi = f1(fixedElement()) === fixedElement()
+    val p2 = hypothesis(psi)
+    val p3 = LeftImplies(emptySeq ++ (pa.bot -> phi) +< (phi ==> psi) +> psi, 0, 2, phi, psi)
+    val p4 = Cut(emptySeq ++ (pa.bot -> phi) ++< pb.bot +> psi ++> (pb.bot -> psi), 1, 3, phi ==> psi)
+    val proof = Proof(IndexedSeq(eq0, weakenIffToImplies1, p2, p3, p4), IndexedSeq(ax"fixed_point"))
+    checkProof(proof)
+  }
+
+  test("byEquiv") {}
+}

--- a/src/test/scala/lisa/proven/tactics/TacticsTest.scala
+++ b/src/test/scala/lisa/proven/tactics/TacticsTest.scala
@@ -30,21 +30,6 @@ class TacticsTest extends ProofCheckerSuite {
     checkProof(proof)
   }
 
-  // illustrate by copying the body of modusPonens and making applicable changes that the claim can be proved by using modus ponens
-  test("manual modus ponens") {
-    val instantiate0: Proof = instantiateForall(Proof(IndexedSeq(hypothesis(p1_implies_p2)), IndexedSeq(ax"p1_implies_p2")), p1_implies_p2, fixedElement())
-    val hypothesis1 = hypothesis(ax2)
-    val pa = hypothesis1
-    val pb = SCSubproof(instantiate0, Seq(-1))
-    val phi = p1(fixedElement())
-    val psi = p2(fixedElement())
-    val mp2 = hypothesis(psi)
-    val mp3 = LeftImplies(emptySeq ++ (pa.bot -> phi) +< (phi ==> psi) +> psi, 0, 2, phi, psi)
-    val mp4 = Cut(emptySeq ++ (pa.bot -> phi) ++< pb.bot +> psi ++> (pb.bot -> (phi ==> psi)), 1, 3, phi ==> psi)
-    val proof = Proof(IndexedSeq(pa, pb, mp2, mp3, mp4), IndexedSeq(ax"p1_implies_p2", ax"A2"))
-    checkProof(proof)
-  }
-
   /* test theory |- f1(fixedElement) = fixedElement using byEquiv
    *
    *                                                          -------------------------------------- hypothesis
@@ -62,31 +47,6 @@ class TacticsTest extends ProofCheckerSuite {
     val proof: SCProof = Proof(IndexedSeq(useEquiv), IndexedSeq(ax"fixed_point"))
     checkProof(proof)
     checkProof(useEquiv.sp)
-  }
-
-  // illustrate by copying the body of byEquiv and making applicable changes that the claim can be proved by using byEquiv
-  test("manual byEquiv") {
-    val instantiate0: Proof = instantiateForall(Proof(IndexedSeq(hypothesis(fixed_point)), IndexedSeq(ax"fixed_point")), fixed_point, fixedElement())
-    val eq1 = RightRefl(() |- fixedElement() === fixedElement(), fixedElement() === fixedElement())
-    val f = instantiate0.conclusion.right.head
-    val f1 = eq1.bot.right.head
-    val pEq = SCSubproof(instantiate0, IndexedSeq(-1))
-    val pr1 = eq1
-    require(pEq.bot.right.contains(f))
-    require(pr1.bot.right.contains(f1))
-    val proof = f match {
-      case ConnectorFormula(Iff, Seq(fl, fr)) =>
-        val f2 = if (isSame(f1, fl)) fr else if (isSame(f1, fr)) fl else throw new Error("not applicable")
-        val p2 = hypothesis(f1)
-        val p3 = hypothesis(f2)
-        val p4 = LeftImplies(Sequent(Set(f1, f1 ==> f2), Set(f2)), 2, 3, f1, f2)
-        val p5 = LeftIff(Sequent(Set(f1, f1 <=> f2), Set(f2)), 4, f1, f2)
-        val p6 = Cut(pEq.bot -> (f1 <=> f2) +< f1 +> f2, 0, 5, f1 <=> f2)
-        val p7 = Cut(p6.bot -< f1 ++ pr1.bot -> f1, 1, 6, f1)
-        new SCProof(IndexedSeq(pEq, pr1, p2, p3, p4, p5, p6, p7), IndexedSeq(ax"fixed_point"))
-      case _ => throw new Error("not applicable")
-    }
-    checkProof(proof)
   }
 
   /* test theory |- f1(anotherFixed) = fixedElement using byEquiv.

--- a/src/test/scala/lisa/proven/tactics/TacticsTest.scala
+++ b/src/test/scala/lisa/proven/tactics/TacticsTest.scala
@@ -25,7 +25,8 @@ class TacticsTest extends ProofCheckerSuite {
   test("modus ponens") {
     val instantiate0: Proof = instantiateForall(Proof(IndexedSeq(hypothesis(p1_implies_p2)), IndexedSeq(ax"p1_implies_p2")), p1_implies_p2, fixedElement())
     val hypothesis1 = hypothesis(ax2)
-    val proof = modusPonens(p1(fixedElement()))(hypothesis1, SCSubproof(instantiate0, Seq(-1)))
+    val sp = modusPonens(p1(fixedElement()))(SCSubproof(Proof(IndexedSeq(hypothesis1), IndexedSeq(ax"A2")), Seq(-2)), SCSubproof(instantiate0, Seq(-1)))
+    val proof = Proof(IndexedSeq(sp), IndexedSeq(ax"p1_implies_p2", ax"A2"))
     checkProof(proof)
   }
 


### PR DESCRIPTION
Current limitation of the tactics is taking `ProofStep`s as arguments. The tactic has no way of knowing the preceding steps or the imports, required for the proof. Hence if the supplied arguments are not the very first steps of the proof and/or the proof needs imports, the result of the tactic application is not a valid proof since it misses these parts. This PR changes the tactics signature to take `Subproof`s as arguments, thus collecting all necessary details.

This PR depends on #30, because without it the tactic application might remove a wrong formula from the sequent, and should be merged after it.