### PR TITLE
Quickfix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -10,6 +10,7 @@ inThisBuild(
       "-deprecation",
       "-unchecked"
     ),
+    javacOptions ++= Seq("-encoding", "UTF-8"),
     semanticdbEnabled := true,
     semanticdbVersion := scalafixSemanticdb.revision,
     scalafixDependencies += "com.github.liancheng" %% "organize-imports" % "0.6.0"

--- a/lisa-front/src/main/scala/lisa/front/parser/KernelRuleIdentifiers.scala
+++ b/lisa-front/src/main/scala/lisa/front/parser/KernelRuleIdentifiers.scala
@@ -85,8 +85,7 @@ private[front] case class KernelRuleIdentifiers(symbols: FrontSymbols) {
     case _: SC.RightSubstIff => RightSubstIff
     case _: SC.InstFunSchema => FunInstantiation
     case _: SC.InstPredSchema => PredInstantiation
-    case SC.SCSubproof(_, _, true) => SubproofShown
-    case SC.SCSubproof(_, _, false) => SubproofHidden
+    case _: SC.SCSubproof => SubproofShown
   }
 
 }

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -202,7 +202,7 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
       val r: List[NormalFormula] = phi match {
         case SimplePredicate(id, args) =>
           val lab = id match {
-            case _: ConstantPredicateLabel=> "cons_pred_" + id.id + "_" + id.arity
+            case _: ConstantPredicateLabel => "cons_pred_" + id.id + "_" + id.arity
             case _: SchematicVarOrPredLabel => "schem_pred_" + id.id + "_" + id.arity
           }
           if (id == top) {
@@ -220,9 +220,9 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
           phi.normalForm.get :: acc
         case SimpleConnector(id, args) =>
           val lab = id match {
-          case _: ConstantConnectorLabel => "cons_conn_" + id.id + "_" + id.arity
-          case _: SchematicConnectorLabel => "schem_conn_" + id.id + "_" + id.arity
-        }
+            case _: ConstantConnectorLabel => "cons_conn_" + id.id + "_" + id.arity
+            case _: SchematicConnectorLabel => "schem_conn_" + id.id + "_" + id.arity
+          }
           phi.normalForm = Some(NormalConnector(id, args.map(_.normalForm.get), updateCodesSig((lab, args map OCBSLCode))))
           phi.normalForm.get :: acc
         case SNeg(child) => pNeg(child, phi, acc)
@@ -250,7 +250,7 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
       val r: List[NormalFormula] = phi match {
         case SimplePredicate(id, args) =>
           val lab = id match {
-            case _: ConstantPredicateLabel=> "cons_pred_" + id.id + "_" + id.arity
+            case _: ConstantPredicateLabel => "cons_pred_" + id.id + "_" + id.arity
             case _: SchematicVarOrPredLabel => "schem_pred_" + id.id + "_" + id.arity
           }
           if (id == top) {

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -201,7 +201,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
       if (phi.normalForm.nonEmpty) return pDisjNormal(phi.normalForm.get, acc)
       val r: List[NormalFormula] = phi match {
         case SimplePredicate(id, args) =>
-          val lab = "pred_" + id.id + "_" + id.arity
+          val lab = id match {
+            case _: ConstantPredicateLabel=> "cons_pred_" + id.id + "_" + id.arity
+            case _: SchematicVarOrPredLabel => "schem_pred_" + id.id + "_" + id.arity
+          }
           if (id == top) {
             phi.normalForm = Some(NLiteral(true))
           } else if (id == bot) {
@@ -216,7 +219,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
           }
           phi.normalForm.get :: acc
         case SimpleConnector(id, args) =>
-          val lab = "conn_" + id.id + "_" + id.arity
+          val lab = id match {
+          case _: ConstantConnectorLabel => "cons_conn_" + id.id + "_" + id.arity
+          case _: SchematicConnectorLabel => "schem_conn_" + id.id + "_" + id.arity
+        }
           phi.normalForm = Some(NormalConnector(id, args.map(_.normalForm.get), updateCodesSig((lab, args map OCBSLCode))))
           phi.normalForm.get :: acc
         case SNeg(child) => pNeg(child, phi, acc)

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -249,7 +249,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
       if (phi.normalForm.nonEmpty) return pNegNormal(phi.normalForm.get, parent, acc)
       val r: List[NormalFormula] = phi match {
         case SimplePredicate(id, args) =>
-          val lab = "pred_" + id.id + "_" + id.arity
+          val lab = id match {
+            case _: ConstantPredicateLabel=> "cons_pred_" + id.id + "_" + id.arity
+            case _: SchematicVarOrPredLabel => "schem_pred_" + id.id + "_" + id.arity
+          }
           if (id == top) {
             phi.normalForm = Some(NLiteral(true))
             parent.normalForm = Some(NLiteral(false))
@@ -271,7 +274,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
           }
           parent.normalForm.get :: acc
         case SimpleConnector(id, args) =>
-          val lab = "conn_" + id.id + "_" + id.arity
+          val lab = id match {
+            case _: ConstantConnectorLabel => "cons_conn_" + id.id + "_" + id.arity
+            case _: SchematicConnectorLabel => "schem_conn_" + id.id + "_" + id.arity
+          }
           phi.normalForm = Some(NormalConnector(id, args.map(_.normalForm.get), updateCodesSig((lab, args map OCBSLCode))))
           parent.normalForm = Some(NNeg(phi.normalForm.get, updateCodesSig(("neg", List(phi.normalForm.get.code)))))
           parent.normalForm.get :: acc

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/Substitutions.scala
@@ -155,7 +155,7 @@ trait Substitutions extends FormulaDefinitions {
     phi match {
       case PredicateFormula(label, args) =>
         label match {
-          case label: SchematicPredicateLabel if m.contains(label) => m(label)(args)
+          case label: SchematicVarOrPredLabel if m.contains(label) => m(label)(args)
           case _ => phi
         }
       case ConnectorFormula(label, args) => ConnectorFormula(label, args.map(instantiatePredicateSchemas(_, m)))

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -466,7 +466,7 @@ object SCProofChecker {
                 SCInvalidProof(SCProof(step), Nil, "Right-hand side of premise instantiated with the map 'insts' must be the same as right-hand side of conclusion.")
             else SCInvalidProof(SCProof(step), Nil, "Left-hand side of premise instantiated with the map 'insts' must be the same as left-hand side of conclusion.")
 
-          case SCSubproof(sp, premises, _) =>
+          case SCSubproof(sp, premises) =>
             if (premises.size == sp.imports.size) {
               val invalid = premises.zipWithIndex.find { case (no, p) => !isSameSequent(ref(no), sp.imports(p)) }
               if (invalid.isEmpty) {

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -329,7 +329,7 @@ object SequentCalculus {
    * @param display A boolean value indicating whether the subproof needs to be expanded when printed. Should probably go and
    *                be replaced by encapsulation.
    */
-  case class SCSubproof(sp: SCProof, premises: Seq[Int] = Seq.empty, display: Boolean = true) extends SCProofStep {
+  case class SCSubproof(sp: SCProof, premises: Seq[Int] = Seq.empty) extends SCProofStep {
     // premises is a list of ints similar to t1, t2... that verifies that imports of the subproof sp are justified by previous steps.
     val bot: Sequent = sp.conclusion
   }

--- a/lisa-utils/src/main/scala/lisa/utils/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Printer.scala
@@ -123,7 +123,7 @@ object Printer {
           )
 
         step match {
-          case sp @ SCSubproof(_, _, display) if display || forceDisplaySubproofs =>
+          case sp @ SCSubproof(_, _) =>
             pretty("Subproof", sp.premises*) +: prettySCProofRecursive(sp.sp, level + 1, currentTree, (if (i == 0) topMostIndices else IndexedSeq.empty) :+ i)
           case other =>
             val line = other match {
@@ -155,7 +155,6 @@ object Printer {
               case RightSubstIff(_, t1, _, _) => pretty("R. SubstIff", t1)
               case InstFunSchema(_, t1, _) => pretty("?Fun Instantiation", t1)
               case InstPredSchema(_, t1, _) => pretty("?Pred Instantiation", t1)
-              case SCSubproof(_, _, false) => pretty("Subproof (hidden)")
               case other => throw new Exception(s"No available method to print this proof step, consider updating Printer.scala\n$other")
             }
             Seq(line)

--- a/lisa-utils/src/main/scala/lisa/utils/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Printer.scala
@@ -128,6 +128,7 @@ object Printer {
           case other =>
             val line = other match {
               case Rewrite(_, t1) => pretty("Rewrite", t1)
+              case RewriteTrue(_) => pretty("RewriteTrue")
               case Hypothesis(_, _) => pretty("Hypo.")
               case Cut(_, t1, t2, _) => pretty("Cut", t1, t2)
               case LeftAnd(_, t1, _, _) => pretty("Left ∧", t1)

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -958,7 +958,7 @@ object BasicStepTactic {
   case class SCSubproof(sp: SCProof, premises: Seq[Int] = Seq.empty, display: Boolean = true) extends ProofStep {
     def asSCProof(currentProof: Library#Proof): ProofStepJudgement =
       sp match {
-        case sp: SCProof => SC.SCSubproof(sp, premises, display)
+        case sp: SCProof => SC.SCSubproof(sp, premises)
       }
   }
 

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
@@ -278,7 +278,7 @@ object SimpleDeducedSteps {
 
       res match {
         case ProofStepJudgement.InvalidProofStep(_, _) => res
-        case ProofStepJudgement.ValidProofStep(SC.SCSubproof(proof: SCProof, _, _)) => {
+        case ProofStepJudgement.ValidProofStep(SC.SCSubproof(proof: SCProof, _)) => {
           // check if the same sequent was obtained
           SC.SCSubproof(
             proof withNewSteps IndexedSeq(SC.Rewrite(bot, proof.length - 1)),

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -93,8 +93,7 @@ object SetTheory extends lisa.Main {
               val p1_3 = SC.RightSubstEq(emptySeq +< (pxy === pxy1) +> (zf <=> in(z, pxy1)), 2, List((pxy, pxy1)), LambdaTermFormula(Seq(g), zf <=> in(z, g)))
               SCProof(IndexedSeq(p1_0, p1_1, p1_2, p1_3), IndexedSeq(() |- pairAxiom))
             },
-            Seq(-1),
-            display = true
+            Seq(-1)
           ) //  ({x,y}={x',y'}) |- ((z∈{x,y})↔(z∈{x',y'}))
           val p1 = SC.SCSubproof(
             {
@@ -102,8 +101,7 @@ object SetTheory extends lisa.Main {
               val p1_1 = instantiateForall(SCProof(IndexedSeq(p1_0), IndexedSeq(() |- pairAxiom)), x, y, z)
               p1_1
             },
-            Seq(-1),
-            display = true
+            Seq(-1)
           ) //  |- (z in {x,y}) <=> (z=x \/ z=y)
           val p2 = SC.SCSubproof(
             {
@@ -157,8 +155,7 @@ object SetTheory extends lisa.Main {
                                   val pa0_1_5 = SC.RightIff(emptySeq +> ((f1 \/ f1) <=> f1), 2, 4, (f1 \/ f1), f1)
                                   val r = SCProof(pa0_0_0, pa0_1_1, pa0_1_2, pa0_1_3, pa0_1_4, pa0_1_5)
                                   r
-                                },
-                                display = false
+                                }
                               ) //   |- (((z=x)∨(z=x))↔(z=x))
                               val pa0_1 = SC.RightSubstEq(
                                 emptySeq +< (pxy === pxy1) +< (x === y) +> ((f1 \/ f1) <=> (z === x1) \/ (z === y1)),
@@ -185,8 +182,7 @@ object SetTheory extends lisa.Main {
                               val pa1_0 = SC.RightRefl(emptySeq +> (y1 === y1), y1 === y1)
                               val pa1_1 = SC.RightOr(emptySeq +> ((y1 === y1) \/ (y1 === x1)), 0, y1 === y1, y1 === x1)
                               SCProof(pa1_0, pa1_1)
-                            },
-                            display = false
+                            }
                           ) //  |- (y'=x' \/ y'=y')
                           val ra3 = byEquiv(pa0.bot.right.head, pa1.bot.right.head)(pa0, pa1) // ({x,y}={x',y'}) y=x|- ((y'=x)
                           val pal = SC.RightSubstEq(emptySeq ++< pa0.bot +> (y1 === y), ra3.length - 1, List((x, y)), LambdaTermFormula(Seq(g), y1 === g))
@@ -210,8 +206,7 @@ object SetTheory extends lisa.Main {
                               val pa1_0 = SC.RightRefl(emptySeq +> (y === y), y === y)
                               val pa1_1 = SC.RightOr(emptySeq +> ((y === y) \/ (y === x)), 0, y === y, y === x)
                               SCProof(pa1_0, pa1_1)
-                            },
-                            display = false
+                            }
                           ) //  |- (y=x)∨(y=y)
                           val rb0 = byEquiv(pb0_0.bot.right.head, pb0_1.bot.right.head)(pb0_0, pb0_1) //  ({x,y}={x',y'}) |- (y=x')∨(y=y')
                           val pb1 =

--- a/src/main/scala/lisa/utilities/prooftransform/ProofUnconditionalizer.scala
+++ b/src/main/scala/lisa/utilities/prooftransform/ProofUnconditionalizer.scala
@@ -224,7 +224,7 @@ case class ProofUnconditionalizer(prOrig: SCProof) extends ProofTransformer(prOr
     })
     // We must separate the case for subproofs for they need to use the modified version of the precedent
     val inner = pS match {
-      case SCSubproof(_, _, _) =>
+      case SCSubproof(_, _) =>
         SCProof(
           hypothesis.toIndexedSeq ++ rewrites.toIndexedSeq ++ IndexedSeq(
             mapStep(
@@ -275,6 +275,7 @@ case class ProofUnconditionalizer(prOrig: SCProof) extends ProofTransformer(prOr
    */
   protected def mapStep(pS: SCProofStep, f: Set[Formula] => Set[Formula], fi: Seq[Int] => Seq[Int] = identity, fsub: Seq[Sequent] = Nil): SCProofStep = pS match {
     case Rewrite(bot, t1) => Rewrite(f(bot.left) |- bot.right, fi(pS.premises).head)
+    case RewriteTrue(bot) => RewriteTrue(f(bot.left) |- bot.right)
     case Hypothesis(bot, phi) => Hypothesis(f(bot.left) |- bot.right, phi)
     case Cut(bot, t1, t2, phi) => Cut(f(bot.left) |- bot.right, fi(pS.premises).head, fi(pS.premises).last, phi)
     case LeftAnd(bot, t1, phi, psi) => LeftAnd(f(bot.left) |- bot.right, fi(pS.premises).head, phi, psi)
@@ -302,8 +303,8 @@ case class ProofUnconditionalizer(prOrig: SCProof) extends ProofTransformer(prOr
     case RightSubstIff(bot, t1, equals, lambdaPhi) => RightSubstIff(f(bot.left) |- bot.right, fi(pS.premises).head, equals, lambdaPhi)
     case InstFunSchema(bot, t1, insts) => InstFunSchema(instantiateFunctionSchemaInSequent(f(bot.left) |- bot.right, insts).left |- bot.right, fi(pS.premises).head, insts)
     case InstPredSchema(bot, t1, insts) => InstPredSchema(instantiatePredicateSchemaInSequent(f(bot.left) |- bot.right, insts).left |- bot.right, fi(pS.premises).head, insts)
-    case SCSubproof(pp, t, b) => {
-      SCSubproof(ProofUnconditionalizer(pp).transformPrivate(fsub.toIndexedSeq ++ t.filter(_ >= 0).map(i => appended_steps(i).bot).toIndexedSeq), fi(t), b)
+    case SCSubproof(pp, t) => {
+      SCSubproof(ProofUnconditionalizer(pp).transformPrivate(fsub.toIndexedSeq ++ t.filter(_ >= 0).map(i => appended_steps(i).bot).toIndexedSeq), fi(t))
     }
   }
 


### PR DESCRIPTION
Solving issues https://github.com/epfl-lara/lisa/issues/74 and https://github.com/epfl-lara/lisa/issues/80

removing the display parameters from subproof as suggested by @cache-nez. Add back the missing case of RewriteTrue in the printer, which was lost in some PR.