### PR TITLE
Move export SetTheoryLibrary.* from Main to proof files

### DIFF
--- a/src/main/scala/lisa/proven/Main.scala
+++ b/src/main/scala/lisa/proven/Main.scala
@@ -4,8 +4,6 @@ package lisa.proven
  * The parent trait of all theory files containing mathematical development
  */
 trait Main {
-  export lisa.proven.SetTheoryLibrary.{*, given}
-
   private val realOutput: String => Unit = println
   private var outString: List[String] = List()
   private val lineBreak = "\n"

--- a/src/main/scala/lisa/proven/mathematics/Mapping.scala
+++ b/src/main/scala/lisa/proven/mathematics/Mapping.scala
@@ -10,6 +10,7 @@ import SetTheory.*
  * Leads to the definition of the cartesian product.
  */
 object Mapping extends lisa.proven.Main {
+  export lisa.proven.SetTheoryLibrary.{*, given}
 
   THEOREM("functionalMapping") of
     "∀a. (a ∈ ?A) ⇒ ∃!x. ?phi(x, a) ⊢ ∃!X. ∀x. (x ∈ X) ↔ ∃a. (a ∈ ?A) ∧ ?phi(x, a)" PROOF {

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -7,6 +7,7 @@ import lisa.proven.tactics.ProofTactics.*
  * An embryo of mathematical development, containing a few example theorems and the definition of the ordered pair.
  */
 object SetTheory extends lisa.proven.Main {
+  export lisa.proven.SetTheoryLibrary.{*, given}
 
   THEOREM("russelParadox") of "∀x. (x ∈ ?y) ↔ ¬(x ∈ x) ⊢" PROOF {
     val y = VariableLabel("y")


### PR DESCRIPTION
Let `Main` be responsible for output-related functionality, this way it can be reused for other theories, e.g. the Peano arithmetic that is under development.