### PR TITLE
Variables change

### DIFF
--- a/lisa-examples/src/main/scala/Example.scala
+++ b/lisa-examples/src/main/scala/Example.scala
@@ -139,15 +139,15 @@ object Example {
     p.formulas.foreach(printAnnotatedFormula)
   }
 
-  val P = SchematicPredicateLabel("P", 1)
+  val P = SchematicNPredicateLabel("P", 1)
 
-  val Q = PredicateFormula(SchematicPredicateLabel("Q", 0), Seq())
-  val R = PredicateFormula(SchematicPredicateLabel("R", 0), Seq())
-  val S = PredicateFormula(SchematicPredicateLabel("S", 0), Seq())
-  val T = PredicateFormula(SchematicPredicateLabel("T", 0), Seq())
-  val A = PredicateFormula(SchematicPredicateLabel("A", 0), Seq())
-  val B = PredicateFormula(SchematicPredicateLabel("B", 0), Seq())
-  val C = PredicateFormula(SchematicPredicateLabel("C", 0), Seq())
+  val Q = PredicateFormula(VariableFormulaLabel("Q"), Seq())
+  val R = PredicateFormula(VariableFormulaLabel("R"), Seq())
+  val S = PredicateFormula(VariableFormulaLabel("S"), Seq())
+  val T = PredicateFormula(VariableFormulaLabel("T"), Seq())
+  val A = PredicateFormula(VariableFormulaLabel("A"), Seq())
+  val B = PredicateFormula(VariableFormulaLabel("B"), Seq())
+  val C = PredicateFormula(VariableFormulaLabel("C"), Seq())
   val x = VariableLabel("x")
   val f = ConstantFunctionLabel("f", 1)
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
@@ -17,6 +17,7 @@ private[fol] trait CommonDefinitions {
    * An labelled node for tree-like structures.
    */
   protected trait Label {
+    val arity: Int
     val id: String
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/CommonDefinitions.scala
@@ -7,13 +7,6 @@ private[fol] trait CommonDefinitions {
   val MaxArity: Int = 1000000
 
   /**
-   * An object with arity information for tree-like structures.
-   */
-  protected trait Arity {
-    val arity: Int
-  }
-
-  /**
    * An labelled node for tree-like structures.
    */
   protected trait Label {

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaDefinitions.scala
@@ -13,7 +13,7 @@ private[fol] trait FormulaDefinitions extends FormulaLabelDefinitions with TermD
   sealed abstract class Formula extends TreeWithLabel[FormulaLabel] {
 
     def constantFunctions: Set[ConstantFunctionLabel]
-    def schematicFunctions: Set[SchematicFunctionLabel]
+    def schematicTerms: Set[SchematicTermLabel]
 
     def constantPredicates: Set[ConstantPredicateLabel]
     def schematicPredicates: Set[SchematicPredicateLabel]
@@ -35,7 +35,7 @@ private[fol] trait FormulaDefinitions extends FormulaLabelDefinitions with TermD
     }
 
     override def constantFunctions: Set[ConstantFunctionLabel] = args.foldLeft(Set.empty[ConstantFunctionLabel])((prev, next) => prev union next.constantFunctions)
-    override def schematicFunctions: Set[SchematicFunctionLabel] = args.foldLeft(Set.empty[SchematicFunctionLabel])((prev, next) => prev union next.schematicFunctions)
+    override def schematicTerms: Set[SchematicTermLabel] = args.foldLeft(Set.empty[SchematicTermLabel])((prev, next) => prev union next.schematicTerms)
   }
 
   /**
@@ -45,7 +45,7 @@ private[fol] trait FormulaDefinitions extends FormulaLabelDefinitions with TermD
     override def freeVariables: Set[VariableLabel] = args.foldLeft(Set.empty[VariableLabel])((prev, next) => prev union next.freeVariables)
 
     override def constantFunctions: Set[ConstantFunctionLabel] = args.foldLeft(Set.empty[ConstantFunctionLabel])((prev, next) => prev union next.constantFunctions)
-    override def schematicFunctions: Set[SchematicFunctionLabel] = args.foldLeft(Set.empty[SchematicFunctionLabel])((prev, next) => prev union next.schematicFunctions)
+    override def schematicTerms: Set[SchematicTermLabel] = args.foldLeft(Set.empty[SchematicTermLabel])((prev, next) => prev union next.schematicTerms)
 
     override def constantPredicates: Set[ConstantPredicateLabel] = args.foldLeft(Set.empty[ConstantPredicateLabel])((prev, next) => prev union next.constantPredicates)
     override def schematicPredicates: Set[SchematicPredicateLabel] = args.foldLeft(Set.empty[SchematicPredicateLabel])((prev, next) => prev union next.schematicPredicates)
@@ -58,7 +58,7 @@ private[fol] trait FormulaDefinitions extends FormulaLabelDefinitions with TermD
     override def freeVariables: Set[VariableLabel] = inner.freeVariables - bound
 
     override def constantFunctions: Set[ConstantFunctionLabel] = inner.constantFunctions
-    override def schematicFunctions: Set[SchematicFunctionLabel] = inner.schematicFunctions
+    override def schematicTerms: Set[SchematicTermLabel] = inner.schematicTerms -bound
 
     override def constantPredicates: Set[ConstantPredicateLabel] = inner.constantPredicates
     override def schematicPredicates: Set[SchematicPredicateLabel] = inner.schematicPredicates

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaDefinitions.scala
@@ -58,7 +58,7 @@ private[fol] trait FormulaDefinitions extends FormulaLabelDefinitions with TermD
     override def freeVariables: Set[VariableLabel] = inner.freeVariables - bound
 
     override def constantFunctions: Set[ConstantFunctionLabel] = inner.constantFunctions
-    override def schematicTerms: Set[SchematicTermLabel] = inner.schematicTerms -bound
+    override def schematicTerms: Set[SchematicTermLabel] = inner.schematicTerms - bound
 
     override def constantPredicates: Set[ConstantPredicateLabel] = inner.constantPredicates
     override def schematicPredicates: Set[SchematicPredicateLabel] = inner.schematicPredicates

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
@@ -73,7 +73,9 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
   /**
    * The label for a binder, namely an object with a body that has the ability to bind variables in it.
    */
-  sealed abstract class BinderLabel(val id: String) extends FormulaLabel
+  sealed abstract class BinderLabel(val id: String) extends FormulaLabel {
+    val arity = 1
+  }
 
   case object Forall extends BinderLabel(id = "∀")
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
@@ -51,7 +51,19 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
   /**
    * A predicate symbol that can be instantiated with any formula.
    */
-  sealed case class SchematicPredicateLabel(id: String, arity: Int) extends PredicateLabel
+  sealed abstract class SchematicPredicateLabel extends PredicateLabel with SchematicLabel
+
+  /**
+   * A predicate symbol of non-zero arity that can be instantiated with any formula taking arguments.
+   */
+  sealed case class SchematicNPredicateLabel(id: String, arity: Int) extends SchematicPredicateLabel
+
+  /**
+   * A predicate symbol of arity 0 that can be instantiated with any formula.
+   */
+  sealed case class VariableFormulaLabel(id: String) extends SchematicPredicateLabel {
+    val arity = 0
+  }
 
   /**
    * The label for a connector, namely a function taking a fixed number of formulas and returning another formula.

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/FormulaLabelDefinitions.scala
@@ -34,7 +34,7 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
    * The label for a predicate, namely a function taking a fixed number of terms and returning a formula.
    * In logical terms it is a predicate symbol.
    */
-  sealed abstract class PredicateLabel extends FormulaLabel with Arity {
+  sealed abstract class PredicateLabel extends FormulaLabel {
     require(arity < MaxArity && arity >= 0)
   }
 
@@ -68,7 +68,7 @@ private[fol] trait FormulaLabelDefinitions extends CommonDefinitions {
   /**
    * The label for a connector, namely a function taking a fixed number of formulas and returning another formula.
    */
-  sealed abstract class ConnectorLabel(val id: String, val arity: Int) extends FormulaLabel with Arity {
+  sealed abstract class ConnectorLabel(val id: String, val arity: Int) extends FormulaLabel {
     require(arity < MaxArity && arity >= -1)
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
@@ -50,7 +50,6 @@ trait Substitutions extends FormulaDefinitions {
     case FunctionTerm(label, args) => FunctionTerm(label, args.map(substituteVariables(_, m)))
   }
 
-
   /**
    * Performs simultaneous substitution of schematic function symbol by "functional" terms, or terms with holes.
    * If the arity of one of the function symbol to substitute doesn't match the corresponding number of arguments, it will produce an error.
@@ -112,7 +111,7 @@ trait Substitutions extends FormulaDefinitions {
       case ConnectorFormula(label, args) => ConnectorFormula(label, args.map(instantiateTermSchemas(_, m)))
       case BinderFormula(label, bound, inner) =>
         val newSubst = m - bound
-        val fv: Set[VariableLabel] = newSubst.flatMap{ case (symbol, LambdaTermTerm(arguments, body)) => body.freeVariables }.toSet
+        val fv: Set[VariableLabel] = newSubst.flatMap { case (symbol, LambdaTermTerm(arguments, body)) => body.freeVariables }.toSet
         if (fv.contains(bound)) {
           val newBoundVariable = VariableLabel(freshId(fv.map(_.name), bound.name))
           val newInner = substituteVariables(inner, Map(bound -> VariableTerm(newBoundVariable)))

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
@@ -8,9 +8,8 @@ trait Substitutions extends FormulaDefinitions {
    * @param vars The names of the "holes" in the term, necessarily of arity 0. The bound variables of the functional term.
    * @param body The term represented by the object, up to instantiation of the bound schematic variables in args.
    */
-  case class LambdaTermTerm(vars: Seq[SchematicFunctionLabel], body: Term) {
-    require(vars.forall(_.arity == 0))
-    def apply(args: Seq[Term]): Term = instantiateNullaryFunctionSchemas(body, (vars zip args).toMap)
+  case class LambdaTermTerm(vars: Seq[VariableLabel], body: Term) {
+    def apply(args: Seq[Term]): Term = substituteVariables(body, (vars zip args).toMap)
   }
 
   /**
@@ -19,10 +18,9 @@ trait Substitutions extends FormulaDefinitions {
    * @param vars The names of the "holes" in a formula, necessarily of arity 0. The bound variables of the functional formula.
    * @param body The formula represented by the object, up to instantiation of the bound schematic variables in args.
    */
-  case class LambdaTermFormula(vars: Seq[SchematicFunctionLabel], body: Formula) {
-    require(vars.forall(_.arity == 0))
+  case class LambdaTermFormula(vars: Seq[VariableLabel], body: Formula) {
     def apply(args: Seq[Term]): Formula = {
-      instantiateFunctionSchemas(body, (vars zip (args map (LambdaTermTerm(Nil, _)))).toMap)
+      substituteVariables(body, (vars zip args).toMap)
     }
     // def instantiateFunctionSchemas(phi: Formula, m: Map[SchematicFunctionLabel, LambdaTermTerm]):Formula = ???
   }
@@ -53,47 +51,25 @@ trait Substitutions extends FormulaDefinitions {
     case FunctionTerm(label, args) => FunctionTerm(label, args.map(substituteVariables(_, m)))
   }
 
-  /**
-   * Performs simultaneous substitution of multiple nullary schematic function symbols by multiple terms in a base term t.
-   * If one of the symbol is not of arity 0, it will produce an error.
-   * It is needed for the implementation of the general FunctionSchemas instantiation method.
-   * @param t The base term
-   * @param m A map from nullary schematic function label to terms.
-   * @return t[m]
-   */
-  private def instantiateNullaryFunctionSchemas(t: Term, m: Map[SchematicFunctionLabel, Term]): Term = {
-    require(m.forall { case (symbol, term) => symbol.arity == 0 })
-    t match {
-      case VariableTerm(_) => t
-      case FunctionTerm(label, args) =>
-        label match {
-          case label: SchematicFunctionLabel if label.arity == 0 => m.getOrElse(label, t)
-          case label => FunctionTerm(label, args.map(instantiateNullaryFunctionSchemas(_, m)))
-        }
-    }
-  }
 
   /**
    * Performs simultaneous substitution of schematic function symbol by "functional" terms, or terms with holes.
-   * If the arity of one of the function symbol to substitute don't match the corresponding number of arguments, or if
-   * one of the "terms with holes" contains a non-nullary symbol, it will produce an error.
+   * If the arity of one of the function symbol to substitute doesn't match the corresponding number of arguments, it will produce an error.
    * @param t The base term
    * @param m The map from schematic function symbols to "terms with holes". A such term is a pair containing a list of
-   *          nullary schematic function symbols (holes) and a term that is the body of the functional term.
+   *          variable symbols (holes) and a term that is the body of the functional term.
    * @return t[m]
    */
-  def instantiateFunctionSchemas(t: Term, m: Map[SchematicFunctionLabel, LambdaTermTerm]): Term = {
+  def instantiateTermSchemas(t: Term, m: Map[SchematicTermLabel, LambdaTermTerm]): Term = {
     require(m.forall { case (symbol, LambdaTermTerm(arguments, body)) => arguments.length == symbol.arity })
     t match {
-      case VariableTerm(_) => t
+      case VariableTerm(label) => m.get(label).map(_.apply(Nil)).getOrElse(t)
       case FunctionTerm(label, args) =>
-        val newArgs = args.map(instantiateFunctionSchemas(_, m))
+        val newArgs = args.map(instantiateTermSchemas(_, m))
         label match {
           case label: ConstantFunctionLabel => FunctionTerm(label, newArgs)
           case label: SchematicFunctionLabel =>
-            if (m.contains(label))
-              m(label)(newArgs) // = instantiateNullaryFunctionSchemas(m(label).body, (m(label).vars zip newArgs).toMap)
-            else FunctionTerm(label, newArgs)
+            m.get(label).map(_(newArgs)).getOrElse(FunctionTerm(label, newArgs))
         }
     }
   }
@@ -123,27 +99,26 @@ trait Substitutions extends FormulaDefinitions {
   }
 
   /**
-   * Instantiate a schematic function symbol in a formula, using higher-order instantiation.
-   *
+   * Performs simultaneous substitution of schematic function symbol by "functional" terms, or terms with holes.
+   * If the arity of one of the function symbol to substitute doesn't match the corresponding number of arguments, it will produce an error.
    * @param phi The base formula
-   * @param f   The symbol to replace
-   * @param r   A term, seen as a function, that will replace f in t.
-   * @param a   The "arguments" of r when seen as a function rather than a ground term.
-   *            Those variables are replaced by the actual arguments of f.
-   * @return phi[r(a1,..., an)/f]
+   * @param m The map from schematic function symbols to "terms with holes". A such term is a pair containing a list of
+   *          variable symbols (holes) and a term that is the body of the functional term.
+   * @return t[m]
    */
-  def instantiateFunctionSchemas(phi: Formula, m: Map[SchematicFunctionLabel, LambdaTermTerm]): Formula = {
+  def instantiateTermSchemas(phi: Formula, m: Map[SchematicTermLabel, LambdaTermTerm]): Formula = {
     require(m.forall { case (symbol, LambdaTermTerm(arguments, body)) => arguments.length == symbol.arity })
     phi match {
-      case PredicateFormula(label, args) => PredicateFormula(label, args.map(instantiateFunctionSchemas(_, m)))
-      case ConnectorFormula(label, args) => ConnectorFormula(label, args.map(instantiateFunctionSchemas(_, m)))
+      case PredicateFormula(label, args) => PredicateFormula(label, args.map(a => instantiateTermSchemas(a, m)))
+      case ConnectorFormula(label, args) => ConnectorFormula(label, args.map(instantiateTermSchemas(_, m)))
       case BinderFormula(label, bound, inner) =>
-        val fv: Set[VariableLabel] = (m.flatMap { case (symbol, LambdaTermTerm(arguments, body)) => body.freeVariables }).toSet
+        val newSubst = m - bound
+        val fv: Set[VariableLabel] = newSubst.flatMap{ case (symbol, LambdaTermTerm(arguments, body)) => body.freeVariables }.toSet
         if (fv.contains(bound)) {
           val newBoundVariable = VariableLabel(freshId(fv.map(_.name), bound.name))
           val newInner = substituteVariables(inner, Map(bound -> VariableTerm(newBoundVariable)))
-          BinderFormula(label, newBoundVariable, instantiateFunctionSchemas(newInner, m))
-        } else BinderFormula(label, bound, instantiateFunctionSchemas(inner, m))
+          BinderFormula(label, newBoundVariable, instantiateTermSchemas(newInner, newSubst))
+        } else BinderFormula(label, bound, instantiateTermSchemas(inner, newSubst))
     }
   }
 
@@ -151,11 +126,9 @@ trait Substitutions extends FormulaDefinitions {
    * Instantiate a schematic predicate symbol in a formula, using higher-order instantiation.
    *
    * @param phi The base formula
-   * @param p   The symbol to replace
-   * @param psi A formula, seen as a function, that will replace p in t.
-   * @param a   The "arguments" of psi when seen as a function rather than a ground formula.
-   *            Those variables are replaced by the actual arguments of p.
-   * @return phi[psi(a1,..., an)/p]
+   * @param m The map from schematic function symbols to "terms with holes". A such term is a pair containing a list of
+   *          variable symbols (holes) and a term that is the body of the functional term.
+   * @return t[m]
    */
   def instantiatePredicateSchemas(phi: Formula, m: Map[SchematicPredicateLabel, LambdaTermFormula]): Formula = {
     require(m.forall { case (symbol, LambdaTermFormula(arguments, body)) => arguments.length == symbol.arity })

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
@@ -31,8 +31,7 @@ trait Substitutions extends FormulaDefinitions {
    * @param vars The names of the "holes" in a formula, necessarily of arity 0.
    * @param body The formula represented by the object, up to instantiation of the bound schematic variables in args.
    */
-  case class LambdaFormulaFormula(vars: Seq[SchematicPredicateLabel], body: Formula) {
-    require(vars.forall(_.arity == 0))
+  case class LambdaFormulaFormula(vars: Seq[VariableFormulaLabel], body: Formula) {
     def apply(args: Seq[Formula]): Formula = instantiatePredicateSchemas(body, (vars zip (args map (LambdaTermFormula(Nil, _)))).toMap)
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/TermDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/TermDefinitions.scala
@@ -8,10 +8,20 @@ private[fol] trait TermDefinitions extends TermLabelDefinitions {
   protected trait TreeWithLabel[A] {
     val label: A
 
+    /**
+     * @return The list of free variables in the term
+     */
     def freeVariables: Set[VariableLabel]
 
+    /**
+     * @return The list of constant (i.e. non schematic) function symbols, including of arity 0.
+     */
     def constantFunctions: Set[ConstantFunctionLabel]
-    def schematicFunctions: Set[SchematicFunctionLabel]
+
+    /**
+     * @return The list of schematic function symbols (including free variables) in the term
+     */
+    def schematicTerms: Set[SchematicTermLabel]
   }
 
   /**
@@ -30,7 +40,7 @@ private[fol] trait TermDefinitions extends TermLabelDefinitions {
     override def freeVariables: Set[VariableLabel] = Set(label)
 
     override def constantFunctions: Set[ConstantFunctionLabel] = Set.empty
-    override def schematicFunctions: Set[SchematicFunctionLabel] = Set.empty
+    override def schematicTerms: Set[SchematicTermLabel] = Set(label)
   }
 
   /**
@@ -48,9 +58,9 @@ private[fol] trait TermDefinitions extends TermLabelDefinitions {
       case l: ConstantFunctionLabel => args.foldLeft(Set.empty[ConstantFunctionLabel])((prev, next) => prev union next.constantFunctions) + l
       case l: SchematicFunctionLabel => args.foldLeft(Set.empty[ConstantFunctionLabel])((prev, next) => prev union next.constantFunctions)
     }
-    override def schematicFunctions: Set[SchematicFunctionLabel] = label match {
-      case l: ConstantFunctionLabel => args.foldLeft(Set.empty[SchematicFunctionLabel])((prev, next) => prev union next.schematicFunctions)
-      case l: SchematicFunctionLabel => args.foldLeft(Set.empty[SchematicFunctionLabel])((prev, next) => prev union next.schematicFunctions) + l
+    override def schematicTerms: Set[SchematicTermLabel] = label match {
+      case l: ConstantFunctionLabel => args.foldLeft(Set.empty[SchematicTermLabel])((prev, next) => prev union next.schematicTerms)
+      case l: SchematicFunctionLabel => args.foldLeft(Set.empty[SchematicTermLabel])((prev, next) => prev union next.schematicTerms) + l
     }
 
     val arity: Int = args.size

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -30,15 +30,6 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
   }
 
   /**
-   * The label of a term which is a variable.
-   *
-   * @param id The name of the variable, for example "x" or "y".
-   */
-  sealed case class VariableLabel(id: String) extends TermLabel {
-    val name: String = id
-  }
-
-  /**
    * The label of a function-like term. Constants are functions of arity 0.
    * There are two kinds of function symbols: Standards and schematic.
    * Standard function symbols denote a particular function. Schematic function symbols
@@ -56,13 +47,25 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    */
   sealed case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel with ConstantLabel
 
+  sealed trait SchematicTermLabel extends TermLabel {
+  }
   /**
    * A schematic function symbol that can be substituted.
    *
    * @param id    The name of the function symbol.
    * @param arity The arity of the function symbol. A function symbol of arity 0 is a constant
    */
-  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel
+  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel with SchematicTermLabel
+
+  /**
+   * The label of a term which is a variable.
+   *
+   * @param id The name of the variable, for example "x" or "y".
+   */
+  sealed case class VariableLabel(id: String) extends SchematicTermLabel {
+    val name: String = id
+    val arity = 0
+  }
 
   /**
    * A function returning true if and only if the two symbols are considered "the same".

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -55,7 +55,9 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    * @param id    The name of the function symbol.
    * @param arity The arity of the function symbol. A function symbol of arity 0 is a constant
    */
-  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel with SchematicTermLabel
+  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel with SchematicTermLabel{
+    require(arity >= 1 && arity < MaxArity)
+  }
 
   /**
    * The label of a term which is a variable.

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -35,7 +35,7 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    * Standard function symbols denote a particular function. Schematic function symbols
    * can be instantiated with any term. This is particularly useful to express axiom schemas.
    */
-  sealed abstract class FunctionLabel extends TermLabel with Arity {
+  sealed abstract class FunctionLabel extends TermLabel {
     require(arity >= 0 && arity < MaxArity)
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/TermLabelDefinitions.scala
@@ -47,15 +47,15 @@ private[fol] trait TermLabelDefinitions extends CommonDefinitions {
    */
   sealed case class ConstantFunctionLabel(id: String, arity: Int) extends FunctionLabel with ConstantLabel
 
-  sealed trait SchematicTermLabel extends TermLabel {
-  }
+  sealed trait SchematicTermLabel extends TermLabel {}
+
   /**
    * A schematic function symbol that can be substituted.
    *
    * @param id    The name of the function symbol.
    * @param arity The arity of the function symbol. A function symbol of arity 0 is a constant
    */
-  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel with SchematicTermLabel{
+  sealed case class SchematicFunctionLabel(id: String, arity: Int) extends FunctionLabel with SchematicTermLabel {
     require(arity >= 1 && arity < MaxArity)
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProof.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProof.scala
@@ -1,6 +1,5 @@
 package lisa.kernel.proof
 
-import lisa.kernel.proof.SCProofChecker._
 import lisa.kernel.proof.SequentCalculus._
 
 /**

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -438,7 +438,7 @@ object SCProofChecker {
            * </pre>
            */
           case InstFunSchema(bot, t1, insts) =>
-            val expected = (ref(t1).left.map(phi => instantiateFunctionSchemas(phi, insts)), ref(t1).right.map(phi => instantiateFunctionSchemas(phi, insts)))
+            val expected = (ref(t1).left.map(phi => instantiateTermSchemas(phi, insts)), ref(t1).right.map(phi => instantiateTermSchemas(phi, insts)))
             if (isSameSet(bot.left, expected._1))
               if (isSameSet(bot.right, expected._2))
                 SCValidProof(SCProof(step))

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -2,7 +2,6 @@ package lisa.kernel.proof
 
 import lisa.kernel.fol.FOL._
 
-import scala.collection.immutable.Set
 
 /**
  * The concrete implementation of sequent calculus (with equality).
@@ -301,7 +300,7 @@ object SequentCalculus {
    *  Γ[r(a)/?f] |- Δ[r(a)/?f]
    * </pre>
    */
-  case class InstFunSchema(bot: Sequent, t1: Int, insts: Map[SchematicFunctionLabel, LambdaTermTerm]) extends SCProofStep { val premises = Seq(t1) }
+  case class InstFunSchema(bot: Sequent, t1: Int, insts: Map[SchematicTermLabel, LambdaTermTerm]) extends SCProofStep { val premises = Seq(t1) }
 
   /**
    * <pre>

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -2,7 +2,6 @@ package lisa.kernel.proof
 
 import lisa.kernel.fol.FOL._
 
-
 /**
  * The concrete implementation of sequent calculus (with equality).
  * This file specifies the sequents and the allowed operations on them, the deduction rules of sequent calculus.

--- a/lisa-theories/src/main/scala/lisa/settheory/SetTheoryZAxioms.scala
+++ b/lisa-theories/src/main/scala/lisa/settheory/SetTheoryZAxioms.scala
@@ -11,7 +11,7 @@ private[settheory] trait SetTheoryZAxioms extends SetTheoryDefinitions {
 
   private val (x, y, z) =
     (VariableLabel("x"), VariableLabel("y"), VariableLabel("z"))
-  private final val sPhi = SchematicPredicateLabel("P", 2)
+  private final val sPhi = SchematicNPredicateLabel("P", 2)
 
   final val emptySetAxiom: Formula = forall(x, !in(x, emptySet()))
   final val extensionalityAxiom: Formula = forall(x, forall(y, forall(z, in(z, x) <=> in(z, y)) <=> (x === y)))

--- a/lisa-theories/src/main/scala/lisa/settheory/SetTheoryZFAxioms.scala
+++ b/lisa-theories/src/main/scala/lisa/settheory/SetTheoryZFAxioms.scala
@@ -9,7 +9,7 @@ import lisa.utils.Helpers.{_, given}
 private[settheory] trait SetTheoryZFAxioms extends SetTheoryZAxioms {
   private val (x, y, a, b) =
     (VariableLabel("x"), VariableLabel("y"), VariableLabel("A"), VariableLabel("B"))
-  private final val sPsi = SchematicPredicateLabel("P", 3)
+  private final val sPsi = SchematicNPredicateLabel("P", 3)
 
   final val replacementSchema: Formula = forall(
     a,

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -147,8 +147,8 @@ trait KernelHelpers {
   def instantiatePredicateSchemaInSequent(s: Sequent, m: Map[SchematicPredicateLabel, LambdaTermFormula]): Sequent = {
     s.left.map(phi => instantiatePredicateSchemas(phi, m)) |- s.right.map(phi => instantiatePredicateSchemas(phi, m))
   }
-  def instantiateFunctionSchemaInSequent(s: Sequent, m: Map[SchematicFunctionLabel, LambdaTermTerm]): Sequent = {
-    s.left.map(phi => instantiateFunctionSchemas(phi, m)) |- s.right.map(phi => instantiateFunctionSchemas(phi, m))
+  def instantiateFunctionSchemaInSequent(s: Sequent, m: Map[SchematicTermLabel, LambdaTermTerm]): Sequent = {
+    s.left.map(phi => instantiateTermSchemas(phi, m)) |- s.right.map(phi => instantiateTermSchemas(phi, m))
   }
 
 }

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -89,6 +89,7 @@ trait KernelHelpers {
   given Conversion[VariableLabel, VariableTerm] = VariableTerm.apply
   given Conversion[VariableTerm, VariableLabel] = _.label
   given Conversion[PredicateFormula, PredicateLabel] = _.label
+  given Conversion[PredicateLabel, Formula] = _.apply()
   given Conversion[FunctionTerm, FunctionLabel] = _.label
   given Conversion[SchematicFunctionLabel, Term] = _.apply()
   given Conversion[VariableFormulaLabel, PredicateFormula] = PredicateFormula.apply(_, Nil)

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -91,6 +91,7 @@ trait KernelHelpers {
   given Conversion[PredicateFormula, PredicateLabel] = _.label
   given Conversion[FunctionTerm, FunctionLabel] = _.label
   given Conversion[SchematicFunctionLabel, Term] = _.apply()
+  given Conversion[VariableFormulaLabel, PredicateFormula] = PredicateFormula.apply(_, Nil)
   given Conversion[(Boolean, List[Int], String), Option[(List[Int], String)]] = tr => if (tr._1) None else Some(tr._2, tr._3)
   given Conversion[Formula, Sequent] = () |- _
 

--- a/lisa-utils/src/main/scala/lisa/utils/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Library.scala
@@ -53,12 +53,12 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
      */
-    def PROOF(proof: Proof)(using String => Unit)(using Throwable =>Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, proof)
+    def PROOF(proof: Proof)(using String => Unit)(using Throwable => Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, proof)
 
     /**
      * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
      */
-    def PROOF(steps: IndexedSeq[SCProofStep])(using String => Unit)(using Throwable =>Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, Proof(steps))
+    def PROOF(steps: IndexedSeq[SCProofStep])(using String => Unit)(using Throwable => Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, Proof(steps))
   }
 
   /**
@@ -80,7 +80,7 @@ abstract class Library(val theory: RunningTheory) {
   /**
    * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
    */
-  case class TheoremNameWithProof(name: String, statement: String, proof: Proof)(using String => Unit)(using Throwable =>Nothing) {
+  case class TheoremNameWithProof(name: String, statement: String, proof: Proof)(using String => Unit)(using Throwable => Nothing) {
     infix def using(justifications: theory.Justification*): theory.Theorem = theory.theorem(name, statement, proof, justifications) match {
       case Judgement.ValidJustification(just) =>
         last = Some(just)
@@ -111,7 +111,7 @@ abstract class Library(val theory: RunningTheory) {
    */
   def complexDefinition(symbol: String, vars: Seq[VariableLabel], v: VariableLabel, f: Formula, proof: Proof, just: Seq[Justification]): Judgement[theory.FunctionDefinition] = {
     theory.functionDefinition(symbol, LambdaTermFormula(vars, f), v, proof, just)
-    //theory.functionDefinition(symbol, LambdaTermFormula(vars, instantiateTermSchemas(f, Map(v -> LambdaTermTerm(Nil, out)))), out, proof, just)
+    // theory.functionDefinition(symbol, LambdaTermFormula(vars, instantiateTermSchemas(f, Map(v -> LambdaTermTerm(Nil, out)))), out, proof, just)
   }
 
   /**
@@ -130,7 +130,7 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
      */
-    infix def as(t: Term)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = {
+    infix def as(t: Term)(using String => Unit)(using Throwable => Nothing): ConstantFunctionLabel = {
       val definition = simpleDefinition(symbol, LambdaTermTerm(vars, t)) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -143,7 +143,7 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
      */
-    infix def as(f: Formula)(using String => Unit)(using Throwable =>Nothing): ConstantPredicateLabel = {
+    infix def as(f: Formula)(using String => Unit)(using Throwable => Nothing): ConstantPredicateLabel = {
       val definition = simpleDefinition(symbol, LambdaTermFormula(vars, f)) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -189,7 +189,7 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
      */
-    infix def using(justifications: theory.Justification*)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = {
+    infix def using(justifications: theory.Justification*)(using String => Unit)(using Throwable => Nothing): ConstantFunctionLabel = {
       val definition = complexDefinition(symbol, vars, out, f, proof, justifications) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -202,7 +202,7 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
      */
-    infix def using(u: Unit)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = using()
+    infix def using(u: Unit)(using String => Unit)(using Throwable => Nothing): ConstantFunctionLabel = using()
   }
 
   /**

--- a/lisa-utils/src/main/scala/lisa/utils/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Library.scala
@@ -53,12 +53,12 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
      */
-    def PROOF(proof: Proof)(using String => Unit): TheoremNameWithProof = TheoremNameWithProof(name, statement, proof)
+    def PROOF(proof: Proof)(using String => Unit)(using Throwable =>Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, proof)
 
     /**
      * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
      */
-    def PROOF(steps: IndexedSeq[SCProofStep])(using String => Unit): TheoremNameWithProof = TheoremNameWithProof(name, statement, Proof(steps))
+    def PROOF(steps: IndexedSeq[SCProofStep])(using String => Unit)(using Throwable =>Nothing): TheoremNameWithProof = TheoremNameWithProof(name, statement, Proof(steps))
   }
 
   /**
@@ -80,7 +80,7 @@ abstract class Library(val theory: RunningTheory) {
   /**
    * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
    */
-  case class TheoremNameWithProof(name: String, statement: String, proof: Proof)(using String => Unit) {
+  case class TheoremNameWithProof(name: String, statement: String, proof: Proof)(using String => Unit)(using Throwable =>Nothing) {
     infix def using(justifications: theory.Justification*): theory.Theorem = theory.theorem(name, statement, proof, justifications) match {
       case Judgement.ValidJustification(just) =>
         last = Some(just)
@@ -101,7 +101,7 @@ abstract class Library(val theory: RunningTheory) {
    */
   def simpleDefinition(symbol: String, expression: LambdaTermTerm): Judgement[theory.FunctionDefinition] = {
     val LambdaTermTerm(vars, body) = expression
-    val out: VariableLabel = VariableLabel(freshId((vars.map(_.id) ++ body.schematicFunctions.map(_.id)).toSet, "y"))
+    val out: VariableLabel = VariableLabel(freshId((vars.map(_.id) ++ body.schematicTerms.map(_.id)).toSet, "y"))
     val proof: Proof = simpleFunctionDefinition(expression, out)
     theory.functionDefinition(symbol, LambdaTermFormula(vars, out === body), out, proof, Nil)
   }
@@ -109,9 +109,9 @@ abstract class Library(val theory: RunningTheory) {
   /**
    * Allows to create a definition by existential uniqueness of a function symbol:
    */
-  def complexDefinition(symbol: String, vars: Seq[SchematicFunctionLabel], v: SchematicFunctionLabel, f: Formula, proof: Proof, just: Seq[Justification]): Judgement[theory.FunctionDefinition] = {
-    val out: VariableLabel = VariableLabel(freshId((vars.map(_.id) ++ f.schematicFunctions.map(_.id)).toSet, "y"))
-    theory.functionDefinition(symbol, LambdaTermFormula(vars, instantiateFunctionSchemas(f, Map(v -> LambdaTermTerm(Nil, out)))), out, proof, just)
+  def complexDefinition(symbol: String, vars: Seq[VariableLabel], v: VariableLabel, f: Formula, proof: Proof, just: Seq[Justification]): Judgement[theory.FunctionDefinition] = {
+    theory.functionDefinition(symbol, LambdaTermFormula(vars, f), v, proof, just)
+    //theory.functionDefinition(symbol, LambdaTermFormula(vars, instantiateTermSchemas(f, Map(v -> LambdaTermTerm(Nil, out)))), out, proof, just)
   }
 
   /**
@@ -125,12 +125,12 @@ abstract class Library(val theory: RunningTheory) {
    * or
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
-  case class FunSymbolDefine(symbol: String, vars: Seq[SchematicFunctionLabel]) {
+  case class FunSymbolDefine(symbol: String, vars: Seq[VariableLabel]) {
 
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
      */
-    infix def as(t: Term)(using String => Unit): ConstantFunctionLabel = {
+    infix def as(t: Term)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = {
       val definition = simpleDefinition(symbol, LambdaTermTerm(vars, t)) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -143,7 +143,7 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
      */
-    infix def as(f: Formula)(using String => Unit): ConstantPredicateLabel = {
+    infix def as(f: Formula)(using String => Unit)(using Throwable =>Nothing): ConstantPredicateLabel = {
       val definition = simpleDefinition(symbol, LambdaTermFormula(vars, f)) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -156,13 +156,13 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
      */
-    infix def asThe(out: SchematicFunctionLabel): DefinitionNameAndOut = DefinitionNameAndOut(symbol, vars, out)
+    infix def asThe(out: VariableLabel): DefinitionNameAndOut = DefinitionNameAndOut(symbol, vars, out)
   }
 
   /**
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
-  case class DefinitionNameAndOut(symbol: String, vars: Seq[SchematicFunctionLabel], out: SchematicFunctionLabel) {
+  case class DefinitionNameAndOut(symbol: String, vars: Seq[VariableLabel], out: VariableLabel) {
 
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
@@ -173,7 +173,7 @@ abstract class Library(val theory: RunningTheory) {
   /**
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
-  case class DefinitionWaitingProof(symbol: String, vars: Seq[SchematicFunctionLabel], out: SchematicFunctionLabel, f: Formula) {
+  case class DefinitionWaitingProof(symbol: String, vars: Seq[VariableLabel], out: VariableLabel, f: Formula) {
 
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
@@ -184,12 +184,12 @@ abstract class Library(val theory: RunningTheory) {
   /**
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
-  case class DefinitionWithProof(symbol: String, vars: Seq[SchematicFunctionLabel], out: SchematicFunctionLabel, f: Formula, proof: Proof) {
+  case class DefinitionWithProof(symbol: String, vars: Seq[VariableLabel], out: VariableLabel, f: Formula, proof: Proof) {
 
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
      */
-    infix def using(justifications: theory.Justification*)(using String => Unit): ConstantFunctionLabel = {
+    infix def using(justifications: theory.Justification*)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = {
       val definition = complexDefinition(symbol, vars, out, f, proof, justifications) match {
         case Judgement.ValidJustification(just) =>
           last = Some(just)
@@ -202,13 +202,13 @@ abstract class Library(val theory: RunningTheory) {
     /**
      * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
      */
-    infix def using(u: Unit)(using String => Unit): ConstantFunctionLabel = using()
+    infix def using(u: Unit)(using String => Unit)(using Throwable =>Nothing): ConstantFunctionLabel = using()
   }
 
   /**
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
-  def DEFINE(symbol: String, vars: SchematicFunctionLabel*): FunSymbolDefine = FunSymbolDefine(symbol, vars)
+  def DEFINE(symbol: String, vars: VariableLabel*): FunSymbolDefine = FunSymbolDefine(symbol, vars)
 
   /**
    * For a definition of the type f(x) := term, construct the required proof ∃!y. y = term.

--- a/lisa-utils/src/main/scala/lisa/utils/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Printer.scala
@@ -67,7 +67,7 @@ object Printer {
         case _ =>
           val labelString = label match {
             case ConstantPredicateLabel(id, _) => id
-            case SchematicPredicateLabel(id, _) => s"?$id"
+            case s:SchematicPredicateLabel => s"?${s.id}"
           }
           prettyFunction(labelString, args.map(prettyTerm(_, compact)), compact)
       }

--- a/lisa-utils/src/main/scala/lisa/utils/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Printer.scala
@@ -67,7 +67,7 @@ object Printer {
         case _ =>
           val labelString = label match {
             case ConstantPredicateLabel(id, _) => id
-            case s:SchematicPredicateLabel => s"?${s.id}"
+            case s: SchematicPredicateLabel => s"?${s.id}"
           }
           prettyFunction(labelString, args.map(prettyTerm(_, compact)), compact)
       }
@@ -150,7 +150,7 @@ object Printer {
    * @return the string representation of this term
    */
   def prettyTerm(term: Term, compact: Boolean = false): String = term match {
-    case VariableTerm(label) => label.id
+    case VariableTerm(label) => s"?${label.id}"
     case FunctionTerm(label, args) =>
       label match {
         case `emptySet` =>

--- a/lisa-utils/src/main/scala/lisa/utils/TheoriesHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/TheoriesHelpers.scala
@@ -1,7 +1,8 @@
 package lisa.utils
 
 import lisa.kernel.fol.FOL.*
-import lisa.kernel.proof.RunningTheoryJudgement.{InvalidJustification, InvalidJustificationException}
+import lisa.kernel.proof.RunningTheoryJudgement.InvalidJustification
+import lisa.kernel.proof.RunningTheoryJudgement.InvalidJustificationException
 import lisa.kernel.proof.SequentCalculus.*
 import lisa.kernel.proof.*
 import lisa.utils.Printer
@@ -91,7 +92,7 @@ trait TheoriesHelpers extends KernelHelpers {
      * If the Judgement is valid, show the inner justification and returns it.
      * Otherwise, output the error leading to the invalid justification and throw an error.
      */
-    def showAndGet(using output: String => Unit)(using finishOutput:Throwable => Nothing): J = {
+    def showAndGet(using output: String => Unit)(using finishOutput: Throwable => Nothing): J = {
       theoryJudgement match {
         case RunningTheoryJudgement.ValidJustification(just) =>
           just.show

--- a/lisa-utils/src/test/scala/lisa/kernel/FolTests.scala
+++ b/lisa-utils/src/test/scala/lisa/kernel/FolTests.scala
@@ -101,7 +101,7 @@ class FolTests extends AnyFunSuite {
   private val a = PredicateFormula(ConstantPredicateLabel("A", 0), Seq())
   private val b = PredicateFormula(ConstantPredicateLabel("B", 0), Seq())
   private val fp = ConstantPredicateLabel("F", 1)
-  private val sT = SchematicFunctionLabel("t", 0)
+  private val sT = VariableLabel("t")
 
   def test_some_random_formulas(n: Int, maxDepth: Int): Unit = {
     (0 to n).foreach(_ => println(formulaGenerator(maxDepth)))

--- a/lisa-utils/src/test/scala/lisa/kernel/IncorrectProofsTests.scala
+++ b/lisa-utils/src/test/scala/lisa/kernel/IncorrectProofsTests.scala
@@ -17,7 +17,7 @@ class IncorrectProofsTests extends ProofCheckerSuite {
     // Shorthand
     implicit def proofStepToProof(proofStep: SCProofStep): SCProof = SCProof(proofStep)
 
-    val (fl, gl, hl) = (SchematicPredicateLabel("f", 0), SchematicPredicateLabel("g", 0), SchematicPredicateLabel("h", 0))
+    val (fl, gl, hl) = (VariableFormulaLabel("f"), VariableFormulaLabel("g"), VariableFormulaLabel("h"))
     val f = PredicateFormula(fl, Seq.empty) // Some arbitrary formulas
     val g = PredicateFormula(gl, Seq.empty)
     val h = PredicateFormula(hl, Seq.empty)

--- a/lisa-utils/src/test/scala/lisa/kernel/ProofTests.scala
+++ b/lisa-utils/src/test/scala/lisa/kernel/ProofTests.scala
@@ -22,7 +22,7 @@ class ProofTests extends AnyFunSuite {
   private val a = PredicateFormula(ConstantPredicateLabel("A", 0), Seq())
   private val b = PredicateFormula(ConstantPredicateLabel("B", 0), Seq())
   private val fp = ConstantPredicateLabel("F", 1)
-  val sT = SchematicFunctionLabel("t", 0)
+  val sT = VariableLabel("t")
 
   test("Verification of Pierce law") {
     val s0 = Hypothesis(a |- a, a)
@@ -36,7 +36,7 @@ class ProofTests extends AnyFunSuite {
 
   test("Verification of substitution") {
     val t0 = Hypothesis(fp(x) |- fp(x), fp(x))
-    val t1 = RightSubstEq(Set(fp(x), x === y) |- fp(y), 0, List((x, y)), LambdaTermFormula(Seq(sT), fp(sT())))
+    val t1 = RightSubstEq(Set(fp(x), x === y) |- fp(y), 0, List((x, y)), LambdaTermFormula(Seq(sT), fp(sT)))
     val pr = new SCProof(IndexedSeq(t0, t1))
     assert(predicateVerifier(pr).isValid)
   }

--- a/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
+++ b/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
@@ -12,48 +12,48 @@ import scala.language.adhocExtensions
 
 abstract class ProofCheckerSuite extends AnyFunSuite {
 
-    import lisa.kernel.fol.FOL.*
+  import lisa.kernel.fol.FOL.*
 
-    protected val (xl, yl, zl, wl, xpl, ypl, zpl, wpl) = (
-        VariableLabel("x"),
-        VariableLabel("y"),
-        VariableLabel("z"),
-        VariableLabel("w"),
-        VariableLabel("x'"),
-        VariableLabel("y'"),
-        VariableLabel("z'"),
-        VariableLabel("w'")
+  protected val (xl, yl, zl, wl, xpl, ypl, zpl, wpl) = (
+    VariableLabel("x"),
+    VariableLabel("y"),
+    VariableLabel("z"),
+    VariableLabel("w"),
+    VariableLabel("x'"),
+    VariableLabel("y'"),
+    VariableLabel("z'"),
+    VariableLabel("w'")
+  )
+  protected val (x, y, z, w, xp, yp, zp, wp) = (
+    VariableTerm(xl),
+    VariableTerm(yl),
+    VariableTerm(zl),
+    VariableTerm(wl),
+    VariableTerm(xpl),
+    VariableTerm(ypl),
+    VariableTerm(zpl),
+    VariableTerm(wpl)
+  )
+
+  protected val (sl, tl, ul, vl) = (VariableLabel("s"), VariableLabel("t"), VariableLabel("u"), VariableLabel("v"))
+  protected val (s, t, u, v) = (VariableTerm(sl), VariableTerm(tl), VariableTerm(ul), VariableTerm(vl))
+
+  def checkProof(proof: SCProof): Unit = {
+    val judgement = checkSCProof(proof)
+    println(Printer.prettySCProof(judgement))
+    println(s"\n(${proof.totalLength} proof steps in total)")
+  }
+
+  def checkProof(proof: SCProof, expected: Sequent): Unit = {
+    val judgement = checkSCProof(proof)
+    assert(judgement.isValid, "\n" + Printer.prettySCProof(judgement))
+    assert(isSameSequent(proof.conclusion, expected), s"(${Printer.prettySequent(proof.conclusion)} did not equal ${Printer.prettySequent(expected)})")
+  }
+
+  def checkIncorrectProof(incorrectProof: SCProof): Unit = {
+    assert(
+      !checkSCProof(incorrectProof).isValid,
+      s"(incorrect proof with conclusion '${Printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
     )
-    protected val (x, y, z, w, xp, yp, zp, wp) = (
-        VariableTerm(xl),
-        VariableTerm(yl),
-        VariableTerm(zl),
-        VariableTerm(wl),
-        VariableTerm(xpl),
-        VariableTerm(ypl),
-        VariableTerm(zpl),
-        VariableTerm(wpl)
-    )
-
-    protected val (sl, tl, ul, vl) = (VariableLabel("s"), VariableLabel("t"), VariableLabel("u"), VariableLabel("v"))
-    protected val (s, t, u, v) = (VariableTerm(sl), VariableTerm(tl), VariableTerm(ul), VariableTerm(vl))
-
-    def checkProof(proof: SCProof): Unit = {
-        val judgement = checkSCProof(proof)
-        println(Printer.prettySCProof(judgement))
-        println(s"\n(${proof.totalLength} proof steps in total)")
-    }
-
-    def checkProof(proof: SCProof, expected: Sequent): Unit = {
-        val judgement = checkSCProof(proof)
-        assert(judgement.isValid, "\n" + Printer.prettySCProof(judgement))
-        assert(isSameSequent(proof.conclusion, expected), s"(${Printer.prettySequent(proof.conclusion)} did not equal ${Printer.prettySequent(expected)})")
-    }
-
-    def checkIncorrectProof(incorrectProof: SCProof): Unit = {
-        assert(
-            !checkSCProof(incorrectProof).isValid,
-            s"(incorrect proof with conclusion '${Printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
-        )
-    }
+  }
 }

--- a/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
+++ b/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
@@ -11,48 +11,49 @@ import org.scalatest.funsuite.AnyFunSuite
 import scala.language.adhocExtensions
 
 abstract class ProofCheckerSuite extends AnyFunSuite {
-  import lisa.kernel.fol.FOL.*
 
-  protected val (xl, yl, zl, wl, xpl, ypl, zpl, wpl) = (
-    SchematicFunctionLabel("x", 0),
-    SchematicFunctionLabel("y", 0),
-    SchematicFunctionLabel("z", 0),
-    SchematicFunctionLabel("w", 0),
-    SchematicFunctionLabel("x'", 0),
-    SchematicFunctionLabel("y'", 0),
-    SchematicFunctionLabel("z'", 0),
-    SchematicFunctionLabel("w'", 0)
-  )
-  protected val (x, y, z, w, xp, yp, zp, wp) = (
-    FunctionTerm(xl, Seq.empty),
-    FunctionTerm(yl, Seq.empty),
-    FunctionTerm(zl, Seq.empty),
-    FunctionTerm(wl, Seq.empty),
-    FunctionTerm(xpl, Seq.empty),
-    FunctionTerm(ypl, Seq.empty),
-    FunctionTerm(zpl, Seq.empty),
-    FunctionTerm(wpl, Seq.empty)
-  )
+    import lisa.kernel.fol.FOL.*
 
-  protected val (sl, tl, ul, vl) = (VariableLabel("s"), VariableLabel("t"), VariableLabel("u"), VariableLabel("v"))
-  protected val (s, t, u, v) = (VariableTerm(sl), VariableTerm(tl), VariableTerm(ul), VariableTerm(vl))
-
-  def checkProof(proof: SCProof): Unit = {
-    val judgement = checkSCProof(proof)
-    println(Printer.prettySCProof(judgement))
-    println(s"\n(${proof.totalLength} proof steps in total)")
-  }
-
-  def checkProof(proof: SCProof, expected: Sequent): Unit = {
-    val judgement = checkSCProof(proof)
-    assert(judgement.isValid, "\n" + Printer.prettySCProof(judgement))
-    assert(isSameSequent(proof.conclusion, expected), s"(${Printer.prettySequent(proof.conclusion)} did not equal ${Printer.prettySequent(expected)})")
-  }
-
-  def checkIncorrectProof(incorrectProof: SCProof): Unit = {
-    assert(
-      !checkSCProof(incorrectProof).isValid,
-      s"(incorrect proof with conclusion '${Printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
+    protected val (xl, yl, zl, wl, xpl, ypl, zpl, wpl) = (
+        VariableLabel("x"),
+        VariableLabel("y"),
+        VariableLabel("z"),
+        VariableLabel("w"),
+        VariableLabel("x'"),
+        VariableLabel("y'"),
+        VariableLabel("z'"),
+        VariableLabel("w'")
     )
-  }
+    protected val (x, y, z, w, xp, yp, zp, wp) = (
+        VariableTerm(xl),
+        VariableTerm(yl),
+        VariableTerm(zl),
+        VariableTerm(wl),
+        VariableTerm(xpl),
+        VariableTerm(ypl),
+        VariableTerm(zpl),
+        VariableTerm(wpl)
+    )
+
+    protected val (sl, tl, ul, vl) = (VariableLabel("s"), VariableLabel("t"), VariableLabel("u"), VariableLabel("v"))
+    protected val (s, t, u, v) = (VariableTerm(sl), VariableTerm(tl), VariableTerm(ul), VariableTerm(vl))
+
+    def checkProof(proof: SCProof): Unit = {
+        val judgement = checkSCProof(proof)
+        println(Printer.prettySCProof(judgement))
+        println(s"\n(${proof.totalLength} proof steps in total)")
+    }
+
+    def checkProof(proof: SCProof, expected: Sequent): Unit = {
+        val judgement = checkSCProof(proof)
+        assert(judgement.isValid, "\n" + Printer.prettySCProof(judgement))
+        assert(isSameSequent(proof.conclusion, expected), s"(${Printer.prettySequent(proof.conclusion)} did not equal ${Printer.prettySequent(expected)})")
+    }
+
+    def checkIncorrectProof(incorrectProof: SCProof): Unit = {
+        assert(
+            !checkSCProof(incorrectProof).isValid,
+            s"(incorrect proof with conclusion '${Printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
+        )
+    }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
@@ -28,17 +28,17 @@ class PrinterTest extends AnyFunSuite {
     assert(prettyFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b))))))) == "¬¬(a ∧ b)")
     assert(prettyFormula(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(b)), ConnectorFormula(Neg, Seq(c))))))) == "¬a ∧ ¬b ∧ ¬c")
 
-    assert(prettyFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ (x = x)")
+    assert(prettyFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ (?x = ?x)")
 
-    assert(prettyFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀x. x = x")
-    assert(prettyFormula(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))))) == "a ∧ ∀x. x = x")
+    assert(prettyFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀x. ?x = ?x")
+    assert(prettyFormula(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))))) == "a ∧ ∀x. ?x = ?x")
     assert(prettyFormula(ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a))) == "(∀x. b) ∧ a")
     assert(prettyFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "(a ∧ ∀x. b) ∧ a")
     assert(prettyFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀x. b) ∨ a")
 
     assert(prettyFormula(BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a)))) == "∀x. ∃y. ∃!z. a")
 
-    assert(prettyFormula(PredicateFormula(ConstantPredicateLabel("f", 2), Seq(x, y, z))) == "f(x, y, z)")
+    assert(prettyFormula(PredicateFormula(ConstantPredicateLabel("f", 2), Seq(x, y, z))) == "f(?x, ?y, ?z)")
   }
 
 }

--- a/src/main/scala/lisa/proven/Main.scala
+++ b/src/main/scala/lisa/proven/Main.scala
@@ -10,6 +10,10 @@ trait Main {
   private var outString: List[String] = List()
   private val lineBreak = "\n"
   given output: (String => Unit) = s => outString = lineBreak :: s :: outString
+  given finishOutput: (Throwable => Nothing) = e => {
+    main(Array[String]())
+    throw e
+  }
 
   /**
    * This specific implementation make sure that what is "shown" in theory files is only printed for the one we run, and not for the whole library.

--- a/src/main/scala/lisa/proven/mathematics/Mapping.scala
+++ b/src/main/scala/lisa/proven/mathematics/Mapping.scala
@@ -11,440 +11,420 @@ import SetTheory.*
  */
 object Mapping extends lisa.proven.Main {
 
-  THEOREM("functionalMapping") of
-    "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {
-      val a = VariableLabel("a")
-      val b = VariableLabel("b")
-      val x = VariableLabel("x")
-      val y = VariableLabel("y")
-      val z = VariableLabel("z")
-      val a1 = SchematicFunctionLabel("a", 0)
-      val b1 = SchematicFunctionLabel("b", 0)
-      val x1 = SchematicFunctionLabel("x", 0)
-      val y1 = SchematicFunctionLabel("y", 0)
-      val z1 = SchematicFunctionLabel("z", 0)
-      val f = SchematicFunctionLabel("f", 0)
-      val h = SchematicPredicateLabel("h", 0)
-      val A = SchematicFunctionLabel("A", 0)()
-      val X = VariableLabel("X")
-      val B = VariableLabel("B")
-      val B1 = VariableLabel("B1")
-      val phi = SchematicPredicateLabel("phi", 2)
-      val sPhi = SchematicPredicateLabel("P", 2)
-      val sPsi = SchematicPredicateLabel("P", 3)
+    THEOREM("functionalMapping") of
+        "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {
+        val a = VariableLabel("a")
+        val b = VariableLabel("b")
+        val x = VariableLabel("x")
+        val y = VariableLabel("y")
+        val z = VariableLabel("z")
+        val f = VariableLabel("f")
+        val h = SchematicPredicateLabel("h", 0)
+        val A = VariableLabel("A")
+        val X = VariableLabel("X")
+        val B = VariableLabel("B")
+        val B1 = VariableLabel("B1")
+        val phi = SchematicPredicateLabel("phi", 2)
+        val sPhi = SchematicPredicateLabel("P", 2)
+        val sPsi = SchematicPredicateLabel("P", 3)
 
-      val H = existsOne(x, phi(x, a))
-      val H1 = forall(a, in(a, A) ==> H)
-      val s0 = hypothesis(H) // () |- existsOne(x, phi(x, a)))
-      val s1 = Weakening((H, in(a, A)) |- existsOne(x, phi(x, a)), 0)
-      val s2 = Rewrite((H) |- in(a, A) ==> existsOne(x, phi(x, a)), 1)
-      // val s3 = RightForall((H) |- forall(a, in(a, A) ==> existsOne(x, phi(x, a))), 2, in(a, A) ==> existsOne(x, phi(x, a)), a) // () |- ∀a∈A. ∃!x. phi(x, a)
-      val s3 = hypothesis(H1)
-      val i1 = () |- replacementSchema
-      val p0 = InstPredSchema(
-        () |- instantiatePredicateSchemas(replacementSchema, Map(sPsi -> LambdaTermFormula(Seq(y1, a1, x1), phi(x1, a1)))),
-        -1,
-        Map(sPsi -> LambdaTermFormula(Seq(y1, a1, x1), phi(x1, a1)))
-      )
-      val p1 = instantiateForall(Proof(steps(p0), imports(i1)), A)
-      val s4 = SCSubproof(p1, Seq(-1)) //
-      val s5 = Rewrite(s3.bot.right.head |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 4)
-      val s6 = Cut((H1) |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 3, 5, s3.bot.right.head) // ⊢ ∃B. ∀x. (x ∈ A) ⇒ ∃y. (y ∈ B) ∧ (y = (x, b))
-
-      val i2 = () |- comprehensionSchema // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,z) /\ sPhi(x,z)))))
-      val q0 = InstPredSchema(
-        () |- instantiatePredicateSchemas(comprehensionSchema, Map(sPhi -> LambdaTermFormula(Seq(x1, z1), exists(a, in(a, A) /\ phi(x1, a))))),
-        -1,
-        Map(sPhi -> LambdaTermFormula(Seq(x1, z1), exists(a, in(a, A) /\ phi(x1, a))))
-      )
-      val q1 = instantiateForall(Proof(steps(q0), imports(i2)), B)
-      val s7 = SCSubproof(q1, Seq(-2)) // ∃y. ∀x. (x ∈ y) ↔ (x ∈ B) ∧ ∃a. a ∈ A /\ x = (a, b)      := exists(y, F(y) )
-      Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7), imports(i1, i2))
-      val s8 = SCSubproof({
-        val y1 = VariableLabel("y1")
-        val f = SchematicFunctionLabel("f", 0)
-        val s0 = hypothesis(in(y1, B))
-        val s1 = RightSubstEq((in(y1, B), x === y1) |- in(x, B), 0, List((x, y1)), LambdaTermFormula(Seq(f), in(f(), B)))
-        val s2 = LeftSubstIff(Set(in(y1, B), (x === y1) <=> phi(x, a), phi(x, a)) |- in(x, B), 1, List(((x === y1), phi(x, a))), LambdaFormulaFormula(Seq(h), h()))
-        val s3 = LeftSubstEq(Set(y === y1, in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 2, List((y, y1)), LambdaTermFormula(Seq(f), (x === f()) <=> phi(x, a)))
-        val s4 = LeftSubstIff(Set((y === y1) <=> phi(y1, a), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 3, List((phi(y1, a), y1 === y)), LambdaFormulaFormula(Seq(h), h()))
-        val s5 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 4, (y === x) <=> phi(x, a), x, y1)
-        val s6 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 5, (x === y) <=> phi(x, a), x, x)
-        val s7 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 6, forall(x, (y === x) <=> phi(x, a)), y)
-        val s8 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a) /\ in(y1, B), phi(x, a)) |- in(x, B), 7)
-        val s9 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), exists(y1, phi(y1, a) /\ in(y1, B)), phi(x, a)) |- in(x, B), 8, phi(y1, a) /\ in(y1, B), y1)
-        val s10 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), And() ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a)) |- in(x, B), 9)
-        val s11 = LeftSubstIff(
-          Set(exists(y, forall(x, (y === x) <=> phi(x, a))), in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a), in(a, A)) |- in(x, B),
-          10,
-          List((And(), in(a, A))),
-          LambdaFormulaFormula(Seq(h), h() ==> exists(y, phi(y, a) /\ in(y, B)))
-        )
-        val s12 = LeftForall(
-          Set(exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-          11,
-          in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)),
-          a,
-          a
-        )
-        val s13 = LeftSubstIff(
-          Set(in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-          12,
-          List((And(), in(a, A))),
-          LambdaFormulaFormula(Seq(h), h() ==> exists(y, forall(x, (y === x) <=> phi(x, a))))
-        )
-        val s14 = LeftForall(
-          Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-          13,
-          in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))),
-          a,
-          a
-        )
-        val s15 = Rewrite(Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a) /\ in(a, A)) |- in(x, B), 14)
-        val s16 = LeftExists(
-          Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B),
-          15,
-          phi(x, a) /\ in(a, A),
-          a
-        )
-        val truc = forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)))
-        val s17 = Rewrite(Set(forall(a, in(a, A) ==> existsOne(x, phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B), 16)
-        Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17))
-        // goal H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
-        // redGoal ∀a.(a ∈ A) => ∃!x. phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s17
-        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s16
-        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A ∧ phi(x, a) |- (x ∈ B)    s15
-        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s14
-        // redGoal (a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s13
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s12
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s11
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s11
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), T ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s10
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∃y1. y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s9
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s8
-        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s7
-        // redGoal ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s6
-        // redGoal (x=y) ↔ phi(x, a), ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s5
-        // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s4
-        // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s3
-        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s2
-        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (x ∈ B)     s1
-        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (y1 ∈ B)     s0
-
-      }) // H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
-
-      val G = forall(a, in(a, A) ==> exists(y, in(y, B) /\ (phi(y, a))))
-      val F = forall(x, iff(in(x, B1), in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))))
-      val s9 = SCSubproof({
-        val p0 = instantiateForall(Proof(hypothesis(F)), x)
-        val left = in(x, B1)
-        val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
-        val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
-        val p2 = destructRightAnd(p1, (right ==> left), (left ==> right)) // F |- in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) => in(x, B1)
-        val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B), exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), p2.length - 1)))
-        p3
-      }) // have F, (x ∈ B),  ∃a. a ∈ A ∧ x = (a, b) |- (x ∈ B1)
-      val s10 = Cut(Set(F, G, H1, exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), 8, 9, in(x, B)) // redGoal F, ∃a. a ∈ A ∧ x = (a, b), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ y = (a, b) |- (x ∈ B1)
-      val s11 = Rewrite(Set(H1, G, F) |- exists(a, in(a, A) /\ (phi(x, a))) ==> in(x, B1), 10) // F |- ∃a. a ∈ A ∧ x = (a, b) => (x ∈ B1)   --- half
-      val s12 = SCSubproof({
-        val p0 = instantiateForall(Proof(hypothesis(F)), x)
-        val left = in(x, B1)
-        val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
-        val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
-        val p2 = destructRightAnd(p1, (left ==> right), (right ==> left)) // F |- in(x, B1) => in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) =>
-        val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B1)) |- exists(a, in(a, A) /\ (phi(x, a))) /\ in(x, B), p2.length - 1)))
-        val p4 = destructRightAnd(p3, exists(a, in(a, A) /\ (phi(x, a))), in(x, B))
-        val p5 = p4.withNewSteps(Vector(Rewrite(F |- in(x, B1) ==> exists(a, in(a, A) /\ (phi(x, a))), p4.length - 1)))
-        p5
-      }) // have F |- (x ∈ B1) ⇒ ∃a. a ∈ A ∧ x = (a, b)    --- other half
-      val s13 = RightIff((H1, G, F) |- in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))), 11, 12, in(x, B1), exists(a, in(a, A) /\ (phi(x, a)))) // have F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-      val s14 =
-        RightForall(
-          (H1, G, F) |- forall(x, in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-          13,
-          in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))),
-          x
-        ) // G, F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-
-      val i3 = () |- extensionalityAxiom
-      val s15 = SCSubproof(
-        {
-          val i1 = s13.bot // G, F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-          val i2 = () |- extensionalityAxiom
-          val t0 = RightSubstIff(
-            Set(H1, G, F, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, X) <=> in(x, B1),
+        val H = existsOne(x, phi(x, a))
+        val H1 = forall(a, in(a, A) ==> H)
+        val s0 = hypothesis(H) // () |- existsOne(x, phi(x, a)))
+        val s1 = Weakening((H, in(a, A)) |- existsOne(x, phi(x, a)), 0)
+        val s2 = Rewrite((H) |- in(a, A) ==> existsOne(x, phi(x, a)), 1)
+        // val s3 = RightForall((H) |- forall(a, in(a, A) ==> existsOne(x, phi(x, a))), 2, in(a, A) ==> existsOne(x, phi(x, a)), a) // () |- ∀a∈A. ∃!x. phi(x, a)
+        val s3 = hypothesis(H1)
+        val i1 = () |- replacementSchema
+        val p0 = InstPredSchema(
+            () |- instantiatePredicateSchemas(replacementSchema, Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))),
             -1,
-            List((in(x, X), exists(a, in(a, A) /\ (phi(x, a))))),
-            LambdaFormulaFormula(Seq(h), h() <=> in(x, B1))
-          ) // redGoal2  F, (z ∈ X) <=> ∃a. a ∈ A ∧ z = (a, b) |- (z ∈ X) <=> (z ∈ B1)
-          val t1 = LeftForall(
-            Set(H1, G, F, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))) |- in(x, X) <=> in(x, B1),
-            0,
-            in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))),
-            x,
-            x
-          ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- (z ∈ X) <=> (z ∈ B1)
-          val t2 = RightForall(t1.bot.left |- forall(x, in(x, X) <=> in(x, B1)), 1, in(x, X) <=> in(x, B1), x) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- ∀z. (z ∈ X) <=> (z ∈ B1)
-          val t3 =
-            SCSubproof(instantiateForall(Proof(steps(Rewrite(() |- extensionalityAxiom, -1)), imports(() |- extensionalityAxiom)), X, B1), Vector(-2)) // (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1)))
-          val t4 = RightSubstIff(
-            t1.bot.left ++ t3.bot.right |- X === B1,
-            2,
-            List((X === B1, forall(z, in(z, X) <=> in(z, B1)))),
-            LambdaFormulaFormula(Seq(h), h())
-          ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)], (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1))) |- X=B1
-          val t5 = Cut(t1.bot.left |- X === B1, 3, 4, t3.bot.right.head) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- X=B1
-          val t6 = Rewrite(Set(H1, G, F) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) ==> (X === B1), 5) //  F |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] ==> X=B1
-          val i3 = s14.bot // F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-          val t7 = RightSubstEq(
-            Set(H1, G, F, X === B1) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-            -3,
-            List((X, B1)),
-            LambdaTermFormula(Seq(f), forall(x, in(x, f()) <=> exists(a, in(a, A) /\ phi(x, a))))
-          ) // redGoal1 F, X=B1 |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-          val t8 = Rewrite(
-            Set(H1, G, F) |- X === B1 ==> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-            7
-          ) // redGoal1 F |- X=B1 ==> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]      -------second half with t6
-          val t9 = RightIff(
-            Set(H1, G, F) |- (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-            6,
-            8,
-            X === B1,
-            forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))
-          ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+            Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))
+        )
+        val p1 = instantiateForall(Proof(steps(p0), imports(i1)), A)
+        val s4 = SCSubproof(p1, Seq(-1)) //
+        val s5 = Rewrite(s3.bot.right.head |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 4)
+        val s6 = Cut((H1) |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 3, 5, s3.bot.right.head) // ⊢ ∃B. ∀x. (x ∈ A) ⇒ ∃y. (y ∈ B) ∧ (y = (x, b))
 
-          Proof(steps(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9), imports(i1, i2, i3))
-        },
-        Vector(13, -3, 14)
-      ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-      val s16 = RightForall(
-        (H1, G, F) |- forall(X, (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
-        15,
-        (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-        X
-      ) // goal  F |- ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-      val s17 = RightExists(
-        (H1, G, F) |- exists(y, forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))))),
-        16,
-        forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
-        y,
-        B1
-      )
-      val s18 = LeftExists((exists(B1, F), G, H1) |- s17.bot.right, 17, F, B1) //  ∃B1. F |- ∃B1. ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-      val s19 = Rewrite(s18.bot.left |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 18) //  ∃B1. F |- ∃!X. [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-      val s20 = Cut((G, H1) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 7, 19, exists(B1, F))
-      val s21 = LeftExists((H1, exists(B, G)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 20, G, B)
-      val s22 = Cut(H1 |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ phi(x, a)))), 6, 21, exists(B, G))
-      val res = steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
-      Proof(res, imports(i1, i2, i3))
+        val i2 = () |- comprehensionSchema // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,z) /\ sPhi(x,z)))))
+        val q0 = InstPredSchema(
+            () |- instantiatePredicateSchemas(comprehensionSchema, Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))),
+            -1,
+            Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))
+        )
+        val q1 = instantiateForall(Proof(steps(q0), imports(i2)), B)
+        val s7 = SCSubproof(q1, Seq(-2)) // ∃y. ∀x. (x ∈ y) ↔ (x ∈ B) ∧ ∃a. a ∈ A /\ x = (a, b)      := exists(y, F(y) )
+        Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7), imports(i1, i2))
+        val s8 = SCSubproof({
+            val y1 = VariableLabel("y1")
+            val s0 = hypothesis(in(y1, B))
+            val s1 = RightSubstEq((in(y1, B), x === y1) |- in(x, B), 0, List((x, y1)), LambdaTermFormula(Seq(f), in(f, B)))
+            val s2 = LeftSubstIff(Set(in(y1, B), (x === y1) <=> phi(x, a), phi(x, a)) |- in(x, B), 1, List(((x === y1), phi(x, a))), LambdaFormulaFormula(Seq(h), h()))
+            val s3 = LeftSubstEq(Set(y === y1, in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 2, List((y, y1)), LambdaTermFormula(Seq(f), (x === f) <=> phi(x, a)))
+            val s4 = LeftSubstIff(Set((y === y1) <=> phi(y1, a), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 3, List((phi(y1, a), y1 === y)), LambdaFormulaFormula(Seq(h), h()))
+            val s5 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 4, (y === x) <=> phi(x, a), x, y1)
+            val s6 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 5, (x === y) <=> phi(x, a), x, x)
+            val s7 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 6, forall(x, (y === x) <=> phi(x, a)), y)
+            val s8 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a) /\ in(y1, B), phi(x, a)) |- in(x, B), 7)
+            val s9 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), exists(y1, phi(y1, a) /\ in(y1, B)), phi(x, a)) |- in(x, B), 8, phi(y1, a) /\ in(y1, B), y1)
+            val s10 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), And() ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a)) |- in(x, B), 9)
+            val s11 = LeftSubstIff(
+                Set(exists(y, forall(x, (y === x) <=> phi(x, a))), in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a), in(a, A)) |- in(x, B),
+                10,
+                List((And(), in(a, A))),
+                LambdaFormulaFormula(Seq(h), h() ==> exists(y, phi(y, a) /\ in(y, B)))
+            )
+            val s12 = LeftForall(
+                Set(exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+                11,
+                in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)),
+                a,
+                a
+            )
+            val s13 = LeftSubstIff(
+                Set(in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+                12,
+                List((And(), in(a, A))),
+                LambdaFormulaFormula(Seq(h), h() ==> exists(y, forall(x, (y === x) <=> phi(x, a))))
+            )
+            val s14 = LeftForall(
+                Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+                13,
+                in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))),
+                a,
+                a
+            )
+            val s15 = Rewrite(Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a) /\ in(a, A)) |- in(x, B), 14)
+            val s16 = LeftExists(
+                Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B),
+                15,
+                phi(x, a) /\ in(a, A),
+                a
+            )
+            val truc = forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)))
+            val s17 = Rewrite(Set(forall(a, in(a, A) ==> existsOne(x, phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B), 16)
+            Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17))
+            // goal H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
+            // redGoal ∀a.(a ∈ A) => ∃!x. phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s17
+            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s16
+            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A ∧ phi(x, a) |- (x ∈ B)    s15
+            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s14
+            // redGoal (a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s13
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s12
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s11
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s11
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), T ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s10
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∃y1. y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s9
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s8
+            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s7
+            // redGoal ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s6
+            // redGoal (x=y) ↔ phi(x, a), ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s5
+            // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s4
+            // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s3
+            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s2
+            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (x ∈ B)     s1
+            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (y1 ∈ B)     s0
+
+        }) // H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
+
+        val G = forall(a, in(a, A) ==> exists(y, in(y, B) /\ (phi(y, a))))
+        val F = forall(x, iff(in(x, B1), in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))))
+        val s9 = SCSubproof({
+            val p0 = instantiateForall(Proof(hypothesis(F)), x)
+            val left = in(x, B1)
+            val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
+            val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
+            val p2 = destructRightAnd(p1, (right ==> left), (left ==> right)) // F |- in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) => in(x, B1)
+            val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B), exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), p2.length - 1)))
+            p3
+        }) // have F, (x ∈ B),  ∃a. a ∈ A ∧ x = (a, b) |- (x ∈ B1)
+        val s10 = Cut(Set(F, G, H1, exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), 8, 9, in(x, B)) // redGoal F, ∃a. a ∈ A ∧ x = (a, b), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ y = (a, b) |- (x ∈ B1)
+        val s11 = Rewrite(Set(H1, G, F) |- exists(a, in(a, A) /\ (phi(x, a))) ==> in(x, B1), 10) // F |- ∃a. a ∈ A ∧ x = (a, b) => (x ∈ B1)   --- half
+        val s12 = SCSubproof({
+            val p0 = instantiateForall(Proof(hypothesis(F)), x)
+            val left = in(x, B1)
+            val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
+            val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
+            val p2 = destructRightAnd(p1, (left ==> right), (right ==> left)) // F |- in(x, B1) => in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) =>
+            val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B1)) |- exists(a, in(a, A) /\ (phi(x, a))) /\ in(x, B), p2.length - 1)))
+            val p4 = destructRightAnd(p3, exists(a, in(a, A) /\ (phi(x, a))), in(x, B))
+            val p5 = p4.withNewSteps(Vector(Rewrite(F |- in(x, B1) ==> exists(a, in(a, A) /\ (phi(x, a))), p4.length - 1)))
+            p5
+        }) // have F |- (x ∈ B1) ⇒ ∃a. a ∈ A ∧ x = (a, b)    --- other half
+        val s13 = RightIff((H1, G, F) |- in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))), 11, 12, in(x, B1), exists(a, in(a, A) /\ (phi(x, a)))) // have F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+        val s14 =
+            RightForall(
+                (H1, G, F) |- forall(x, in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+                13,
+                in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))),
+                x
+            ) // G, F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+
+        val i3 = () |- extensionalityAxiom
+        val s15 = SCSubproof(
+            {
+                val i1 = s13.bot // G, F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+                val i2 = () |- extensionalityAxiom
+                val t0 = RightSubstIff(
+                    Set(H1, G, F, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, X) <=> in(x, B1),
+                    -1,
+                    List((in(x, X), exists(a, in(a, A) /\ (phi(x, a))))),
+                    LambdaFormulaFormula(Seq(h), h() <=> in(x, B1))
+                ) // redGoal2  F, (z ∈ X) <=> ∃a. a ∈ A ∧ z = (a, b) |- (z ∈ X) <=> (z ∈ B1)
+                val t1 = LeftForall(
+                    Set(H1, G, F, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))) |- in(x, X) <=> in(x, B1),
+                    0,
+                    in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))),
+                    x,
+                    x
+                ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- (z ∈ X) <=> (z ∈ B1)
+                val t2 = RightForall(t1.bot.left |- forall(x, in(x, X) <=> in(x, B1)), 1, in(x, X) <=> in(x, B1), x) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- ∀z. (z ∈ X) <=> (z ∈ B1)
+                val t3 =
+                    SCSubproof(instantiateForall(Proof(steps(Rewrite(() |- extensionalityAxiom, -1)), imports(() |- extensionalityAxiom)), X, B1), Vector(-2)) // (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1)))
+                val t4 = RightSubstIff(
+                    t1.bot.left ++ t3.bot.right |- X === B1,
+                    2,
+                    List((X === B1, forall(z, in(z, X) <=> in(z, B1)))),
+                    LambdaFormulaFormula(Seq(h), h())
+                ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)], (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1))) |- X=B1
+                val t5 = Cut(t1.bot.left |- X === B1, 3, 4, t3.bot.right.head) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- X=B1
+                val t6 = Rewrite(Set(H1, G, F) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) ==> (X === B1), 5) //  F |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] ==> X=B1
+                val i3 = s14.bot // F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+                val t7 = RightSubstEq(
+                    Set(H1, G, F, X === B1) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+                    -3,
+                    List((X, B1)),
+                    LambdaTermFormula(Seq(f), forall(x, in(x, f) <=> exists(a, in(a, A) /\ phi(x, a))))
+                ) // redGoal1 F, X=B1 |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+                val t8 = Rewrite(
+                    Set(H1, G, F) |- X === B1 ==> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+                    7
+                ) // redGoal1 F |- X=B1 ==> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]      -------second half with t6
+                val t9 = RightIff(
+                    Set(H1, G, F) |- (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+                    6,
+                    8,
+                    X === B1,
+                    forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))
+                ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+
+                Proof(steps(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9), imports(i1, i2, i3))
+            },
+            Vector(13, -3, 14)
+        ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+        val s16 = RightForall(
+            (H1, G, F) |- forall(X, (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
+            15,
+            (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+            X
+        ) // goal  F |- ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+        val s17 = RightExists(
+            (H1, G, F) |- exists(y, forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))))),
+            16,
+            forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
+            y,
+            B1
+        )
+        val s18 = LeftExists((exists(B1, F), G, H1) |- s17.bot.right, 17, F, B1) //  ∃B1. F |- ∃B1. ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+        val s19 = Rewrite(s18.bot.left |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 18) //  ∃B1. F |- ∃!X. [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+        val s20 = Cut((G, H1) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 7, 19, exists(B1, F))
+        val s21 = LeftExists((H1, exists(B, G)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 20, G, B)
+        val s22 = Cut(H1 |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ phi(x, a)))), 6, 21, exists(B, G))
+        val res = steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
+        Proof(res, imports(i1, i2, i3))
     } using (ax"replacementSchema", ax"comprehensionSchema", ax"extensionalityAxiom")
-  show
+    show
 
-  THEOREM("lemmaLayeredTwoArgumentsMap") of
-    "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
-      val a = VariableLabel("a")
-      val b = VariableLabel("b")
-      val x = VariableLabel("x")
-      val x1 = VariableLabel("x1")
-      val y = VariableLabel("y")
-      val z = VariableLabel("z")
-      val a_ = SchematicFunctionLabel("a", 0)
-      val b_ = SchematicFunctionLabel("b", 0)
-      val x_ = SchematicFunctionLabel("x", 0)
-      val x1_ = SchematicFunctionLabel("x1", 0)
-      val y_ = SchematicFunctionLabel("y", 0)
-      val z_ = SchematicFunctionLabel("z", 0)
-      val f = SchematicFunctionLabel("f", 0)
-      val h = SchematicPredicateLabel("h", 0)
-      val A = SchematicFunctionLabel("A", 0)()
-      val X = VariableLabel("X")
-      val B = SchematicFunctionLabel("B", 0)()
-      val B1 = VariableLabel("B1")
-      val phi = SchematicPredicateLabel("phi", 2)
-      val psi = SchematicPredicateLabel("psi", 3)
-      val H = existsOne(x, phi(x, a))
-      val H1 = forall(a, in(a, A) ==> H)
-      val i1 = thm"functionalMapping"
-      val H2 = instantiatePredicateSchemas(H1, Map(phi -> LambdaTermFormula(Seq(x_, a_), psi(x_, a_, b))))
-      val s0 = InstPredSchema((H2) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), -1, Map(phi -> LambdaTermFormula(Seq(x_, a_), psi(x_, a_, b))))
-      val s1 = Weakening((H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 0)
-      val s2 =
-        LeftSubstIff((in(b, B) ==> H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 1, List((in(b, B), And())), LambdaFormulaFormula(Seq(h), h() ==> H2))
-      val s3 = LeftForall((forall(b, in(b, B) ==> H2), in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 2, in(b, B) ==> H2, b, b)
-      val s4 = Rewrite(forall(b, in(b, B) ==> H2) |- in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 3)
-      val s5 = RightForall(
-        forall(b, in(b, B) ==> H2) |- forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))),
-        4,
-        in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))),
-        b
-      )
-      val s6 = InstFunSchema(
-        forall(b, in(b, B) ==> existsOne(X, phi(X, b))) |- instantiateFunctionSchemas(i1.right.head, Map(SchematicFunctionLabel("A", 0) -> LambdaTermTerm(Nil, B))),
-        -1,
-        Map(SchematicFunctionLabel("A", 0) -> LambdaTermTerm(Nil, B))
-      )
-      val s7 = InstPredSchema(
-        forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))) |- existsOne(
-          X,
-          forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
-        ),
-        6,
-        Map(phi -> LambdaTermFormula(Seq(y_, b_), forall(x, in(x, y_) <=> exists(a, in(a, A) /\ psi(x, a, b_)))))
-      )
-      val s8 = Cut(
-        forall(b, in(b, B) ==> H2) |- existsOne(X, forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))),
-        5,
-        7,
-        forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
-      )
-      Proof(Vector(s0, s1, s2, s3, s4, s5, s6, s7, s8), Vector(i1))
-      // have ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s0
-      // have (b ∈ B), ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s1
-      // have (b ∈ B), (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s2
-      // have (b ∈ B), ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s3
-      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s4
-      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  ∀b. (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s5
-      // by thmMapFunctional have ∀b. (b ∈ B) ⇒ ∃!x. ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)        phi(x, b) = ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)    s6
-      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b)    |-    ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)   s7
+    THEOREM("lemmaLayeredTwoArgumentsMap") of
+        "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
+        val a = VariableLabel("a")
+        val b = VariableLabel("b")
+        val x = VariableLabel("x")
+        val x1 = VariableLabel("x1")
+        val y = VariableLabel("y")
+        val z = VariableLabel("z")
+        val f = VariableLabel("f")
+        val h = SchematicPredicateLabel("h", 0)
+        val A = VariableLabel("A")
+        val X = VariableLabel("X")
+        val B = VariableLabel("B")
+        val B1 = VariableLabel("B1")
+        val phi = SchematicPredicateLabel("phi", 2)
+        val psi = SchematicPredicateLabel("psi", 3)
+        val H = existsOne(x, phi(x, a))
+        val H1 = forall(a, in(a, A) ==> H)
+        val i1 = thm"functionalMapping"
+        val H2 = instantiatePredicateSchemas(H1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
+        val s0 = InstPredSchema((H2) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), -1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
+        val s1 = Weakening((H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 0)
+        val s2 =
+            LeftSubstIff((in(b, B) ==> H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 1, List((in(b, B), And())), LambdaFormulaFormula(Seq(h), h() ==> H2))
+        val s3 = LeftForall((forall(b, in(b, B) ==> H2), in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 2, in(b, B) ==> H2, b, b)
+        val s4 = Rewrite(forall(b, in(b, B) ==> H2) |- in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 3)
+        val s5 = RightForall(
+            forall(b, in(b, B) ==> H2) |- forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))),
+            4,
+            in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))),
+            b
+        )
+        val s6 = InstFunSchema(
+            forall(b, in(b, B) ==> existsOne(X, phi(X, b))) |- instantiateTermSchemas(i1.right.head, Map(A -> LambdaTermTerm(Nil, B))),
+            -1,
+            Map(SchematicFunctionLabel("A", 0) -> LambdaTermTerm(Nil, B))
+        )
+        val s7 = InstPredSchema(
+            forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))) |- existsOne(
+                X,
+                forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
+            ),
+            6,
+            Map(phi -> LambdaTermFormula(Seq(y, b), forall(x, in(x, y) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
+        )
+        val s8 = Cut(
+            forall(b, in(b, B) ==> H2) |- existsOne(X, forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))),
+            5,
+            7,
+            forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
+        )
+        Proof(Vector(s0, s1, s2, s3, s4, s5, s6, s7, s8), Vector(i1))
+        // have ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s0
+        // have (b ∈ B), ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s1
+        // have (b ∈ B), (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s2
+        // have (b ∈ B), ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s3
+        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s4
+        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  ∀b. (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s5
+        // by thmMapFunctional have ∀b. (b ∈ B) ⇒ ∃!x. ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)        phi(x, b) = ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)    s6
+        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b)    |-    ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)   s7
 
     } using (thm"functionalMapping")
-  show
+    show
 
-  THEOREM("applyFunctionToUniqueObject") of
-    "∃!x. ?phi(x) ⊢ ∃!z. ∃x. (z = ?F(x)) ∧ ?phi(x)" PROOF {
-      val x = VariableLabel("x")
-      val x1 = VariableLabel("x1")
-      val z = VariableLabel("z")
-      val z1 = VariableLabel("z1")
-      val F = SchematicFunctionLabel("F", 1)
-      val f = SchematicFunctionLabel("f", 0)
-      val phi = SchematicPredicateLabel("phi", 1)
-      val g = SchematicPredicateLabel("g", 0)
+    THEOREM("applyFunctionToUniqueObject") of
+        "∃!x. ?phi(x) ⊢ ∃!z. ∃x. (z = ?F(x)) ∧ ?phi(x)" PROOF {
+        val x = VariableLabel("x")
+        val x1 = VariableLabel("x1")
+        val z = VariableLabel("z")
+        val z1 = VariableLabel("z1")
+        val F = SchematicFunctionLabel("F", 1)
+        val f = VariableLabel("f")
+        val phi = SchematicPredicateLabel("phi", 1)
+        val g = SchematicPredicateLabel("g", 0)
 
-      val g2 = SCSubproof({
-        val s0 = hypothesis(F(x1) === z)
-        val s1 = LeftSubstEq((x === x1, F(x) === z) |- F(x1) === z, 0, List((x, x1)), LambdaTermFormula(Seq(f), F(f()) === z))
-        val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g()))
-        val s3 = LeftForall(Set(forall(x, phi(x) <=> (x === x1)), phi(x), F(x) === z) |- F(x1) === z, 2, phi(x) <=> (x === x1), x, x)
-        val s4 = Rewrite(Set(forall(x, phi(x) <=> (x === x1)), phi(x) /\ (F(x) === z)) |- F(x1) === z, 3)
-        val s5 = LeftExists(Set(forall(x, phi(x) <=> (x === x1)), exists(x, phi(x) /\ (F(x) === z))) |- F(x1) === z, 4, phi(x) /\ (F(x) === z), x)
-        val s6 = Rewrite(forall(x, phi(x) <=> (x === x1)) |- exists(x, phi(x) /\ (F(x) === z)) ==> (F(x1) === z), 5)
-        Proof(steps(s0, s1, s2, s3, s4, s5, s6))
-      }) // redGoal2 ∀x. x=x1 <=> phi(x)   ⊢   ∃x. z=F(x) /\ phi(x) ==> F(x1)=z  g2.s5
+        val g2 = SCSubproof({
+            val s0 = hypothesis(F(x1) === z)
+            val s1 = LeftSubstEq((x === x1, F(x) === z) |- F(x1) === z, 0, List((x, x1)), LambdaTermFormula(Seq(f), F(f) === z))
+            val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g()))
+            val s3 = LeftForall(Set(forall(x, phi(x) <=> (x === x1)), phi(x), F(x) === z) |- F(x1) === z, 2, phi(x) <=> (x === x1), x, x)
+            val s4 = Rewrite(Set(forall(x, phi(x) <=> (x === x1)), phi(x) /\ (F(x) === z)) |- F(x1) === z, 3)
+            val s5 = LeftExists(Set(forall(x, phi(x) <=> (x === x1)), exists(x, phi(x) /\ (F(x) === z))) |- F(x1) === z, 4, phi(x) /\ (F(x) === z), x)
+            val s6 = Rewrite(forall(x, phi(x) <=> (x === x1)) |- exists(x, phi(x) /\ (F(x) === z)) ==> (F(x1) === z), 5)
+            Proof(steps(s0, s1, s2, s3, s4, s5, s6))
+        }) // redGoal2 ∀x. x=x1 <=> phi(x)   ⊢   ∃x. z=F(x) /\ phi(x) ==> F(x1)=z  g2.s5
 
-      val g1 = SCSubproof({
-        val s0 = hypothesis(phi(x1))
-        val s1 = LeftForall(forall(x, (x === x1) <=> phi(x)) |- phi(x1), 0, (x === x1) <=> phi(x), x, x1)
-        val s2 = hypothesis(z === F(x1))
-        val s3 = RightAnd((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- (z === F(x1)) /\ phi(x1), Seq(2, 1), Seq(z === F(x1), phi(x1)))
-        val s4 = RightExists((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- exists(x, (z === F(x)) /\ phi(x)), 3, (z === F(x)) /\ phi(x), x, x1)
-        val s5 = Rewrite(forall(x, (x === x1) <=> phi(x)) |- z === F(x1) ==> exists(x, (z === F(x)) /\ phi(x)), 4)
-        Proof(steps(s0, s1, s2, s3, s4, s5))
-      })
+        val g1 = SCSubproof({
+            val s0 = hypothesis(phi(x1))
+            val s1 = LeftForall(forall(x, (x === x1) <=> phi(x)) |- phi(x1), 0, (x === x1) <=> phi(x), x, x1)
+            val s2 = hypothesis(z === F(x1))
+            val s3 = RightAnd((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- (z === F(x1)) /\ phi(x1), Seq(2, 1), Seq(z === F(x1), phi(x1)))
+            val s4 = RightExists((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- exists(x, (z === F(x)) /\ phi(x)), 3, (z === F(x)) /\ phi(x), x, x1)
+            val s5 = Rewrite(forall(x, (x === x1) <=> phi(x)) |- z === F(x1) ==> exists(x, (z === F(x)) /\ phi(x)), 4)
+            Proof(steps(s0, s1, s2, s3, s4, s5))
+        })
 
-      val s0 = g1
-      val s1 = g2
-      val s2 = RightIff(forall(x, (x === x1) <=> phi(x)) |- (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), 0, 1, z === F(x1), exists(x, (z === F(x)) /\ phi(x)))
-      val s3 = RightForall(forall(x, (x === x1) <=> phi(x)) |- forall(z, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x))), 2, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), z)
-      val s4 = RightExists(
-        forall(x, (x === x1) <=> phi(x)) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))),
-        3,
-        forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x))),
-        z1,
-        F(x1)
-      )
-      val s5 = LeftExists(exists(x1, forall(x, (x === x1) <=> phi(x))) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))), 4, forall(x, (x === x1) <=> phi(x)), x1)
-      val s6 = Rewrite(existsOne(x, phi(x)) |- existsOne(z, exists(x, (z === F(x)) /\ phi(x))), 5) // goal ∃!x. phi(x)   ⊢   ∃!z. ∃x. z=F(x) /\ phi(x)
-      Proof(Vector(s0, s1, s2, s3, s4, s5, s6))
+        val s0 = g1
+        val s1 = g2
+        val s2 = RightIff(forall(x, (x === x1) <=> phi(x)) |- (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), 0, 1, z === F(x1), exists(x, (z === F(x)) /\ phi(x)))
+        val s3 = RightForall(forall(x, (x === x1) <=> phi(x)) |- forall(z, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x))), 2, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), z)
+        val s4 = RightExists(
+            forall(x, (x === x1) <=> phi(x)) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))),
+            3,
+            forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x))),
+            z1,
+            F(x1)
+        )
+        val s5 = LeftExists(exists(x1, forall(x, (x === x1) <=> phi(x))) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))), 4, forall(x, (x === x1) <=> phi(x)), x1)
+        val s6 = Rewrite(existsOne(x, phi(x)) |- existsOne(z, exists(x, (z === F(x)) /\ phi(x))), 5) // goal ∃!x. phi(x)   ⊢   ∃!z. ∃x. z=F(x) /\ phi(x)
+        Proof(Vector(s0, s1, s2, s3, s4, s5, s6))
     } using ()
-  show
+    show
 
-  THEOREM("mapTwoArguments") of
-    "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
-      val a = VariableLabel("a")
-      val b = VariableLabel("b")
-      val x = VariableLabel("x")
-      val x1 = VariableLabel("x1")
-      val x_ = SchematicFunctionLabel("x", 0)
-      val y_ = SchematicFunctionLabel("y", 0)
-      val F = SchematicFunctionLabel("F", 1)
-      val A = SchematicFunctionLabel("A", 0)()
-      val B = SchematicFunctionLabel("B", 0)()
-      val phi = SchematicPredicateLabel("phi", 1)
-      val psi = SchematicPredicateLabel("psi", 3)
+    THEOREM("mapTwoArguments") of
+        "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
+        val a = VariableLabel("a")
+        val b = VariableLabel("b")
+        val x = VariableLabel("x")
+        val x1 = VariableLabel("x1")
+        val y = VariableLabel("y")
+        val F = SchematicFunctionLabel("F", 1)
+        val A = VariableLabel("A")
+        val B = VariableLabel("B")
+        val phi = SchematicPredicateLabel("phi", 1)
+        val psi = SchematicPredicateLabel("psi", 3)
 
-      val i1 = thm"lemmaLayeredTwoArgumentsMap"
-      val i2 = thm"applyFunctionToUniqueObject"
-      val rPhi = forall(x, in(x, y_) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
-      val seq0 = instantiatePredicateSchemaInSequent(i2, Map(phi -> LambdaTermFormula(Seq(y_), rPhi)))
-      val s0 = InstPredSchema(seq0, -2, Map(phi -> LambdaTermFormula(Seq(y_), rPhi))) // val s0 = InstPredSchema(instantiatePredicateSchemaInSequent(i2, phi, rPhi, Seq(X)), -2, phi, rPhi, Seq(X))
-      val seq1 = instantiateFunctionSchemaInSequent(seq0, Map(F -> LambdaTermTerm(Seq(x_), union(x_))))
-      val s1 = InstFunSchema(seq1, 0, Map(F -> LambdaTermTerm(Seq(x_), union(x_))))
-      val s2 = Cut(i1.left |- seq1.right, -1, 1, seq1.left.head)
-      Proof(steps(s0, s1, s2), imports(i1, i2))
+        val i1 = thm"lemmaLayeredTwoArgumentsMap"
+        val i2 = thm"applyFunctionToUniqueObject"
+        val rPhi = forall(x, in(x, y) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
+        val seq0 = instantiatePredicateSchemaInSequent(i2, Map(phi -> LambdaTermFormula(Seq(y), rPhi)))
+        val s0 = InstPredSchema(seq0, -2, Map(phi -> LambdaTermFormula(Seq(y), rPhi))) // val s0 = InstPredSchema(instantiatePredicateSchemaInSequent(i2, phi, rPhi, Seq(X)), -2, phi, rPhi, Seq(X))
+        val seq1 = instantiateFunctionSchemaInSequent(seq0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
+        val s1 = InstFunSchema(seq1, 0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
+        val s2 = Cut(i1.left |- seq1.right, -1, 1, seq1.left.head)
+        Proof(steps(s0, s1, s2), imports(i1, i2))
     } using (thm"lemmaLayeredTwoArgumentsMap", thm"applyFunctionToUniqueObject")
-  show
+    show
 
-  val A = SchematicFunctionLabel("A", 0)
-  val B = SchematicFunctionLabel("B", 0)
-  private val sz = SchematicFunctionLabel("z", 0)
-  val cartesianProduct: ConstantFunctionLabel =
-    DEFINE("cartProd", A, B) asThe sz suchThat {
-      val a = VariableLabel("a")
-      val b = VariableLabel("b")
-      val x = VariableLabel("x")
-      val x0 = VariableLabel("x0")
-      val x1 = VariableLabel("x1")
-      val A = SchematicFunctionLabel("A", 0)()
-      val B = SchematicFunctionLabel("B", 0)()
-      exists(x, (sz === union(x)) /\ forall(x0, in(x0, x) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x0) <=> exists(a, in(a, A) /\ (x1 === oPair(a, b)))))))
-    } PROOF {
-      def makeFunctional(t: Term): Proof = {
-        val x = VariableLabel(freshId(t.freeVariables.map(_.id), "x"))
-        val y = VariableLabel(freshId(t.freeVariables.map(_.id), "y"))
-        val s0 = RightRefl(() |- t === t, t === t)
-        val s1 = Rewrite(() |- (x === t) <=> (x === t), 0)
-        val s2 = RightForall(() |- forall(x, (x === t) <=> (x === t)), 1, (x === t) <=> (x === t), x)
-        val s3 = RightExists(() |- exists(y, forall(x, (x === y) <=> (x === t))), 2, forall(x, (x === y) <=> (x === t)), y, t)
-        val s4 = Rewrite(() |- existsOne(x, x === t), 3)
-        Proof(s0, s1, s2, s3, s4)
-      }
+    val A = VariableLabel("A")
+    val B = VariableLabel("B")
+    private val z = VariableLabel("z")
+    val cartesianProduct: ConstantFunctionLabel =
+        DEFINE("cartProd", A, B) asThe z suchThat {
+            val a = VariableLabel("a")
+            val b = VariableLabel("b")
+            val x = VariableLabel("x")
+            val x0 = VariableLabel("x0")
+            val x1 = VariableLabel("x1")
+            val A = VariableLabel("A")
+            val B = VariableLabel("B")
+            exists(x, (z === union(x)) /\ forall(x0, in(x0, x) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x0) <=> exists(a, in(a, A) /\ (x1 === oPair(a, b)))))))
+        } PROOF {
+            def makeFunctional(t: Term): Proof = {
+                val x = VariableLabel(freshId(t.freeVariables.map(_.id), "x"))
+                val y = VariableLabel(freshId(t.freeVariables.map(_.id), "y"))
+                val s0 = RightRefl(() |- t === t, t === t)
+                val s1 = Rewrite(() |- (x === t) <=> (x === t), 0)
+                val s2 = RightForall(() |- forall(x, (x === t) <=> (x === t)), 1, (x === t) <=> (x === t), x)
+                val s3 = RightExists(() |- exists(y, forall(x, (x === y) <=> (x === t))), 2, forall(x, (x === y) <=> (x === t)), y, t)
+                val s4 = Rewrite(() |- existsOne(x, x === t), 3)
+                Proof(s0, s1, s2, s3, s4)
+            }
 
-      val a = VariableLabel("a")
-      val b = VariableLabel("b")
-      val x = VariableLabel("x")
-      val a_ = SchematicFunctionLabel("a", 0)
-      val b_ = SchematicFunctionLabel("b", 0)
-      val x_ = SchematicFunctionLabel("x", 0)
-      val x1 = VariableLabel("x1")
-      val F = SchematicFunctionLabel("F", 1)
-      val A = SchematicFunctionLabel("A", 0)()
-      val X = VariableLabel("X")
-      val B = SchematicFunctionLabel("B", 0)()
-      val phi = SchematicPredicateLabel("phi", 1)
-      val psi = SchematicPredicateLabel("psi", 3)
+            val a = VariableLabel("a")
+            val b = VariableLabel("b")
+            val x = VariableLabel("x")
+            val A = VariableLabel("A")
+            val B = VariableLabel("B")
+            val psi = SchematicPredicateLabel("psi", 3)
 
-      val i1 = thm"mapTwoArguments" // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)
+            val i1 = thm"mapTwoArguments" // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)
 
-      val s0 = SCSubproof({
-        val s0 = SCSubproof(makeFunctional(oPair(a, b)))
-        val s1 = Weakening((in(b, B), in(a, A)) |- s0.bot.right, 0)
-        val s2 = Rewrite(in(b, B) |- in(a, A) ==> s0.bot.right.head, 1)
-        val s3 = RightForall(in(b, B) |- forall(a, in(a, A) ==> s0.bot.right.head), 2, in(a, A) ==> s0.bot.right.head, a)
-        val s4 = Rewrite(() |- in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), 3)
-        val s5 = RightForall(() |- forall(b, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head)), 4, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), b)
-        Proof(steps(s0, s1, s2, s3, s4, s5))
-      }) // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. x= (a, b)
+            val s0 = SCSubproof({
+                val s0 = SCSubproof(makeFunctional(oPair(a, b)))
+                val s1 = Weakening((in(b, B), in(a, A)) |- s0.bot.right, 0)
+                val s2 = Rewrite(in(b, B) |- in(a, A) ==> s0.bot.right.head, 1)
+                val s3 = RightForall(in(b, B) |- forall(a, in(a, A) ==> s0.bot.right.head), 2, in(a, A) ==> s0.bot.right.head, a)
+                val s4 = Rewrite(() |- in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), 3)
+                val s5 = RightForall(() |- forall(b, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head)), 4, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), b)
+                Proof(steps(s0, s1, s2, s3, s4, s5))
+            }) // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. x= (a, b)
 
-      val s1 = InstPredSchema(
-        instantiatePredicateSchemaInSequent(i1, Map(psi -> LambdaTermFormula(Seq(x_, a_, b_), x_ === oPair(a_, b_)))),
-        -1,
-        Map(psi -> LambdaTermFormula(Seq(x_, a_, b_), x_ === oPair(a_, b_)))
-      )
-      val s2 = Cut(() |- s1.bot.right, 0, 1, s1.bot.left.head)
-      Proof(steps(s0, s1, s2), imports(i1))
-    } using (thm"mapTwoArguments")
-  show
+            val s1 = InstPredSchema(
+                instantiatePredicateSchemaInSequent(i1, Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))),
+                -1,
+                Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))
+            )
+            val s2 = Cut(() |- s1.bot.right, 0, 1, s1.bot.left.head)
+            Proof(steps(s0, s1, s2), imports(i1))
+        } using (thm"mapTwoArguments")
+    show
 
 }

--- a/src/main/scala/lisa/proven/mathematics/Mapping.scala
+++ b/src/main/scala/lisa/proven/mathematics/Mapping.scala
@@ -14,19 +14,18 @@ object Mapping extends lisa.proven.Main {
     THEOREM("functionalMapping") of
         "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {
         val a = VariableLabel("a")
-        val b = VariableLabel("b")
         val x = VariableLabel("x")
         val y = VariableLabel("y")
         val z = VariableLabel("z")
         val f = VariableLabel("f")
-        val h = SchematicPredicateLabel("h", 0)
+        val h = VariableFormulaLabel("h")
         val A = VariableLabel("A")
         val X = VariableLabel("X")
         val B = VariableLabel("B")
         val B1 = VariableLabel("B1")
-        val phi = SchematicPredicateLabel("phi", 2)
-        val sPhi = SchematicPredicateLabel("P", 2)
-        val sPsi = SchematicPredicateLabel("P", 3)
+        val phi = SchematicNPredicateLabel("phi", 2)
+        val sPhi = SchematicNPredicateLabel("P", 2)
+        val sPsi = SchematicNPredicateLabel("P", 3)
 
         val H = existsOne(x, phi(x, a))
         val H1 = forall(a, in(a, A) ==> H)
@@ -244,13 +243,13 @@ object Mapping extends lisa.proven.Main {
         val y = VariableLabel("y")
         val z = VariableLabel("z")
         val f = VariableLabel("f")
-        val h = SchematicPredicateLabel("h", 0)
+        val h = VariableFormulaLabel("h")
         val A = VariableLabel("A")
         val X = VariableLabel("X")
         val B = VariableLabel("B")
         val B1 = VariableLabel("B1")
-        val phi = SchematicPredicateLabel("phi", 2)
-        val psi = SchematicPredicateLabel("psi", 3)
+        val phi = SchematicNPredicateLabel("phi", 2)
+        val psi = SchematicNPredicateLabel("psi", 3)
         val H = existsOne(x, phi(x, a))
         val H1 = forall(a, in(a, A) ==> H)
         val i1 = thm"functionalMapping"
@@ -270,7 +269,7 @@ object Mapping extends lisa.proven.Main {
         val s6 = InstFunSchema(
             forall(b, in(b, B) ==> existsOne(X, phi(X, b))) |- instantiateTermSchemas(i1.right.head, Map(A -> LambdaTermTerm(Nil, B))),
             -1,
-            Map(SchematicFunctionLabel("A", 0) -> LambdaTermTerm(Nil, B))
+            Map(A -> LambdaTermTerm(Nil, B))
         )
         val s7 = InstPredSchema(
             forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))) |- existsOne(
@@ -307,13 +306,13 @@ object Mapping extends lisa.proven.Main {
         val z1 = VariableLabel("z1")
         val F = SchematicFunctionLabel("F", 1)
         val f = VariableLabel("f")
-        val phi = SchematicPredicateLabel("phi", 1)
-        val g = SchematicPredicateLabel("g", 0)
+        val phi = SchematicNPredicateLabel("phi", 1)
+        val g = VariableFormulaLabel("g")
 
         val g2 = SCSubproof({
             val s0 = hypothesis(F(x1) === z)
             val s1 = LeftSubstEq((x === x1, F(x) === z) |- F(x1) === z, 0, List((x, x1)), LambdaTermFormula(Seq(f), F(f) === z))
-            val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g()))
+            val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g))
             val s3 = LeftForall(Set(forall(x, phi(x) <=> (x === x1)), phi(x), F(x) === z) |- F(x1) === z, 2, phi(x) <=> (x === x1), x, x)
             val s4 = Rewrite(Set(forall(x, phi(x) <=> (x === x1)), phi(x) /\ (F(x) === z)) |- F(x1) === z, 3)
             val s5 = LeftExists(Set(forall(x, phi(x) <=> (x === x1)), exists(x, phi(x) /\ (F(x) === z))) |- F(x1) === z, 4, phi(x) /\ (F(x) === z), x)
@@ -358,8 +357,8 @@ object Mapping extends lisa.proven.Main {
         val F = SchematicFunctionLabel("F", 1)
         val A = VariableLabel("A")
         val B = VariableLabel("B")
-        val phi = SchematicPredicateLabel("phi", 1)
-        val psi = SchematicPredicateLabel("psi", 3)
+        val phi = SchematicNPredicateLabel("phi", 1)
+        val psi = SchematicNPredicateLabel("psi", 3)
 
         val i1 = thm"lemmaLayeredTwoArgumentsMap"
         val i2 = thm"applyFunctionToUniqueObject"
@@ -403,7 +402,7 @@ object Mapping extends lisa.proven.Main {
             val x = VariableLabel("x")
             val A = VariableLabel("A")
             val B = VariableLabel("B")
-            val psi = SchematicPredicateLabel("psi", 3)
+            val psi = SchematicNPredicateLabel("psi", 3)
 
             val i1 = thm"mapTwoArguments" // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)
 

--- a/src/main/scala/lisa/proven/mathematics/Mapping.scala
+++ b/src/main/scala/lisa/proven/mathematics/Mapping.scala
@@ -11,419 +11,419 @@ import SetTheory.*
  */
 object Mapping extends lisa.proven.Main {
 
-    THEOREM("functionalMapping") of
-        "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {
-        val a = VariableLabel("a")
-        val x = VariableLabel("x")
-        val y = VariableLabel("y")
-        val z = VariableLabel("z")
-        val f = VariableLabel("f")
-        val h = VariableFormulaLabel("h")
-        val A = VariableLabel("A")
-        val X = VariableLabel("X")
-        val B = VariableLabel("B")
-        val B1 = VariableLabel("B1")
-        val phi = SchematicNPredicateLabel("phi", 2)
-        val sPhi = SchematicNPredicateLabel("P", 2)
-        val sPsi = SchematicNPredicateLabel("P", 3)
+  THEOREM("functionalMapping") of
+    "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {
+      val a = VariableLabel("a")
+      val x = VariableLabel("x")
+      val y = VariableLabel("y")
+      val z = VariableLabel("z")
+      val f = VariableLabel("f")
+      val h = VariableFormulaLabel("h")
+      val A = VariableLabel("A")
+      val X = VariableLabel("X")
+      val B = VariableLabel("B")
+      val B1 = VariableLabel("B1")
+      val phi = SchematicNPredicateLabel("phi", 2)
+      val sPhi = SchematicNPredicateLabel("P", 2)
+      val sPsi = SchematicNPredicateLabel("P", 3)
 
-        val H = existsOne(x, phi(x, a))
-        val H1 = forall(a, in(a, A) ==> H)
-        val s0 = hypothesis(H) // () |- existsOne(x, phi(x, a)))
-        val s1 = Weakening((H, in(a, A)) |- existsOne(x, phi(x, a)), 0)
-        val s2 = Rewrite((H) |- in(a, A) ==> existsOne(x, phi(x, a)), 1)
-        // val s3 = RightForall((H) |- forall(a, in(a, A) ==> existsOne(x, phi(x, a))), 2, in(a, A) ==> existsOne(x, phi(x, a)), a) // () |- ∀a∈A. ∃!x. phi(x, a)
-        val s3 = hypothesis(H1)
-        val i1 = () |- replacementSchema
-        val p0 = InstPredSchema(
-            () |- instantiatePredicateSchemas(replacementSchema, Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))),
+      val H = existsOne(x, phi(x, a))
+      val H1 = forall(a, in(a, A) ==> H)
+      val s0 = hypothesis(H) // () |- existsOne(x, phi(x, a)))
+      val s1 = Weakening((H, in(a, A)) |- existsOne(x, phi(x, a)), 0)
+      val s2 = Rewrite((H) |- in(a, A) ==> existsOne(x, phi(x, a)), 1)
+      // val s3 = RightForall((H) |- forall(a, in(a, A) ==> existsOne(x, phi(x, a))), 2, in(a, A) ==> existsOne(x, phi(x, a)), a) // () |- ∀a∈A. ∃!x. phi(x, a)
+      val s3 = hypothesis(H1)
+      val i1 = () |- replacementSchema
+      val p0 = InstPredSchema(
+        () |- instantiatePredicateSchemas(replacementSchema, Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))),
+        -1,
+        Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))
+      )
+      val p1 = instantiateForall(Proof(steps(p0), imports(i1)), A)
+      val s4 = SCSubproof(p1, Seq(-1)) //
+      val s5 = Rewrite(s3.bot.right.head |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 4)
+      val s6 = Cut((H1) |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 3, 5, s3.bot.right.head) // ⊢ ∃B. ∀x. (x ∈ A) ⇒ ∃y. (y ∈ B) ∧ (y = (x, b))
+
+      val i2 = () |- comprehensionSchema // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,z) /\ sPhi(x,z)))))
+      val q0 = InstPredSchema(
+        () |- instantiatePredicateSchemas(comprehensionSchema, Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))),
+        -1,
+        Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))
+      )
+      val q1 = instantiateForall(Proof(steps(q0), imports(i2)), B)
+      val s7 = SCSubproof(q1, Seq(-2)) // ∃y. ∀x. (x ∈ y) ↔ (x ∈ B) ∧ ∃a. a ∈ A /\ x = (a, b)      := exists(y, F(y) )
+      Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7), imports(i1, i2))
+      val s8 = SCSubproof({
+        val y1 = VariableLabel("y1")
+        val s0 = hypothesis(in(y1, B))
+        val s1 = RightSubstEq((in(y1, B), x === y1) |- in(x, B), 0, List((x, y1)), LambdaTermFormula(Seq(f), in(f, B)))
+        val s2 = LeftSubstIff(Set(in(y1, B), (x === y1) <=> phi(x, a), phi(x, a)) |- in(x, B), 1, List(((x === y1), phi(x, a))), LambdaFormulaFormula(Seq(h), h()))
+        val s3 = LeftSubstEq(Set(y === y1, in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 2, List((y, y1)), LambdaTermFormula(Seq(f), (x === f) <=> phi(x, a)))
+        val s4 = LeftSubstIff(Set((y === y1) <=> phi(y1, a), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 3, List((phi(y1, a), y1 === y)), LambdaFormulaFormula(Seq(h), h()))
+        val s5 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 4, (y === x) <=> phi(x, a), x, y1)
+        val s6 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 5, (x === y) <=> phi(x, a), x, x)
+        val s7 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 6, forall(x, (y === x) <=> phi(x, a)), y)
+        val s8 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a) /\ in(y1, B), phi(x, a)) |- in(x, B), 7)
+        val s9 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), exists(y1, phi(y1, a) /\ in(y1, B)), phi(x, a)) |- in(x, B), 8, phi(y1, a) /\ in(y1, B), y1)
+        val s10 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), And() ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a)) |- in(x, B), 9)
+        val s11 = LeftSubstIff(
+          Set(exists(y, forall(x, (y === x) <=> phi(x, a))), in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a), in(a, A)) |- in(x, B),
+          10,
+          List((And(), in(a, A))),
+          LambdaFormulaFormula(Seq(h), h() ==> exists(y, phi(y, a) /\ in(y, B)))
+        )
+        val s12 = LeftForall(
+          Set(exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+          11,
+          in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)),
+          a,
+          a
+        )
+        val s13 = LeftSubstIff(
+          Set(in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+          12,
+          List((And(), in(a, A))),
+          LambdaFormulaFormula(Seq(h), h() ==> exists(y, forall(x, (y === x) <=> phi(x, a))))
+        )
+        val s14 = LeftForall(
+          Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
+          13,
+          in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))),
+          a,
+          a
+        )
+        val s15 = Rewrite(Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a) /\ in(a, A)) |- in(x, B), 14)
+        val s16 = LeftExists(
+          Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B),
+          15,
+          phi(x, a) /\ in(a, A),
+          a
+        )
+        val truc = forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)))
+        val s17 = Rewrite(Set(forall(a, in(a, A) ==> existsOne(x, phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B), 16)
+        Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17))
+        // goal H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
+        // redGoal ∀a.(a ∈ A) => ∃!x. phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s17
+        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s16
+        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A ∧ phi(x, a) |- (x ∈ B)    s15
+        // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s14
+        // redGoal (a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s13
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s12
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s11
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s11
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), T ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s10
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∃y1. y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s9
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s8
+        // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s7
+        // redGoal ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s6
+        // redGoal (x=y) ↔ phi(x, a), ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s5
+        // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s4
+        // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s3
+        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s2
+        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (x ∈ B)     s1
+        // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (y1 ∈ B)     s0
+
+      }) // H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
+
+      val G = forall(a, in(a, A) ==> exists(y, in(y, B) /\ (phi(y, a))))
+      val F = forall(x, iff(in(x, B1), in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))))
+      val s9 = SCSubproof({
+        val p0 = instantiateForall(Proof(hypothesis(F)), x)
+        val left = in(x, B1)
+        val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
+        val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
+        val p2 = destructRightAnd(p1, (right ==> left), (left ==> right)) // F |- in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) => in(x, B1)
+        val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B), exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), p2.length - 1)))
+        p3
+      }) // have F, (x ∈ B),  ∃a. a ∈ A ∧ x = (a, b) |- (x ∈ B1)
+      val s10 = Cut(Set(F, G, H1, exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), 8, 9, in(x, B)) // redGoal F, ∃a. a ∈ A ∧ x = (a, b), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ y = (a, b) |- (x ∈ B1)
+      val s11 = Rewrite(Set(H1, G, F) |- exists(a, in(a, A) /\ (phi(x, a))) ==> in(x, B1), 10) // F |- ∃a. a ∈ A ∧ x = (a, b) => (x ∈ B1)   --- half
+      val s12 = SCSubproof({
+        val p0 = instantiateForall(Proof(hypothesis(F)), x)
+        val left = in(x, B1)
+        val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
+        val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
+        val p2 = destructRightAnd(p1, (left ==> right), (right ==> left)) // F |- in(x, B1) => in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) =>
+        val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B1)) |- exists(a, in(a, A) /\ (phi(x, a))) /\ in(x, B), p2.length - 1)))
+        val p4 = destructRightAnd(p3, exists(a, in(a, A) /\ (phi(x, a))), in(x, B))
+        val p5 = p4.withNewSteps(Vector(Rewrite(F |- in(x, B1) ==> exists(a, in(a, A) /\ (phi(x, a))), p4.length - 1)))
+        p5
+      }) // have F |- (x ∈ B1) ⇒ ∃a. a ∈ A ∧ x = (a, b)    --- other half
+      val s13 = RightIff((H1, G, F) |- in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))), 11, 12, in(x, B1), exists(a, in(a, A) /\ (phi(x, a)))) // have F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+      val s14 =
+        RightForall(
+          (H1, G, F) |- forall(x, in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+          13,
+          in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))),
+          x
+        ) // G, F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+
+      val i3 = () |- extensionalityAxiom
+      val s15 = SCSubproof(
+        {
+          val i1 = s13.bot // G, F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+          val i2 = () |- extensionalityAxiom
+          val t0 = RightSubstIff(
+            Set(H1, G, F, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, X) <=> in(x, B1),
             -1,
-            Map(sPsi -> LambdaTermFormula(Seq(y, a, x), phi(x, a)))
-        )
-        val p1 = instantiateForall(Proof(steps(p0), imports(i1)), A)
-        val s4 = SCSubproof(p1, Seq(-1)) //
-        val s5 = Rewrite(s3.bot.right.head |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 4)
-        val s6 = Cut((H1) |- exists(B, forall(x, in(x, A) ==> exists(y, in(y, B) /\ (phi(y, x))))), 3, 5, s3.bot.right.head) // ⊢ ∃B. ∀x. (x ∈ A) ⇒ ∃y. (y ∈ B) ∧ (y = (x, b))
-
-        val i2 = () |- comprehensionSchema // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,z) /\ sPhi(x,z)))))
-        val q0 = InstPredSchema(
-            () |- instantiatePredicateSchemas(comprehensionSchema, Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))),
-            -1,
-            Map(sPhi -> LambdaTermFormula(Seq(x, z), exists(a, in(a, A) /\ phi(x, a))))
-        )
-        val q1 = instantiateForall(Proof(steps(q0), imports(i2)), B)
-        val s7 = SCSubproof(q1, Seq(-2)) // ∃y. ∀x. (x ∈ y) ↔ (x ∈ B) ∧ ∃a. a ∈ A /\ x = (a, b)      := exists(y, F(y) )
-        Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7), imports(i1, i2))
-        val s8 = SCSubproof({
-            val y1 = VariableLabel("y1")
-            val s0 = hypothesis(in(y1, B))
-            val s1 = RightSubstEq((in(y1, B), x === y1) |- in(x, B), 0, List((x, y1)), LambdaTermFormula(Seq(f), in(f, B)))
-            val s2 = LeftSubstIff(Set(in(y1, B), (x === y1) <=> phi(x, a), phi(x, a)) |- in(x, B), 1, List(((x === y1), phi(x, a))), LambdaFormulaFormula(Seq(h), h()))
-            val s3 = LeftSubstEq(Set(y === y1, in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 2, List((y, y1)), LambdaTermFormula(Seq(f), (x === f) <=> phi(x, a)))
-            val s4 = LeftSubstIff(Set((y === y1) <=> phi(y1, a), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 3, List((phi(y1, a), y1 === y)), LambdaFormulaFormula(Seq(h), h()))
-            val s5 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), (x === y) <=> phi(x, a), phi(x, a)) |- in(x, B), 4, (y === x) <=> phi(x, a), x, y1)
-            val s6 = LeftForall(Set(forall(x, (y === x) <=> phi(x, a)), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 5, (x === y) <=> phi(x, a), x, x)
-            val s7 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a), in(y1, B), phi(x, a)) |- in(x, B), 6, forall(x, (y === x) <=> phi(x, a)), y)
-            val s8 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), phi(y1, a) /\ in(y1, B), phi(x, a)) |- in(x, B), 7)
-            val s9 = LeftExists(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), exists(y1, phi(y1, a) /\ in(y1, B)), phi(x, a)) |- in(x, B), 8, phi(y1, a) /\ in(y1, B), y1)
-            val s10 = Rewrite(Set(exists(y, forall(x, (y === x) <=> phi(x, a))), And() ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a)) |- in(x, B), 9)
-            val s11 = LeftSubstIff(
-                Set(exists(y, forall(x, (y === x) <=> phi(x, a))), in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)), phi(x, a), in(a, A)) |- in(x, B),
-                10,
-                List((And(), in(a, A))),
-                LambdaFormulaFormula(Seq(h), h() ==> exists(y, phi(y, a) /\ in(y, B)))
-            )
-            val s12 = LeftForall(
-                Set(exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-                11,
-                in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)),
-                a,
-                a
-            )
-            val s13 = LeftSubstIff(
-                Set(in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-                12,
-                List((And(), in(a, A))),
-                LambdaFormulaFormula(Seq(h), h() ==> exists(y, forall(x, (y === x) <=> phi(x, a))))
-            )
-            val s14 = LeftForall(
-                Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a), in(a, A)) |- in(x, B),
-                13,
-                in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a))),
-                a,
-                a
-            )
-            val s15 = Rewrite(Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), phi(x, a) /\ in(a, A)) |- in(x, B), 14)
-            val s16 = LeftExists(
-                Set(forall(a, in(a, A) ==> exists(y, forall(x, (y === x) <=> phi(x, a)))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B),
-                15,
-                phi(x, a) /\ in(a, A),
-                a
-            )
-            val truc = forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B)))
-            val s17 = Rewrite(Set(forall(a, in(a, A) ==> existsOne(x, phi(x, a))), forall(a, in(a, A) ==> exists(y, phi(y, a) /\ in(y, B))), exists(a, phi(x, a) /\ in(a, A))) |- in(x, B), 16)
-            Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17))
-            // goal H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
-            // redGoal ∀a.(a ∈ A) => ∃!x. phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s17
-            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)    s16
-            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A ∧ phi(x, a) |- (x ∈ B)    s15
-            // redGoal ∀a.(a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s14
-            // redGoal (a ∈ A) => ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s13
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s12
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s11
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s11
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), T ⇒ ∃y. y ∈ B ∧ phi(y, a), a ∈ A <=> T,  phi(x, a) |- (x ∈ B)    s10
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), ∃y1. y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s9
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B ∧ phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s8
-            // redGoal ∃y. ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s7
-            // redGoal ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s6
-            // redGoal (x=y) ↔ phi(x, a), ∀x. (x=y) ↔ phi(x, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s5
-            // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, phi(y1, a), a ∈ A,  phi(x, a) |- (x ∈ B)    s4
-            // redGoal (x=y) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s3
-            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  phi(x, a) |- (x ∈ B)     s2
-            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (x ∈ B)     s1
-            // redGoal (x=y1) ↔ phi(x, a), (y1=y) ↔ phi(y1, a), y1 ∈ B, (y1=y), a ∈ A,  x=y1 |- (y1 ∈ B)     s0
-
-        }) // H, ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ phi(y, a), ∃a. a ∈ A ∧ phi(x, a) |- (x ∈ B)
-
-        val G = forall(a, in(a, A) ==> exists(y, in(y, B) /\ (phi(y, a))))
-        val F = forall(x, iff(in(x, B1), in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))))
-        val s9 = SCSubproof({
-            val p0 = instantiateForall(Proof(hypothesis(F)), x)
-            val left = in(x, B1)
-            val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
-            val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
-            val p2 = destructRightAnd(p1, (right ==> left), (left ==> right)) // F |- in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) => in(x, B1)
-            val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B), exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), p2.length - 1)))
-            p3
-        }) // have F, (x ∈ B),  ∃a. a ∈ A ∧ x = (a, b) |- (x ∈ B1)
-        val s10 = Cut(Set(F, G, H1, exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, B1), 8, 9, in(x, B)) // redGoal F, ∃a. a ∈ A ∧ x = (a, b), ∀a. (a ∈ A) ⇒ ∃y. y ∈ B ∧ y = (a, b) |- (x ∈ B1)
-        val s11 = Rewrite(Set(H1, G, F) |- exists(a, in(a, A) /\ (phi(x, a))) ==> in(x, B1), 10) // F |- ∃a. a ∈ A ∧ x = (a, b) => (x ∈ B1)   --- half
-        val s12 = SCSubproof({
-            val p0 = instantiateForall(Proof(hypothesis(F)), x)
-            val left = in(x, B1)
-            val right = in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a)))
-            val p1 = p0.withNewSteps(Vector(Rewrite(F |- (left ==> right) /\ (right ==> left), p0.length - 1)))
-            val p2 = destructRightAnd(p1, (left ==> right), (right ==> left)) // F |- in(x, B1) => in(x, B) /\ exists(a, in(a, A) /\ (phi(x, a))) =>
-            val p3 = p2.withNewSteps(Vector(Rewrite(Set(F, in(x, B1)) |- exists(a, in(a, A) /\ (phi(x, a))) /\ in(x, B), p2.length - 1)))
-            val p4 = destructRightAnd(p3, exists(a, in(a, A) /\ (phi(x, a))), in(x, B))
-            val p5 = p4.withNewSteps(Vector(Rewrite(F |- in(x, B1) ==> exists(a, in(a, A) /\ (phi(x, a))), p4.length - 1)))
-            p5
-        }) // have F |- (x ∈ B1) ⇒ ∃a. a ∈ A ∧ x = (a, b)    --- other half
-        val s13 = RightIff((H1, G, F) |- in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))), 11, 12, in(x, B1), exists(a, in(a, A) /\ (phi(x, a)))) // have F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-        val s14 =
-            RightForall(
-                (H1, G, F) |- forall(x, in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-                13,
-                in(x, B1) <=> exists(a, in(a, A) /\ (phi(x, a))),
-                x
-            ) // G, F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-
-        val i3 = () |- extensionalityAxiom
-        val s15 = SCSubproof(
-            {
-                val i1 = s13.bot // G, F |- (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-                val i2 = () |- extensionalityAxiom
-                val t0 = RightSubstIff(
-                    Set(H1, G, F, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) |- in(x, X) <=> in(x, B1),
-                    -1,
-                    List((in(x, X), exists(a, in(a, A) /\ (phi(x, a))))),
-                    LambdaFormulaFormula(Seq(h), h() <=> in(x, B1))
-                ) // redGoal2  F, (z ∈ X) <=> ∃a. a ∈ A ∧ z = (a, b) |- (z ∈ X) <=> (z ∈ B1)
-                val t1 = LeftForall(
-                    Set(H1, G, F, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))) |- in(x, X) <=> in(x, B1),
-                    0,
-                    in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))),
-                    x,
-                    x
-                ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- (z ∈ X) <=> (z ∈ B1)
-                val t2 = RightForall(t1.bot.left |- forall(x, in(x, X) <=> in(x, B1)), 1, in(x, X) <=> in(x, B1), x) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- ∀z. (z ∈ X) <=> (z ∈ B1)
-                val t3 =
-                    SCSubproof(instantiateForall(Proof(steps(Rewrite(() |- extensionalityAxiom, -1)), imports(() |- extensionalityAxiom)), X, B1), Vector(-2)) // (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1)))
-                val t4 = RightSubstIff(
-                    t1.bot.left ++ t3.bot.right |- X === B1,
-                    2,
-                    List((X === B1, forall(z, in(z, X) <=> in(z, B1)))),
-                    LambdaFormulaFormula(Seq(h), h())
-                ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)], (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1))) |- X=B1
-                val t5 = Cut(t1.bot.left |- X === B1, 3, 4, t3.bot.right.head) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- X=B1
-                val t6 = Rewrite(Set(H1, G, F) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) ==> (X === B1), 5) //  F |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] ==> X=B1
-                val i3 = s14.bot // F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
-                val t7 = RightSubstEq(
-                    Set(H1, G, F, X === B1) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-                    -3,
-                    List((X, B1)),
-                    LambdaTermFormula(Seq(f), forall(x, in(x, f) <=> exists(a, in(a, A) /\ phi(x, a))))
-                ) // redGoal1 F, X=B1 |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-                val t8 = Rewrite(
-                    Set(H1, G, F) |- X === B1 ==> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-                    7
-                ) // redGoal1 F |- X=B1 ==> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]      -------second half with t6
-                val t9 = RightIff(
-                    Set(H1, G, F) |- (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-                    6,
-                    8,
-                    X === B1,
-                    forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))
-                ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-
-                Proof(steps(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9), imports(i1, i2, i3))
-            },
-            Vector(13, -3, 14)
-        ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-        val s16 = RightForall(
-            (H1, G, F) |- forall(X, (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
-            15,
-            (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
-            X
-        ) // goal  F |- ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-        val s17 = RightExists(
-            (H1, G, F) |- exists(y, forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))))),
-            16,
-            forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
-            y,
-            B1
-        )
-        val s18 = LeftExists((exists(B1, F), G, H1) |- s17.bot.right, 17, F, B1) //  ∃B1. F |- ∃B1. ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-        val s19 = Rewrite(s18.bot.left |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 18) //  ∃B1. F |- ∃!X. [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
-        val s20 = Cut((G, H1) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 7, 19, exists(B1, F))
-        val s21 = LeftExists((H1, exists(B, G)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 20, G, B)
-        val s22 = Cut(H1 |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ phi(x, a)))), 6, 21, exists(B, G))
-        val res = steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
-        Proof(res, imports(i1, i2, i3))
-    } using (ax"replacementSchema", ax"comprehensionSchema", ax"extensionalityAxiom")
-    show
-
-    THEOREM("lemmaLayeredTwoArgumentsMap") of
-        "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
-        val a = VariableLabel("a")
-        val b = VariableLabel("b")
-        val x = VariableLabel("x")
-        val x1 = VariableLabel("x1")
-        val y = VariableLabel("y")
-        val z = VariableLabel("z")
-        val f = VariableLabel("f")
-        val h = VariableFormulaLabel("h")
-        val A = VariableLabel("A")
-        val X = VariableLabel("X")
-        val B = VariableLabel("B")
-        val B1 = VariableLabel("B1")
-        val phi = SchematicNPredicateLabel("phi", 2)
-        val psi = SchematicNPredicateLabel("psi", 3)
-        val H = existsOne(x, phi(x, a))
-        val H1 = forall(a, in(a, A) ==> H)
-        val i1 = thm"functionalMapping"
-        val H2 = instantiatePredicateSchemas(H1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
-        val s0 = InstPredSchema((H2) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), -1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
-        val s1 = Weakening((H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 0)
-        val s2 =
-            LeftSubstIff((in(b, B) ==> H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 1, List((in(b, B), And())), LambdaFormulaFormula(Seq(h), h() ==> H2))
-        val s3 = LeftForall((forall(b, in(b, B) ==> H2), in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 2, in(b, B) ==> H2, b, b)
-        val s4 = Rewrite(forall(b, in(b, B) ==> H2) |- in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 3)
-        val s5 = RightForall(
-            forall(b, in(b, B) ==> H2) |- forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))),
-            4,
-            in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))),
-            b
-        )
-        val s6 = InstFunSchema(
-            forall(b, in(b, B) ==> existsOne(X, phi(X, b))) |- instantiateTermSchemas(i1.right.head, Map(A -> LambdaTermTerm(Nil, B))),
-            -1,
-            Map(A -> LambdaTermTerm(Nil, B))
-        )
-        val s7 = InstPredSchema(
-            forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))) |- existsOne(
-                X,
-                forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
-            ),
+            List((in(x, X), exists(a, in(a, A) /\ (phi(x, a))))),
+            LambdaFormulaFormula(Seq(h), h() <=> in(x, B1))
+          ) // redGoal2  F, (z ∈ X) <=> ∃a. a ∈ A ∧ z = (a, b) |- (z ∈ X) <=> (z ∈ B1)
+          val t1 = LeftForall(
+            Set(H1, G, F, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))) |- in(x, X) <=> in(x, B1),
+            0,
+            in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))),
+            x,
+            x
+          ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- (z ∈ X) <=> (z ∈ B1)
+          val t2 = RightForall(t1.bot.left |- forall(x, in(x, X) <=> in(x, B1)), 1, in(x, X) <=> in(x, B1), x) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- ∀z. (z ∈ X) <=> (z ∈ B1)
+          val t3 =
+            SCSubproof(instantiateForall(Proof(steps(Rewrite(() |- extensionalityAxiom, -1)), imports(() |- extensionalityAxiom)), X, B1), Vector(-2)) // (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1)))
+          val t4 = RightSubstIff(
+            t1.bot.left ++ t3.bot.right |- X === B1,
+            2,
+            List((X === B1, forall(z, in(z, X) <=> in(z, B1)))),
+            LambdaFormulaFormula(Seq(h), h())
+          ) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)], (∀z. (z ∈ X) <=> (z ∈ B1)) <=> (X === B1))) |- X=B1
+          val t5 = Cut(t1.bot.left |- X === B1, 3, 4, t3.bot.right.head) // redGoal2  F, [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] |- X=B1
+          val t6 = Rewrite(Set(H1, G, F) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))) ==> (X === B1), 5) //  F |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)] ==> X=B1
+          val i3 = s14.bot // F |- ∀x. (x ∈ B1) <=> ∃a. a ∈ A ∧ x = (a, b)
+          val t7 = RightSubstEq(
+            Set(H1, G, F, X === B1) |- forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+            -3,
+            List((X, B1)),
+            LambdaTermFormula(Seq(f), forall(x, in(x, f) <=> exists(a, in(a, A) /\ phi(x, a))))
+          ) // redGoal1 F, X=B1 |- [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+          val t8 = Rewrite(
+            Set(H1, G, F) |- X === B1 ==> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+            7
+          ) // redGoal1 F |- X=B1 ==> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]      -------second half with t6
+          val t9 = RightIff(
+            Set(H1, G, F) |- (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
             6,
-            Map(phi -> LambdaTermFormula(Seq(y, b), forall(x, in(x, y) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
-        )
-        val s8 = Cut(
-            forall(b, in(b, B) ==> H2) |- existsOne(X, forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))),
-            5,
-            7,
-            forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
-        )
-        Proof(Vector(s0, s1, s2, s3, s4, s5, s6, s7, s8), Vector(i1))
-        // have ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s0
-        // have (b ∈ B), ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s1
-        // have (b ∈ B), (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s2
-        // have (b ∈ B), ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s3
-        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s4
-        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  ∀b. (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s5
-        // by thmMapFunctional have ∀b. (b ∈ B) ⇒ ∃!x. ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)        phi(x, b) = ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)    s6
-        // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b)    |-    ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)   s7
+            8,
+            X === B1,
+            forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))
+          ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+
+          Proof(steps(t0, t1, t2, t3, t4, t5, t6, t7, t8, t9), imports(i1, i2, i3))
+        },
+        Vector(13, -3, 14)
+      ) // goal  F |- X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+      val s16 = RightForall(
+        (H1, G, F) |- forall(X, (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
+        15,
+        (X === B1) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))),
+        X
+      ) // goal  F |- ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+      val s17 = RightExists(
+        (H1, G, F) |- exists(y, forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a)))))),
+        16,
+        forall(X, (X === y) <=> forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))),
+        y,
+        B1
+      )
+      val s18 = LeftExists((exists(B1, F), G, H1) |- s17.bot.right, 17, F, B1) //  ∃B1. F |- ∃B1. ∀X. X=B1 <=> [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+      val s19 = Rewrite(s18.bot.left |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 18) //  ∃B1. F |- ∃!X. [∀x. (x ∈ X) <=> ∃a. a ∈ A ∧ x = (a, b)]
+      val s20 = Cut((G, H1) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 7, 19, exists(B1, F))
+      val s21 = LeftExists((H1, exists(B, G)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ (phi(x, a))))), 20, G, B)
+      val s22 = Cut(H1 |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ phi(x, a)))), 6, 21, exists(B, G))
+      val res = steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10, s11, s12, s13, s14, s15, s16, s17, s18, s19, s20, s21, s22)
+      Proof(res, imports(i1, i2, i3))
+    } using (ax"replacementSchema", ax"comprehensionSchema", ax"extensionalityAxiom")
+  show
+
+  THEOREM("lemmaLayeredTwoArgumentsMap") of
+    "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
+      val a = VariableLabel("a")
+      val b = VariableLabel("b")
+      val x = VariableLabel("x")
+      val x1 = VariableLabel("x1")
+      val y = VariableLabel("y")
+      val z = VariableLabel("z")
+      val f = VariableLabel("f")
+      val h = VariableFormulaLabel("h")
+      val A = VariableLabel("A")
+      val X = VariableLabel("X")
+      val B = VariableLabel("B")
+      val B1 = VariableLabel("B1")
+      val phi = SchematicNPredicateLabel("phi", 2)
+      val psi = SchematicNPredicateLabel("psi", 3)
+      val H = existsOne(x, phi(x, a))
+      val H1 = forall(a, in(a, A) ==> H)
+      val i1 = thm"functionalMapping"
+      val H2 = instantiatePredicateSchemas(H1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
+      val s0 = InstPredSchema((H2) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), -1, Map(phi -> LambdaTermFormula(Seq(x, a), psi(x, a, b))))
+      val s1 = Weakening((H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 0)
+      val s2 =
+        LeftSubstIff((in(b, B) ==> H2, in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 1, List((in(b, B), And())), LambdaFormulaFormula(Seq(h), h() ==> H2))
+      val s3 = LeftForall((forall(b, in(b, B) ==> H2), in(b, B)) |- existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 2, in(b, B) ==> H2, b, b)
+      val s4 = Rewrite(forall(b, in(b, B) ==> H2) |- in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))), 3)
+      val s5 = RightForall(
+        forall(b, in(b, B) ==> H2) |- forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))),
+        4,
+        in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))),
+        b
+      )
+      val s6 = InstFunSchema(
+        forall(b, in(b, B) ==> existsOne(X, phi(X, b))) |- instantiateTermSchemas(i1.right.head, Map(A -> LambdaTermTerm(Nil, B))),
+        -1,
+        Map(A -> LambdaTermTerm(Nil, B))
+      )
+      val s7 = InstPredSchema(
+        forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b))))) |- existsOne(
+          X,
+          forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
+        ),
+        6,
+        Map(phi -> LambdaTermFormula(Seq(y, b), forall(x, in(x, y) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
+      )
+      val s8 = Cut(
+        forall(b, in(b, B) ==> H2) |- existsOne(X, forall(x, in(x, X) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))),
+        5,
+        7,
+        forall(b, in(b, B) ==> existsOne(X, forall(x, in(x, X) <=> exists(a, in(a, A) /\ psi(x, a, b)))))
+      )
+      Proof(Vector(s0, s1, s2, s3, s4, s5, s6, s7, s8), Vector(i1))
+      // have ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s0
+      // have (b ∈ B), ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s1
+      // have (b ∈ B), (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s2
+      // have (b ∈ B), ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s3
+      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s4
+      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b) ⊢  ∀b. (b ∈ B) ⇒ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ A) ∧ ?psi(x, a, b)    s5
+      // by thmMapFunctional have ∀b. (b ∈ B) ⇒ ∃!x. ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)        phi(x, b) = ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)    s6
+      // have ∀b. (b ∈ B) ⇒ ∀a. (a ∈ A) ⇒ ∃!x. ?psi(x, a, b)    |-    ∃!X. ∀x. (x ∈ X) ↔ ∃b. (b ∈ B) ∧ ∀x1. (x1 ∈ x) ↔ ∃a. (a ∈ A) ∧ ?psi(x1, a, b)   s7
 
     } using (thm"functionalMapping")
-    show
+  show
 
-    THEOREM("applyFunctionToUniqueObject") of
-        "∃!x. ?phi(x) ⊢ ∃!z. ∃x. (z = ?F(x)) ∧ ?phi(x)" PROOF {
-        val x = VariableLabel("x")
-        val x1 = VariableLabel("x1")
-        val z = VariableLabel("z")
-        val z1 = VariableLabel("z1")
-        val F = SchematicFunctionLabel("F", 1)
-        val f = VariableLabel("f")
-        val phi = SchematicNPredicateLabel("phi", 1)
-        val g = VariableFormulaLabel("g")
+  THEOREM("applyFunctionToUniqueObject") of
+    "∃!x. ?phi(x) ⊢ ∃!z. ∃x. (z = ?F(x)) ∧ ?phi(x)" PROOF {
+      val x = VariableLabel("x")
+      val x1 = VariableLabel("x1")
+      val z = VariableLabel("z")
+      val z1 = VariableLabel("z1")
+      val F = SchematicFunctionLabel("F", 1)
+      val f = VariableLabel("f")
+      val phi = SchematicNPredicateLabel("phi", 1)
+      val g = VariableFormulaLabel("g")
 
-        val g2 = SCSubproof({
-            val s0 = hypothesis(F(x1) === z)
-            val s1 = LeftSubstEq((x === x1, F(x) === z) |- F(x1) === z, 0, List((x, x1)), LambdaTermFormula(Seq(f), F(f) === z))
-            val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g))
-            val s3 = LeftForall(Set(forall(x, phi(x) <=> (x === x1)), phi(x), F(x) === z) |- F(x1) === z, 2, phi(x) <=> (x === x1), x, x)
-            val s4 = Rewrite(Set(forall(x, phi(x) <=> (x === x1)), phi(x) /\ (F(x) === z)) |- F(x1) === z, 3)
-            val s5 = LeftExists(Set(forall(x, phi(x) <=> (x === x1)), exists(x, phi(x) /\ (F(x) === z))) |- F(x1) === z, 4, phi(x) /\ (F(x) === z), x)
-            val s6 = Rewrite(forall(x, phi(x) <=> (x === x1)) |- exists(x, phi(x) /\ (F(x) === z)) ==> (F(x1) === z), 5)
-            Proof(steps(s0, s1, s2, s3, s4, s5, s6))
-        }) // redGoal2 ∀x. x=x1 <=> phi(x)   ⊢   ∃x. z=F(x) /\ phi(x) ==> F(x1)=z  g2.s5
+      val g2 = SCSubproof({
+        val s0 = hypothesis(F(x1) === z)
+        val s1 = LeftSubstEq((x === x1, F(x) === z) |- F(x1) === z, 0, List((x, x1)), LambdaTermFormula(Seq(f), F(f) === z))
+        val s2 = LeftSubstIff(Set(phi(x) <=> (x === x1), phi(x), F(x) === z) |- F(x1) === z, 1, List((x === x1, phi(x))), LambdaFormulaFormula(Seq(g), g))
+        val s3 = LeftForall(Set(forall(x, phi(x) <=> (x === x1)), phi(x), F(x) === z) |- F(x1) === z, 2, phi(x) <=> (x === x1), x, x)
+        val s4 = Rewrite(Set(forall(x, phi(x) <=> (x === x1)), phi(x) /\ (F(x) === z)) |- F(x1) === z, 3)
+        val s5 = LeftExists(Set(forall(x, phi(x) <=> (x === x1)), exists(x, phi(x) /\ (F(x) === z))) |- F(x1) === z, 4, phi(x) /\ (F(x) === z), x)
+        val s6 = Rewrite(forall(x, phi(x) <=> (x === x1)) |- exists(x, phi(x) /\ (F(x) === z)) ==> (F(x1) === z), 5)
+        Proof(steps(s0, s1, s2, s3, s4, s5, s6))
+      }) // redGoal2 ∀x. x=x1 <=> phi(x)   ⊢   ∃x. z=F(x) /\ phi(x) ==> F(x1)=z  g2.s5
 
-        val g1 = SCSubproof({
-            val s0 = hypothesis(phi(x1))
-            val s1 = LeftForall(forall(x, (x === x1) <=> phi(x)) |- phi(x1), 0, (x === x1) <=> phi(x), x, x1)
-            val s2 = hypothesis(z === F(x1))
-            val s3 = RightAnd((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- (z === F(x1)) /\ phi(x1), Seq(2, 1), Seq(z === F(x1), phi(x1)))
-            val s4 = RightExists((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- exists(x, (z === F(x)) /\ phi(x)), 3, (z === F(x)) /\ phi(x), x, x1)
-            val s5 = Rewrite(forall(x, (x === x1) <=> phi(x)) |- z === F(x1) ==> exists(x, (z === F(x)) /\ phi(x)), 4)
-            Proof(steps(s0, s1, s2, s3, s4, s5))
-        })
+      val g1 = SCSubproof({
+        val s0 = hypothesis(phi(x1))
+        val s1 = LeftForall(forall(x, (x === x1) <=> phi(x)) |- phi(x1), 0, (x === x1) <=> phi(x), x, x1)
+        val s2 = hypothesis(z === F(x1))
+        val s3 = RightAnd((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- (z === F(x1)) /\ phi(x1), Seq(2, 1), Seq(z === F(x1), phi(x1)))
+        val s4 = RightExists((forall(x, (x === x1) <=> phi(x)), z === F(x1)) |- exists(x, (z === F(x)) /\ phi(x)), 3, (z === F(x)) /\ phi(x), x, x1)
+        val s5 = Rewrite(forall(x, (x === x1) <=> phi(x)) |- z === F(x1) ==> exists(x, (z === F(x)) /\ phi(x)), 4)
+        Proof(steps(s0, s1, s2, s3, s4, s5))
+      })
 
-        val s0 = g1
-        val s1 = g2
-        val s2 = RightIff(forall(x, (x === x1) <=> phi(x)) |- (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), 0, 1, z === F(x1), exists(x, (z === F(x)) /\ phi(x)))
-        val s3 = RightForall(forall(x, (x === x1) <=> phi(x)) |- forall(z, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x))), 2, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), z)
-        val s4 = RightExists(
-            forall(x, (x === x1) <=> phi(x)) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))),
-            3,
-            forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x))),
-            z1,
-            F(x1)
-        )
-        val s5 = LeftExists(exists(x1, forall(x, (x === x1) <=> phi(x))) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))), 4, forall(x, (x === x1) <=> phi(x)), x1)
-        val s6 = Rewrite(existsOne(x, phi(x)) |- existsOne(z, exists(x, (z === F(x)) /\ phi(x))), 5) // goal ∃!x. phi(x)   ⊢   ∃!z. ∃x. z=F(x) /\ phi(x)
-        Proof(Vector(s0, s1, s2, s3, s4, s5, s6))
+      val s0 = g1
+      val s1 = g2
+      val s2 = RightIff(forall(x, (x === x1) <=> phi(x)) |- (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), 0, 1, z === F(x1), exists(x, (z === F(x)) /\ phi(x)))
+      val s3 = RightForall(forall(x, (x === x1) <=> phi(x)) |- forall(z, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x))), 2, (z === F(x1)) <=> exists(x, (z === F(x)) /\ phi(x)), z)
+      val s4 = RightExists(
+        forall(x, (x === x1) <=> phi(x)) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))),
+        3,
+        forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x))),
+        z1,
+        F(x1)
+      )
+      val s5 = LeftExists(exists(x1, forall(x, (x === x1) <=> phi(x))) |- exists(z1, forall(z, (z === z1) <=> exists(x, (z === F(x)) /\ phi(x)))), 4, forall(x, (x === x1) <=> phi(x)), x1)
+      val s6 = Rewrite(existsOne(x, phi(x)) |- existsOne(z, exists(x, (z === F(x)) /\ phi(x))), 5) // goal ∃!x. phi(x)   ⊢   ∃!z. ∃x. z=F(x) /\ phi(x)
+      Proof(Vector(s0, s1, s2, s3, s4, s5, s6))
     } using ()
-    show
+  show
 
-    THEOREM("mapTwoArguments") of
-        "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
-        val a = VariableLabel("a")
-        val b = VariableLabel("b")
-        val x = VariableLabel("x")
-        val x1 = VariableLabel("x1")
-        val y = VariableLabel("y")
-        val F = SchematicFunctionLabel("F", 1)
-        val A = VariableLabel("A")
-        val B = VariableLabel("B")
-        val phi = SchematicNPredicateLabel("phi", 1)
-        val psi = SchematicNPredicateLabel("psi", 3)
+  THEOREM("mapTwoArguments") of
+    "∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)" PROOF {
+      val a = VariableLabel("a")
+      val b = VariableLabel("b")
+      val x = VariableLabel("x")
+      val x1 = VariableLabel("x1")
+      val y = VariableLabel("y")
+      val F = SchematicFunctionLabel("F", 1)
+      val A = VariableLabel("A")
+      val B = VariableLabel("B")
+      val phi = SchematicNPredicateLabel("phi", 1)
+      val psi = SchematicNPredicateLabel("psi", 3)
 
-        val i1 = thm"lemmaLayeredTwoArgumentsMap"
-        val i2 = thm"applyFunctionToUniqueObject"
-        val rPhi = forall(x, in(x, y) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
-        val seq0 = instantiatePredicateSchemaInSequent(i2, Map(phi -> LambdaTermFormula(Seq(y), rPhi)))
-        val s0 = InstPredSchema(seq0, -2, Map(phi -> LambdaTermFormula(Seq(y), rPhi))) // val s0 = InstPredSchema(instantiatePredicateSchemaInSequent(i2, phi, rPhi, Seq(X)), -2, phi, rPhi, Seq(X))
-        val seq1 = instantiateFunctionSchemaInSequent(seq0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
-        val s1 = InstFunSchema(seq1, 0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
-        val s2 = Cut(i1.left |- seq1.right, -1, 1, seq1.left.head)
-        Proof(steps(s0, s1, s2), imports(i1, i2))
+      val i1 = thm"lemmaLayeredTwoArgumentsMap"
+      val i2 = thm"applyFunctionToUniqueObject"
+      val rPhi = forall(x, in(x, y) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x) <=> exists(a, in(a, A) /\ psi(x1, a, b)))))
+      val seq0 = instantiatePredicateSchemaInSequent(i2, Map(phi -> LambdaTermFormula(Seq(y), rPhi)))
+      val s0 = InstPredSchema(seq0, -2, Map(phi -> LambdaTermFormula(Seq(y), rPhi))) // val s0 = InstPredSchema(instantiatePredicateSchemaInSequent(i2, phi, rPhi, Seq(X)), -2, phi, rPhi, Seq(X))
+      val seq1 = instantiateFunctionSchemaInSequent(seq0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
+      val s1 = InstFunSchema(seq1, 0, Map(F -> LambdaTermTerm(Seq(x), union(x))))
+      val s2 = Cut(i1.left |- seq1.right, -1, 1, seq1.left.head)
+      Proof(steps(s0, s1, s2), imports(i1, i2))
     } using (thm"lemmaLayeredTwoArgumentsMap", thm"applyFunctionToUniqueObject")
-    show
+  show
 
-    val A = VariableLabel("A")
-    val B = VariableLabel("B")
-    private val z = VariableLabel("z")
-    val cartesianProduct: ConstantFunctionLabel =
-        DEFINE("cartProd", A, B) asThe z suchThat {
-            val a = VariableLabel("a")
-            val b = VariableLabel("b")
-            val x = VariableLabel("x")
-            val x0 = VariableLabel("x0")
-            val x1 = VariableLabel("x1")
-            val A = VariableLabel("A")
-            val B = VariableLabel("B")
-            exists(x, (z === union(x)) /\ forall(x0, in(x0, x) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x0) <=> exists(a, in(a, A) /\ (x1 === oPair(a, b)))))))
-        } PROOF {
-            def makeFunctional(t: Term): Proof = {
-                val x = VariableLabel(freshId(t.freeVariables.map(_.id), "x"))
-                val y = VariableLabel(freshId(t.freeVariables.map(_.id), "y"))
-                val s0 = RightRefl(() |- t === t, t === t)
-                val s1 = Rewrite(() |- (x === t) <=> (x === t), 0)
-                val s2 = RightForall(() |- forall(x, (x === t) <=> (x === t)), 1, (x === t) <=> (x === t), x)
-                val s3 = RightExists(() |- exists(y, forall(x, (x === y) <=> (x === t))), 2, forall(x, (x === y) <=> (x === t)), y, t)
-                val s4 = Rewrite(() |- existsOne(x, x === t), 3)
-                Proof(s0, s1, s2, s3, s4)
-            }
+  val A = VariableLabel("A")
+  val B = VariableLabel("B")
+  private val z = VariableLabel("z")
+  val cartesianProduct: ConstantFunctionLabel =
+    DEFINE("cartProd", A, B) asThe z suchThat {
+      val a = VariableLabel("a")
+      val b = VariableLabel("b")
+      val x = VariableLabel("x")
+      val x0 = VariableLabel("x0")
+      val x1 = VariableLabel("x1")
+      val A = VariableLabel("A")
+      val B = VariableLabel("B")
+      exists(x, (z === union(x)) /\ forall(x0, in(x0, x) <=> exists(b, in(b, B) /\ forall(x1, in(x1, x0) <=> exists(a, in(a, A) /\ (x1 === oPair(a, b)))))))
+    } PROOF {
+      def makeFunctional(t: Term): Proof = {
+        val x = VariableLabel(freshId(t.freeVariables.map(_.id), "x"))
+        val y = VariableLabel(freshId(t.freeVariables.map(_.id), "y"))
+        val s0 = RightRefl(() |- t === t, t === t)
+        val s1 = Rewrite(() |- (x === t) <=> (x === t), 0)
+        val s2 = RightForall(() |- forall(x, (x === t) <=> (x === t)), 1, (x === t) <=> (x === t), x)
+        val s3 = RightExists(() |- exists(y, forall(x, (x === y) <=> (x === t))), 2, forall(x, (x === y) <=> (x === t)), y, t)
+        val s4 = Rewrite(() |- existsOne(x, x === t), 3)
+        Proof(s0, s1, s2, s3, s4)
+      }
 
-            val a = VariableLabel("a")
-            val b = VariableLabel("b")
-            val x = VariableLabel("x")
-            val A = VariableLabel("A")
-            val B = VariableLabel("B")
-            val psi = SchematicNPredicateLabel("psi", 3)
+      val a = VariableLabel("a")
+      val b = VariableLabel("b")
+      val x = VariableLabel("x")
+      val A = VariableLabel("A")
+      val B = VariableLabel("B")
+      val psi = SchematicNPredicateLabel("psi", 3)
 
-            val i1 = thm"mapTwoArguments" // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)
+      val i1 = thm"mapTwoArguments" // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. ?psi(x, a, b) ⊢ ∃!z. ∃x. (z = U(x)) ∧ ∀x_0. (x_0 ∈ x) ↔ ∃b. (b ∈ ?B) ∧ ∀x1. (x1 ∈ x_0) ↔ ∃a. (a ∈ ?A) ∧ ?psi(x1, a, b)
 
-            val s0 = SCSubproof({
-                val s0 = SCSubproof(makeFunctional(oPair(a, b)))
-                val s1 = Weakening((in(b, B), in(a, A)) |- s0.bot.right, 0)
-                val s2 = Rewrite(in(b, B) |- in(a, A) ==> s0.bot.right.head, 1)
-                val s3 = RightForall(in(b, B) |- forall(a, in(a, A) ==> s0.bot.right.head), 2, in(a, A) ==> s0.bot.right.head, a)
-                val s4 = Rewrite(() |- in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), 3)
-                val s5 = RightForall(() |- forall(b, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head)), 4, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), b)
-                Proof(steps(s0, s1, s2, s3, s4, s5))
-            }) // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. x= (a, b)
+      val s0 = SCSubproof({
+        val s0 = SCSubproof(makeFunctional(oPair(a, b)))
+        val s1 = Weakening((in(b, B), in(a, A)) |- s0.bot.right, 0)
+        val s2 = Rewrite(in(b, B) |- in(a, A) ==> s0.bot.right.head, 1)
+        val s3 = RightForall(in(b, B) |- forall(a, in(a, A) ==> s0.bot.right.head), 2, in(a, A) ==> s0.bot.right.head, a)
+        val s4 = Rewrite(() |- in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), 3)
+        val s5 = RightForall(() |- forall(b, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head)), 4, in(b, B) ==> forall(a, in(a, A) ==> s0.bot.right.head), b)
+        Proof(steps(s0, s1, s2, s3, s4, s5))
+      }) // ∀b. (b ∈ ?B) ⇒ ∀a. (a ∈ ?A) ⇒ ∃!x. x= (a, b)
 
-            val s1 = InstPredSchema(
-                instantiatePredicateSchemaInSequent(i1, Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))),
-                -1,
-                Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))
-            )
-            val s2 = Cut(() |- s1.bot.right, 0, 1, s1.bot.left.head)
-            Proof(steps(s0, s1, s2), imports(i1))
-        } using (thm"mapTwoArguments")
-    show
+      val s1 = InstPredSchema(
+        instantiatePredicateSchemaInSequent(i1, Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))),
+        -1,
+        Map(psi -> LambdaTermFormula(Seq(x, a, b), x === oPair(a, b)))
+      )
+      val s2 = Cut(() |- s1.bot.right, 0, 1, s1.bot.left.head)
+      Proof(steps(s0, s1, s2), imports(i1))
+    } using (thm"mapTwoArguments")
+  show
 
 }

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -24,7 +24,7 @@ object SetTheory extends lisa.proven.Main {
       val x = VariableLabel("x")
       val y = VariableLabel("y")
       val z = VariableLabel("z")
-      val h = SchematicPredicateLabel("h", 0)
+      val h = VariableFormulaLabel("h")
       val fin = SCSubproof(
         {
           val pr0 = SCSubproof(
@@ -47,7 +47,7 @@ object SetTheory extends lisa.proven.Main {
             Sequent(pr1.bot.right, Set(in(z, pair(x, y)) <=> in(z, pair(y, x)))),
             0,
             List(((x === z) \/ (y === z), in(z, pair(y, x)))),
-            LambdaFormulaFormula(Seq(h), in(z, pair(x, y)) <=> h())
+            LambdaFormulaFormula(Seq(h), in(z, pair(x, y)) <=> h)
           )
           val pr3 = Cut(Sequent(pr1.bot.left, pr2.bot.right), 1, 2, pr2.bot.left.head)
           val pr4 = RightForall(Sequent(Set(), Set(forall(z, pr2.bot.right.head))), 3, pr2.bot.right.head, z)
@@ -81,7 +81,7 @@ object SetTheory extends lisa.proven.Main {
       val y1 = VariableLabel("y'")
       val z = VariableLabel("z")
       val g = VariableLabel("g")
-      val h = SchematicPredicateLabel("h", 0)
+      val h = VariableFormulaLabel("h")
       val pxy = pair(x, y)
       val pxy1 = pair(x1, y1)
       val p0 = SCSubproof(
@@ -125,7 +125,7 @@ object SetTheory extends lisa.proven.Main {
             emptySeq +< p3.bot.left.head +< p2.bot.right.head +> (((z === x) \/ (z === y)) <=> ((z === x1) \/ (z === y1))),
             3,
             List(((z === x1) \/ (z === y1), in(z, pxy1))),
-            LambdaFormulaFormula(Seq(h), h() <=> ((z === x) \/ (z === y)))
+            LambdaFormulaFormula(Seq(h), h <=> ((z === x) \/ (z === y)))
           ) //  ((z∈{x',y'})↔((x'=z)∨(y'=z))), ({x,y}={x',y'}) |- (((z=x)∨(z=y))↔((z=x')∨(z=y')))
           val p5 = Cut(emptySeq ++< p3.bot ++> p4.bot, 2, 4, p2.bot.right.head)
           Proof(IndexedSeq(p0, p1, p2, p3, p4, p5), IndexedSeq(() |- pairAxiom))
@@ -172,7 +172,7 @@ object SetTheory extends lisa.proven.Main {
                                 emptySeq +< (pxy === pxy1) +< (x === y) +< (f1 <=> (f1 \/ f1)) +> (f1 <=> ((z === x1) \/ (z === y1))),
                                 1,
                                 List((f1, f1 \/ f1)),
-                                LambdaFormulaFormula(Seq(h), h() <=> ((z === x1) \/ (z === y1)))
+                                LambdaFormulaFormula(Seq(h), h <=> ((z === x1) \/ (z === y1)))
                               )
                               val pa0_3 =
                                 Cut(emptySeq +< (pxy === pxy1) +< (x === y) +> (f1 <=> ((z === x1) \/ (z === y1))), 0, 2, f1 <=> (f1 \/ f1)) //  (x=y), ({x,y}={x',y'}) |- ((z=x)↔((z=x')∨(z=y')))
@@ -275,7 +275,7 @@ object SetTheory extends lisa.proven.Main {
                       pd0_1.bot.right |- ((x1 === x) \/ (x1 === y)),
                       0,
                       List(((x1 === x) \/ (x1 === y), (x1 === x1) \/ (x1 === y1))),
-                      LambdaFormulaFormula(Seq(h), h())
+                      LambdaFormulaFormula(Seq(h), h)
                     ) // (x'=x \/ x'=y) <=> (x'=x' \/ x'=y') |- (x'=x \/ x'=y)
                     val pd0_3 = Cut(pd0_1.bot.left |- pd0_2.bot.right, 1, 2, pd0_1.bot.right.head) //  ({x,y}={x',y'}) |- (x=x' \/ y=x')
                     destructRightOr(Proof(IndexedSeq(pd0_0, pd0_1, pd0_2, pd0_3), IndexedSeq(pd0_m1.bot)), x === x1, y === x1) //  ({x,y}={x',y'}) |- x=x',  y=x'
@@ -333,8 +333,8 @@ object SetTheory extends lisa.proven.Main {
     val x = VariableLabel("x")
     val y = VariableLabel("y")
     val z = VariableLabel("z")
-    val h = SchematicPredicateLabel("h", 0)
-    val sPhi = SchematicPredicateLabel("P", 2)
+    val h = VariableFormulaLabel("h")
+    val sPhi = SchematicNPredicateLabel("P", 2)
     // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,y) /\ sPhi(x,z)))))
     val i1 = () |- comprehensionSchema
     val i2 = thm"russelParadox" // forall(x1, in(x1,y) <=> !in(x1, x1)) |- ()
@@ -345,7 +345,7 @@ object SetTheory extends lisa.proven.Main {
       (in(x, z) <=> And(), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> (And() /\ !in(x, x)),
       1,
       List((in(x, z), And())),
-      LambdaFormulaFormula(Seq(h), in(x, y) <=> (h() /\ !in(x, x)))
+      LambdaFormulaFormula(Seq(h), in(x, y) <=> (h /\ !in(x, x)))
     ) // in(x1,y1) <=> (in(x1,z1) /\ in(x1, x1)) |- in(x,y) <=> (And() /\ in(x1, x1))
     val s3 = Rewrite((in(x, z), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> !in(x, x), 2)
     val s4 = LeftForall((forall(x, in(x, z)), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> !in(x, x), 3, in(x, z), x, x)

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -9,12 +9,12 @@ import lisa.proven.tactics.ProofTactics.*
 object SetTheory extends lisa.proven.Main {
 
   THEOREM("russelParadox") of "∀x. (x ∈ ?y) ↔ ¬(x ∈ x) ⊢" PROOF {
-    val y = SchematicFunctionLabel("y", 0)
-    val x_ = VariableLabel("x")
+    val y = VariableLabel("y")
+    val x = VariableLabel("x")
     val contra = in(y, y) <=> !in(y, y)
     val s0 = Hypothesis(contra |- contra, contra)
-    val s1 = LeftForall(forall(x_, in(x_, y) <=> !in(x_, x_)) |- contra, 0, in(x_, y) <=> !in(x_, x_), x_, y)
-    val s2 = Rewrite(forall(x_, in(x_, y) <=> !in(x_, x_)) |- (), 1)
+    val s1 = LeftForall(forall(x, in(x, y) <=> !in(x, x)) |- contra, 0, in(x, y) <=> !in(x, x), x, y)
+    val s2 = Rewrite(forall(x, in(x, y) <=> !in(x, x)) |- (), 1)
     Proof(s0, s1, s2)
   } using ()
   thm"russelParadox".show
@@ -80,7 +80,7 @@ object SetTheory extends lisa.proven.Main {
       val x1 = VariableLabel("x'")
       val y1 = VariableLabel("y'")
       val z = VariableLabel("z")
-      val g = SchematicFunctionLabel("g", 0)
+      val g = VariableLabel("g")
       val h = SchematicPredicateLabel("h", 0)
       val pxy = pair(x, y)
       val pxy1 = pair(x1, y1)
@@ -92,7 +92,7 @@ object SetTheory extends lisa.proven.Main {
               val p1_0 = hypothesis(zf)
               val p1_1 = RightImplies(emptySeq +> (zf ==> zf), 0, zf, zf)
               val p1_2 = RightIff(emptySeq +> (zf <=> zf), 1, 1, zf, zf) //  |- (z in {x,y} <=> z in {x,y})
-              val p1_3 = RightSubstEq(emptySeq +< (pxy === pxy1) +> (zf <=> in(z, pxy1)), 2, List((pxy, pxy1)), LambdaTermFormula(Seq(g), zf <=> in(z, g())))
+              val p1_3 = RightSubstEq(emptySeq +< (pxy === pxy1) +> (zf <=> in(z, pxy1)), 2, List((pxy, pxy1)), LambdaTermFormula(Seq(g), zf <=> in(z, g)))
               Proof(IndexedSeq(p1_0, p1_1, p1_2, p1_3), IndexedSeq(() |- pairAxiom))
             },
             Seq(-1),
@@ -119,7 +119,7 @@ object SetTheory extends lisa.proven.Main {
             emptySeq +< (pxy === pxy1) +> (in(z, pxy1) <=> ((z === x) \/ (z === y))),
             1,
             List((pxy, pxy1)),
-            LambdaTermFormula(Seq(g), in(z, g()) <=> ((z === x) \/ (z === y)))
+            LambdaTermFormula(Seq(g), in(z, g) <=> ((z === x) \/ (z === y)))
           ) //   ({x,y}={x',y'}) |- ((z∈{x',y'})↔((z=x)∨(z=y)))
           val p4 = RightSubstIff(
             emptySeq +< p3.bot.left.head +< p2.bot.right.head +> (((z === x) \/ (z === y)) <=> ((z === x1) \/ (z === y1))),
@@ -166,7 +166,7 @@ object SetTheory extends lisa.proven.Main {
                                 emptySeq +< (pxy === pxy1) +< (x === y) +> ((f1 \/ f1) <=> (z === x1) \/ (z === y1)),
                                 -1,
                                 List((x, y)),
-                                LambdaTermFormula(Seq(g), (f1 \/ (z === g())) <=> ((z === x1) \/ (z === y1)))
+                                LambdaTermFormula(Seq(g), (f1 \/ (z === g)) <=> ((z === x1) \/ (z === y1)))
                               ) //  ({x,y}={x',y'}) y=x|- (z=x)\/(z=x) <=> (z=x' \/ z=y')
                               val pa0_2 = RightSubstIff(
                                 emptySeq +< (pxy === pxy1) +< (x === y) +< (f1 <=> (f1 \/ f1)) +> (f1 <=> ((z === x1) \/ (z === y1))),
@@ -191,7 +191,7 @@ object SetTheory extends lisa.proven.Main {
                             display = false
                           ) //  |- (y'=x' \/ y'=y')
                           val ra3 = byEquiv(pa0.bot.right.head, pa1.bot.right.head)(pa0, pa1) // ({x,y}={x',y'}) y=x|- ((y'=x)
-                          val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), ra3.length - 1, List((x, y)), LambdaTermFormula(Seq(g), y1 === g()))
+                          val pal = RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), ra3.length - 1, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
                           Proof(ra3.steps, IndexedSeq(pam1.bot)).appended(pal) // (x=y), ({x,y}={x',y'}) |- (y'=y)
                         },
                         IndexedSeq(-1)
@@ -217,7 +217,7 @@ object SetTheory extends lisa.proven.Main {
                           ) //  |- (y=x)∨(y=y)
                           val rb0 = byEquiv(pb0_0.bot.right.head, pb0_1.bot.right.head)(pb0_0, pb0_1) //  ({x,y}={x',y'}) |- (y=x')∨(y=y')
                           val pb1 =
-                            RightSubstEq(emptySeq ++< rb0.conclusion +< (x === x1) +> ((y === x) \/ (y === y1)), rb0.length - 1, List((x, x1)), LambdaTermFormula(Seq(g), (y === g()) \/ (y === y1)))
+                            RightSubstEq(emptySeq ++< rb0.conclusion +< (x === x1) +> ((y === x) \/ (y === y1)), rb0.length - 1, List((x, x1)), LambdaTermFormula(Seq(g), (y === g) \/ (y === y1)))
                           val rb1 = destructRightOr(
                             rb0.appended(pb1), //  ({x,y}={x',y'}) , x=x'|- (y=x)∨(y=y')
                             y === x,
@@ -237,7 +237,7 @@ object SetTheory extends lisa.proven.Main {
                 val pc1 = RightRefl(emptySeq +> (x === x), x === x)
                 val pc2 = RightAnd(emptySeq ++< pc0.bot +> ((y1 === y) /\ (x === x)), Seq(0, 1), Seq(y1 === y, x === x)) // ({x,y}={x',y'}), x=x' |- (x=x /\ y=y')
                 val pc3 =
-                  RightSubstEq(emptySeq ++< pc2.bot +> ((y1 === y) /\ (x1 === x)), 2, List((x, x1)), LambdaTermFormula(Seq(g), (y1 === y) /\ (g() === x))) // ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')
+                  RightSubstEq(emptySeq ++< pc2.bot +> ((y1 === y) /\ (x1 === x)), 2, List((x, x1)), LambdaTermFormula(Seq(g), (y1 === y) /\ (g === x))) // ({x,y}={x',y'}), x=x' |- (x=x' /\ y=y')
                 val pc4 = RightOr(
                   emptySeq ++< pc3.bot +> (pc3.bot.right.head \/ ((x === y1) /\ (y === x1))),
                   3,
@@ -330,40 +330,38 @@ object SetTheory extends lisa.proven.Main {
   thm"unorderedPair_deconstruction".show
 
   THEOREM("noUniversalSet") of "∀x. x ∈ ?z ⊢" PROOF {
-    val x = SchematicFunctionLabel("x", 0)
-    val z = SchematicFunctionLabel("z", 0)
-    val x1 = VariableLabel("x")
-    val y1 = VariableLabel("y")
-    val z1 = VariableLabel("z")
+    val x = VariableLabel("x")
+    val y = VariableLabel("y")
+    val z = VariableLabel("z")
     val h = SchematicPredicateLabel("h", 0)
     val sPhi = SchematicPredicateLabel("P", 2)
     // forall(z, exists(y, forall(x, in(x,y) <=> (in(x,y) /\ sPhi(x,z)))))
     val i1 = () |- comprehensionSchema
     val i2 = thm"russelParadox" // forall(x1, in(x1,y) <=> !in(x1, x1)) |- ()
-    val p0 = InstPredSchema(() |- forall(z1, exists(y1, forall(x1, in(x1, y1) <=> (in(x1, z1) /\ !in(x1, x1))))), -1, Map(sPhi -> LambdaTermFormula(Seq(x, z), !in(x(), x()))))
+    val p0 = InstPredSchema(() |- forall(z, exists(y, forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x))))), -1, Map(sPhi -> LambdaTermFormula(Seq(x, z), !in(x, x))))
     val s0 = SCSubproof(instantiateForall(Proof(IndexedSeq(p0), IndexedSeq(i1)), z), Seq(-1)) // exists(y1, forall(x1, in(x1,y1) <=> (in(x1,z1) /\ !in(x1, x1))))
-    val s1 = hypothesis(in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))) // in(x,y) <=> (in(x,z) /\ in(x, x)) |- in(x,y) <=> (in(x,z) /\ in(x, x))
+    val s1 = hypothesis(in(x, y) <=> (in(x, z) /\ !in(x, x))) // in(x,y) <=> (in(x,z) /\ in(x, x)) |- in(x,y) <=> (in(x,z) /\ in(x, x))
     val s2 = RightSubstIff(
-      (in(x1, z) <=> And(), in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))) |- in(x1, y1) <=> (And() /\ !in(x1, x1)),
+      (in(x, z) <=> And(), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> (And() /\ !in(x, x)),
       1,
-      List((in(x1, z), And())),
-      LambdaFormulaFormula(Seq(h), in(x1, y1) <=> (h() /\ !in(x1, x1)))
+      List((in(x, z), And())),
+      LambdaFormulaFormula(Seq(h), in(x, y) <=> (h() /\ !in(x, x)))
     ) // in(x1,y1) <=> (in(x1,z1) /\ in(x1, x1)) |- in(x,y) <=> (And() /\ in(x1, x1))
-    val s3 = Rewrite((in(x1, z), in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))) |- in(x1, y1) <=> !in(x1, x1), 2)
-    val s4 = LeftForall((forall(x1, in(x1, z)), in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))) |- in(x1, y1) <=> !in(x1, x1), 3, in(x1, z), x1, x1)
-    val s5 = LeftForall((forall(x1, in(x1, z)), forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1)))) |- in(x1, y1) <=> !in(x1, x1), 4, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1)), x1, x1)
-    val s6 = RightForall((forall(x1, in(x1, z)), forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1)))) |- forall(x1, in(x1, y1) <=> !in(x1, x1)), 5, in(x1, y1) <=> !in(x1, x1), x1)
-    val s7 = InstFunSchema(forall(x1, in(x1, y1) <=> !in(x1, x1)) |- (), -2, Map(SchematicFunctionLabel("y", 0) -> LambdaTermTerm(Nil, y1)))
-    val s8 = Cut((forall(x1, in(x1, z)), forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1)))) |- (), 6, 7, forall(x1, in(x1, y1) <=> !in(x1, x1)))
-    val s9 = LeftExists((forall(x1, in(x1, z)), exists(y1, forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))))) |- (), 8, forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1))), y1)
-    val s10 = Cut(forall(x1, in(x1, z)) |- (), 0, 9, exists(y1, forall(x1, in(x1, y1) <=> (in(x1, z) /\ !in(x1, x1)))))
+    val s3 = Rewrite((in(x, z), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> !in(x, x), 2)
+    val s4 = LeftForall((forall(x, in(x, z)), in(x, y) <=> (in(x, z) /\ !in(x, x))) |- in(x, y) <=> !in(x, x), 3, in(x, z), x, x)
+    val s5 = LeftForall((forall(x, in(x, z)), forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x)))) |- in(x, y) <=> !in(x, x), 4, in(x, y) <=> (in(x, z) /\ !in(x, x)), x, x)
+    val s6 = RightForall((forall(x, in(x, z)), forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x)))) |- forall(x, in(x, y) <=> !in(x, x)), 5, in(x, y) <=> !in(x, x), x)
+    val s7 = InstFunSchema(forall(x, in(x, y) <=> !in(x, x)) |- (), -2, Map(y -> LambdaTermTerm(Nil, y)))
+    val s8 = Cut((forall(x, in(x, z)), forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x)))) |- (), 6, 7, forall(x, in(x, y) <=> !in(x, x)))
+    val s9 = LeftExists((forall(x, in(x, z)), exists(y, forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x))))) |- (), 8, forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x))), y)
+    val s10 = Cut(forall(x, in(x, z)) |- (), 0, 9, exists(y, forall(x, in(x, y) <=> (in(x, z) /\ !in(x, x)))))
     Proof(steps(s0, s1, s2, s3, s4, s5, s6, s7, s8, s9, s10), imports(i1, i2))
   } using (ax"comprehensionSchema", thm"russelParadox")
   show
 
-  private val sx = SchematicFunctionLabel("x", 0)
-  private val sy = SchematicFunctionLabel("y", 0)
-  val oPair: ConstantFunctionLabel = DEFINE("", sx, sy) as pair(pair(sx, sy), pair(sx, sx))
+  private val x = VariableLabel("x")
+  private val y = VariableLabel("y")
+  val oPair: ConstantFunctionLabel = DEFINE("", x, y) as pair(pair(x, y), pair(x, x))
   show
 
 }

--- a/src/main/scala/lisa/proven/tactics/SimplePropositionalSolver.scala
+++ b/src/main/scala/lisa/proven/tactics/SimplePropositionalSolver.scala
@@ -149,7 +149,7 @@ object SimplePropositionalSolver {
 
     } else {
       val f = s.left.find(f => s.right.contains(f))
-      List(Hypothesis(s, if (f.nonEmpty) f.get else PredicateFormula(SchematicPredicateLabel("P", 0), Seq())))
+      List(Hypothesis(s, if (f.nonEmpty) f.get else PredicateFormula(VariableFormulaLabel("P"), Seq())))
     }
   }
 


### PR DESCRIPTION
Merge the concept of Variables and Schematic (term) symbols, effectively by replacing 0-ary schemas by variables. Also introduce formula variables in place of 0-ary schematic predicates.

Any work on top of current LISA release should be easily adaptable by:
 - Changing all instances of Arity 0 SchematicFunctionLabel by VariableLabel
 - Changing all instances of Arity 0 SchematicPredicateLabel by VariableFormulaLabel
 - Changing all matching on SchematicFunctionLabel by either VariableLabel, SchematicFunctionLabel or SchematicTermLabel, according to whether the arity should be =0, >0 or >=0.
 - Changing all instances of multiary SchematicPredicateLabel by SchematicNPredicateLabel
 - Removing the empty parenthesis () that where used to transform an Arity 0 label to a term or formula. Variables have the implicit conversion without the call.