### PR TITLE
In ProofCheckerSuite#checkProof, fail if the proof is not valid

### DIFF
--- a/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
+++ b/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
@@ -2,6 +2,8 @@ package lisa.test
 
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SCProofChecker.*
+import lisa.kernel.proof.SCProofCheckerJudgement
+import lisa.kernel.proof.SCProofCheckerJudgement.SCInvalidProof
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus.isSameSequent
 import lisa.utils.Helpers.{_, given}
@@ -40,8 +42,7 @@ abstract class ProofCheckerSuite extends AnyFunSuite {
 
   def checkProof(proof: SCProof): Unit = {
     val judgement = checkSCProof(proof)
-    println(Printer.prettySCProof(judgement))
-    println(s"\n(${proof.totalLength} proof steps in total)")
+    assert(judgement.isValid, Printer.prettySCProof(judgement, true))
   }
 
   def checkProof(proof: SCProof, expected: Sequent): Unit = {


### PR DESCRIPTION
This ensures that the test will fail if an invalid proof is found when a valid one was expected.