### PR TITLE
In CI, run tests before checking style

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
           java-version: 1.8
       - name: Compile
         run: sbt compile
+      - name: Run tests
+        run: sbt test
       - name: Check style
         run: sbt "scalafixAll --check"
       - name: Check format
         run: sbt scalafmtCheckAll
-      - name: Run tests
-        run: sbt test
 


### PR DESCRIPTION
It's much more useful to know if a PR passes tests than if it's formatted properly, so in the CI, let's run tests before `scalafix --check` /  `scalafmtCheck`.