### PR TITLE
Proof checking at the level of tactics

### DIFF
--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -15,13 +15,23 @@ import lisa.utils.tactics.ProofTacticLib.{_, given}
 object BasicStepTactic {
 
   object Hypothesis extends ProofTactic with ParameterlessHave {
-    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.Hypothesis(bot, bot.left.intersect(bot.right).head)), Seq())
+    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement = {
+      val intersectedPivot = bot.left.intersect(bot.right)
+
+      if (intersectedPivot.isEmpty)
+        proof.InvalidProofTactic("A formula for input to Hypothesis could not be inferred from left and right side of the sequent.")
+      else
+        proof.ValidProofTactic(Seq(SC.Hypothesis(bot, intersectedPivot.head)), Seq())
+    }
   }
 
   object Rewrite extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
+    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      if (!SC.isSameSequent(bot, proof.getSequent(premise)))
+        proof.InvalidProofTactic("The premise and the conclusion are not trivially equivalent.")
+      else
+        proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
+    }
   }
 
   /**
@@ -32,23 +42,36 @@ object BasicStepTactic {
    * </pre>
    */
   object Cut extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.Cut(bot, -1, -2, phi)), Seq(prem1, prem2))
+    def withParameters(using proof: Library#Proof)(phi: Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val leftSequent = proof.getSequent(prem1)
+      lazy val rightSequent = proof.getSequent(prem2)
+
+      if (!contains(leftSequent.right, phi))
+        proof.InvalidProofTactic("Right-hand side of first premise does not contain φ as claimed.")
+      else if (!contains(rightSequent.left, phi))
+        proof.InvalidProofTactic("Left-hand side of second premise does not contain φ as claimed.")
+      else if (!isSameSet(bot.left, leftSequent.left ++ rightSequent.left.filterNot(isSame(_, phi))))
+        proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the union of the left-hand sides of the premises.")
+      else if (!isSameSet(bot.right, leftSequent.right.filterNot(isSame(_, phi)) ++ rightSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the union of the right-hand sides of the premises.")
+      else
+        proof.ValidProofTactic(Seq(SC.Cut(bot, -1, -2, phi)), Seq(prem1, prem2))
+    }
 
     def apply(using proof: Library#Proof)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val leftSequent = proof.getSequent(prem1)
-      val rightSequent = proof.getSequent(prem2)
-      val cutSet = rightSequent.left.diff(bot.left) ++ leftSequent.right.diff(bot.right)
+      lazy val leftSequent = proof.getSequent(prem1)
+      lazy val rightSequent = proof.getSequent(prem2)
+      lazy val cutSet = rightSequent.left.diff(bot.left) ++ leftSequent.right.diff(bot.right)
       lazy val intersectedCutSet = rightSequent.left & leftSequent.right
 
-      if (cutSet.nonEmpty)
-        if (cutSet.tail.isEmpty) {
-          proof.ValidProofTactic(Seq(SC.Cut(bot, -1, -2, cutSet.head)), Seq(prem1, prem2))
-        } else
+      if (!cutSet.isEmpty)
+        if (cutSet.tail.isEmpty)
+          Cut.withParameters(cutSet.head)(prem1, prem2)(bot)
+        else
           proof.InvalidProofTactic("Inferred cut pivot is not a singleton set.")
-      else if (intersectedCutSet.nonEmpty && intersectedCutSet.tail.isEmpty)
+      else if (!intersectedCutSet.isEmpty && intersectedCutSet.tail.isEmpty)
         // can still find a pivot
-        proof.ValidProofTactic(Seq(SC.Cut(bot, -1, -2, intersectedCutSet.head)), Seq(prem1, prem2))
+        Cut.withParameters(intersectedCutSet.head)(prem1, prem2)(bot)
       else
         proof.InvalidProofTactic("A consistent cut pivot cannot be inferred from the premises. Possibly a missing or extraneous clause.")
     }
@@ -63,27 +86,41 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftAnd extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(phi: Formula, psi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftAnd(bot, -1, phi, psi)), Seq(premise))
-    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = bot.left.diff(premiseSequent.left)
+    def withParameters(using proof: Library#Proof)(phi: Formula, psi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val phiAndPsi = ConnectorFormula(And, Seq(phi, psi))
 
-      if (pivot.nonEmpty && pivot.tail.isEmpty)
+      if (!isSameSet(bot.right, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of the conclusion is not the same as the right-hand side of the premise.")
+      else if (
+        !isSameSet(bot.left + phi, premiseSequent.left + phiAndPsi) &&
+        !isSameSet(bot.left + psi, premiseSequent.left + phiAndPsi) &&
+        !isSameSet(bot.left + phi + psi, premiseSequent.left + phiAndPsi)
+      )
+        proof.InvalidProofTactic("Left-hand side of premise + φ∧ψ is not the same as left-hand side of conclusion + either φ, ψ or both.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftAnd(bot, -1, phi, psi)), Seq(premise))
+    }
+
+    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = bot.left.diff(premiseSequent.left)
+
+      if (!pivot.isEmpty && pivot.tail.isEmpty)
         pivot.head match {
           case ConnectorFormula(And, Seq(phi, psi)) =>
             if (premiseSequent.left.contains(phi))
-              proof.ValidProofTactic(Seq(SC.LeftAnd(bot, -1, phi, psi)), Seq(premise))
+              LeftAnd.withParameters(phi, psi)(premise)(bot)
             else
-              proof.ValidProofTactic(Seq(SC.LeftAnd(bot, -1, psi, phi)), Seq(premise))
+              LeftAnd.withParameters(phi, psi)(premise)(bot)
           case _ => proof.InvalidProofTactic("Could not infer a conjunction as pivot from premise and conclusion.")
         }
       else
       // try a rewrite, if it works, go ahead with it, otherwise malformed
       if (SC.isSameSequent(premiseSequent, bot))
-        proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
+        Rewrite(premise)(bot)
       else
-        proof.InvalidProofTactic("Left-hand side of conclusion + φ∧ψ must be same as left-hand side of premise + either φ, ψ or both.")
+        proof.InvalidProofTactic("Left-hand side of premise + φ∧ψ is not the same as left-hand side of conclusion + either φ, ψ or both.")
     }
   }
 
@@ -95,16 +132,31 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftOr extends ProofTactic {
-    def apply(using proof: Library#Proof)(phis: Formula*)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftOr(bot, Range(-1, -premises.length - 1, -1), phis)), premises.toSeq)
-    def apply(using proof: Library#Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequents = premises.map(proof.getSequent)
-      val pivots = premiseSequents.map(_.left.diff(bot.left))
+    def withParameters(using proof: Library#Proof)(disjuncts: Formula*)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequents = premises.map(proof.getSequent(_))
+      lazy val disjunction = ConnectorFormula(Or, disjuncts)
 
-      if (pivots.exists(_.isEmpty))
-        proof.ValidProofTactic(Seq(SC.Weakening(bot, pivots.indexWhere(_.isEmpty))), premises.toSeq)
+      if (premises.length == 0)
+        proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
+      else if (!isSameSet(bot.right, premiseSequents.map(_.right).reduce(_ union _)))
+        proof.InvalidProofTactic("Right-hand side of conclusion is not the union of the right-hand sides of the premises.")
+      else if (!isSameSet(disjuncts.foldLeft(bot.left)(_ + _), premiseSequents.map(_.left).reduce(_ union _) + disjunction))
+        proof.InvalidProofTactic("Left-hand side of conclusion + disjuncts is not the same as the union of the left-hand sides of the premises + φ∨ψ.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftOr(bot, Range(-1, -premises.length - 1, -1), disjuncts)), premises.toSeq)
+    }
+
+    def apply(using proof: Library#Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequents = premises.map(proof.getSequent(_))
+      lazy val pivots = premiseSequents.map(_.left.diff(bot.left))
+
+      if (premises.length == 0)
+        proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
+      else if (pivots.exists(_.isEmpty))
+        // the check is implicitly done!
+        proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premises(pivots.indexWhere(_.isEmpty))))
       else if (pivots.forall(_.tail.isEmpty))
-        proof.ValidProofTactic(Seq(SC.LeftOr(bot, Range(-1, -premises.length - 1, -1), pivots.map(_.head))), premises.toSeq)
+        LeftOr.withParameters(pivots.map(_.head) : _*)(premises : _*)(bot)
       else
         // some extraneous formulae
         proof.InvalidProofTactic("Left-hand side of conclusion + disjuncts is not the same as the union of the left-hand sides of the premises + φ∨ψ.")
@@ -119,20 +171,30 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftImplies extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: Formula, psi: Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftImplies(bot, -1, -2, phi, psi)), Seq(prem1, prem2))
+    def withParameters(using proof: Library#Proof)(phi: Formula, psi: Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val leftSequent = proof.getSequent(prem1)
+      lazy val rightSequent = proof.getSequent(prem2)
+      lazy val implication = ConnectorFormula(Implies, Seq(phi, psi))
+
+      if (!isSameSet(bot.right + phi, leftSequent.right union rightSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the union of right-hand sides of premises.")
+      else if (!isSameSet(bot.left + psi, leftSequent.left union rightSequent.left + implication))
+        proof.InvalidProofTactic("Left-hand side of conclusion + ψ is not the union of left-hand sides of premises + φ→ψ.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftImplies(bot, -1, -2, phi, psi)), Seq(prem1, prem2))
+    }
     def apply(using proof: Library#Proof)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val leftSequent = proof.getSequent(prem1)
-      val rightSequent = proof.getSequent(prem2)
-      val pivotLeft = leftSequent.right.diff(bot.right)
+      lazy val leftSequent = proof.getSequent(prem1)
+      lazy val rightSequent = proof.getSequent(prem2)
+      lazy val pivotLeft = leftSequent.right.diff(bot.right)
       lazy val pivotRight = rightSequent.left.diff(bot.left)
 
       if (pivotLeft.isEmpty)
-        proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(prem1, prem2))
+        proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(prem1))
       else if (pivotRight.isEmpty)
-        proof.ValidProofTactic(Seq(SC.Weakening(bot, -2)), Seq(prem1, prem2))
+        proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(prem2))
       else if (pivotLeft.tail.isEmpty && pivotRight.tail.isEmpty)
-        proof.ValidProofTactic(Seq(SC.LeftImplies(bot, -1, -2, pivotLeft.head, pivotRight.head)), Seq(prem1, prem2))
+        LeftImplies.withParameters(pivotLeft.head, pivotRight.head)(prem1, prem2)(bot)
       else
         proof.InvalidProofTactic("Could not infer an implication as a pivot from the premises and conclusion, possible extraneous formulae in premises.")
     }
@@ -146,18 +208,33 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftIff extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(phi: Formula, psi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftIff(bot, -1, phi, psi)), Seq(premise))
+    def withParameters(using proof: Library#Proof)(phi: Formula, psi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val implication = ConnectorFormula(Iff, Seq(phi, psi))
+      lazy val impLeft = ConnectorFormula(Implies, Seq(phi, psi))
+      lazy val impRight = ConnectorFormula(Implies, Seq(psi, phi))
+
+      if (!isSameSet(bot.right, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of premise is not the same as right-hand side of conclusion.")
+      else if (
+        !isSameSet(bot.left + impLeft, premiseSequent.left + implication) &&
+        !isSameSet(bot.left + impRight, premiseSequent.left + implication) &&
+        !isSameSet(bot.left + impLeft + impRight, premiseSequent.left + implication)
+      )
+        proof.InvalidProofTactic("Left-hand side of premise + φ↔ψ is not the same as left-hand side of conclusion + either φ→ψ, ψ→φ or both.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftIff(bot, -1, phi, psi)), Seq(premise))
+    }
 
     def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = premiseSequent.left.diff(bot.left)
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = premiseSequent.left.diff(bot.left)
 
       if (pivot.isEmpty)
         proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premise))
       else
         pivot.head match {
-          case ConnectorFormula(Implies, Seq(phi, psi)) => proof.ValidProofTactic(Seq(SC.LeftIff(bot, -1, phi, psi)), Seq(premise))
+          case ConnectorFormula(Implies, Seq(phi, psi)) => LeftIff.withParameters(phi, psi)(premise)(bot)
           case _ => proof.InvalidProofTactic("Could not infer a pivot implication from premise.")
         }
     }
@@ -171,18 +248,27 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftNot extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(phi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftNot(bot, -1, phi)), Seq(premise))
+    def withParameters(using proof: Library#Proof)(phi: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val negation = ConnectorFormula(Neg, Seq(phi))
+
+      if (!isSameSet(bot.right + phi, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the same as right-hand side of premise.")
+      else if (!isSameSet(bot.left, premiseSequent.left + negation))
+        proof.InvalidProofTactic("Left-hand side of conclusion is not the same as left-hand side of premise + ¬φ.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftNot(bot, -1, phi)), Seq(premise))
+    }
     def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = premiseSequent.right.diff(bot.right)
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = premiseSequent.right.diff(bot.right)
 
       if (pivot.isEmpty)
         proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premise))
       else if (pivot.tail.isEmpty)
-        proof.ValidProofTactic(Seq(SC.LeftNot(bot, -1, pivot.head)), Seq(premise))
+        LeftNot.withParameters(pivot.head)(premise)(bot)
       else
-        proof.InvalidProofTactic("Right-hand side of conclusion + φ must be the same as right-hand side of premise.")
+        proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the same as right-hand side of premise.")
 
     }
   }
@@ -196,22 +282,32 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftForall extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: Formula, x: VariableLabel, t: Term)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftForall(bot, -1, phi, x, t)), Seq(premise))
+    def withParameters(using proof: Library#Proof)(phi: Formula, x: VariableLabel, t: Term)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val quantified = BinderFormula(Forall, x, phi)
+      lazy val instantiated = substituteVariables(phi, Map(x -> t))
+
+      if (!isSameSet(bot.right, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion is not the same as right-hand side of premise")
+      else if (!isSameSet(bot.left + instantiated, premiseSequent.left + quantified))
+        proof.InvalidProofTactic("Left-hand side of conclusion + φ[t/x] is not the same as left-hand side of premise + ∀x. φ")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftForall(bot, -1, phi, x, t)), Seq(premise))
+    }
 
     def apply(using proof: Library#Proof)(t: Term)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = bot.left.diff(premiseSequent.left)
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = bot.left.diff(premiseSequent.left)
       lazy val instantiatedPivot = premiseSequent.left.diff(bot.left)
 
-      if (pivot.nonEmpty)
+      if (!pivot.isEmpty)
         if (pivot.tail.isEmpty)
           pivot.head match {
-            case BinderFormula(Forall, x, phi) => proof.ValidProofTactic(Seq(SC.LeftForall(bot, -1, phi, x, t)), Seq(premise))
+            case BinderFormula(Forall, x, phi) => LeftForall.withParameters(phi, x, t)(premise)(bot)
             case _ => proof.InvalidProofTactic("Could not infer a universally quantified pivot from premise and conclusion.")
           }
         else
-          proof.InvalidProofTactic("Left-hand side of conclusion + φ[t/x] must be the same as left-hand side of premise + ∀x. φ.")
+          proof.InvalidProofTactic("Left-hand side of conclusion + φ[t/x] is not the same as left-hand side of premise + ∀x. φ.")
       else if (instantiatedPivot.isEmpty) proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premise))
       else if (instantiatedPivot.tail.isEmpty) {
         // go through conclusion to find a matching quantified formula
@@ -225,10 +321,10 @@ object BasicStepTactic {
         )
 
         quantifiedPhi match {
-          case Some(BinderFormula(Forall, x, phi)) => proof.ValidProofTactic(Seq(SC.LeftForall(bot, -1, phi, x, t)), Seq(premise))
+          case Some(BinderFormula(Forall, x, phi)) => LeftForall.withParameters(phi, x, t)(premise)(bot)
           case _ => proof.InvalidProofTactic("Could not infer a universally quantified pivot from premise and conclusion.")
         }
-      } else proof.InvalidProofTactic("Left-hand side of conclusion + φ[t/x] must be the same as left-hand side of premise + ∀x. φ.")
+      } else proof.InvalidProofTactic("Left-hand side of conclusion + φ[t/x] is not the same as left-hand side of premise + ∀x. φ.")
     }
   }
 
@@ -241,13 +337,25 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftExists extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(phi: Formula, x: VariableLabel)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftExists(bot, -1, phi, x)), Seq(premise))
+    def withParameters(using proof: Library#Proof)(phi: Formula, x: VariableLabel)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val quantified = BinderFormula(Exists, x, phi)
+
+      if ((bot.left union bot.right).exists(_.freeVariables.contains(x)))
+        proof.InvalidProofTactic("The variable x must not be free in the resulting sequent.")
+      else if (!isSameSet(bot.right, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion is not the same as right-hand side of premise")
+      else if (!isSameSet(bot.left + phi, premiseSequent.left + quantified))
+        proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the same as left-hand side of premise + ∃x. φ")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftExists(bot, -1, phi, x)), Seq(premise))
+    }
 
     def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = bot.left.diff(premiseSequent.left)
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = bot.left.diff(premiseSequent.left)
       lazy val instantiatedPivot = premiseSequent.left.diff(bot.left)
+
       if (pivot.isEmpty)
         if (instantiatedPivot.isEmpty) proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
         else if (instantiatedPivot.tail.isEmpty) {
@@ -260,17 +368,17 @@ object BasicStepTactic {
           )
 
           quantifiedPhi match {
-            case Some(BinderFormula(Exists, x, phi)) => proof.ValidProofTactic(Seq(SC.LeftExists(bot, -1, phi, x)), Seq(premise))
+            case Some(BinderFormula(Exists, x, phi)) => LeftExists.withParameters(phi, x)(premise)(bot)
             case _ => proof.InvalidProofTactic("Could not infer an existensially quantified pivot from premise and conclusion.")
           }
-        } else proof.InvalidProofTactic("Left-hand side of conclusion + φ must be the same as left-hand side of premise + ∃x. φ.")
+        } else proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the same as left-hand side of premise + ∃x. φ.")
       else if (pivot.tail.isEmpty)
         pivot.head match {
-          case BinderFormula(Exists, x, phi) => proof.ValidProofTactic(Seq(SC.LeftExists(bot, -1, phi, x)), Seq(premise))
+          case BinderFormula(Exists, x, phi) => LeftExists.withParameters(phi, x)(premise)(bot)
           case _ => proof.InvalidProofTactic("Could not infer an existentially quantified pivot from premise and conclusion.")
         }
       else
-        proof.InvalidProofTactic("Left-hand side of conclusion + φ must be the same as left-hand side of premise + ∃x. φ.")
+        proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the same as left-hand side of premise + ∃x. φ.")
     }
   }
 
@@ -282,12 +390,23 @@ object BasicStepTactic {
    * </pre>
    */
   object LeftExistsOne extends ProofTactic with ParameterlessAndThen {
-    def apply(using proof: Library#Proof)(phi: Formula, x: VariableLabel)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.LeftExistsOne(bot, -1, phi, x)), Seq(premise))
+    def withParameters(using proof: Library#Proof)(phi: Formula, x: VariableLabel)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val y = VariableLabel(freshId(phi.freeVariables.map(_.id) + x.id, "y"))
+      lazy val instantiated = BinderFormula(Exists, y, BinderFormula(Forall, x, ConnectorFormula(Iff, List(PredicateFormula(equality, List(VariableTerm(x), VariableTerm(y))), phi))))
+      lazy val quantified = BinderFormula(ExistsOne, x, phi)
+
+      if (!isSameSet(bot.right, premiseSequent.right))
+        proof.InvalidProofTactic("Right-hand side of conclusion is not the same as right-hand side of premise.")
+      else if (!isSameSet(bot.left + instantiated, premiseSequent.left + quantified))
+        proof.InvalidProofTactic("Left-hand side of conclusion + ∃y.∀x. (x=y) ↔ φ is not the same as left-hand side of premise + ∃!x. φ.")
+      else
+        proof.ValidProofTactic(Seq(SC.LeftExistsOne(bot, -1, phi, x)), Seq(premise))
+    }
 
     def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-      val premiseSequent = proof.getSequent(premise)
-      val pivot = bot.left.diff(premiseSequent.left)
+      lazy val premiseSequent = proof.getSequent(premise)
+      lazy val pivot = bot.left.diff(premiseSequent.left)
       lazy val instantiatedPivot = premiseSequent.left.diff(bot.left)
 
       if (pivot.isEmpty)
@@ -296,19 +415,18 @@ object BasicStepTactic {
         else if (instantiatedPivot.tail.isEmpty) {
           instantiatedPivot.head match {
             // ∃_. ∀x. _ ↔ φ == extract ==> x, phi
-            case BinderFormula(Exists, _, BinderFormula(Forall, x, ConnectorFormula(Iff, Seq(_, phi)))) =>
-              proof.ValidProofTactic(Seq(SC.LeftExistsOne(bot, -1, phi, x)), Seq(premise))
+            case BinderFormula(Exists, _, BinderFormula(Forall, x, ConnectorFormula(Iff, Seq(_, phi)))) => LeftExistsOne.withParameters(phi, x)(premise)(bot)
             case _ => proof.InvalidProofTactic("Could not infer an existentially quantified pivot from premise and conclusion.")
           }
         } else
-          proof.InvalidProofTactic("Left-hand side of conclusion + φ must be the same as left-hand side of premise + ∃x. φ.")
+          proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the same as left-hand side of premise + ∃x. φ.")
       else if (pivot.tail.isEmpty)
         pivot.head match {
-          case BinderFormula(ExistsOne, x, phi) => proof.ValidProofTactic(Seq(SC.LeftExistsOne(bot, -1, phi, x)), Seq(premise))
+          case BinderFormula(ExistsOne, x, phi) => LeftExistsOne.withParameters(phi, x)(premise)(bot)
           case _ => proof.InvalidProofTactic("Could not infer an existentially quantified pivot from premise and conclusion.")
         }
       else
-        proof.InvalidProofTactic("Left-hand side of conclusion + φ must be the same as left-hand side of premise + ∃x. φ.")
+        proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the same as left-hand side of premise + ∃x. φ.")
     }
   }
 

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -156,7 +156,7 @@ object BasicStepTactic {
         // the check is implicitly done!
         proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premises(pivots.indexWhere(_.isEmpty))))
       else if (pivots.forall(_.tail.isEmpty))
-        LeftOr.withParameters(pivots.map(_.head) : _*)(premises : _*)(bot)
+        LeftOr.withParameters(pivots.map(_.head): _*)(premises: _*)(bot)
       else
         // some extraneous formulae
         proof.InvalidProofTactic("Left-hand side of conclusion + disjuncts is not the same as the union of the left-hand sides of the premises + φ∨ψ.")

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
@@ -25,9 +25,6 @@ object SimpleDeducedSteps {
     def apply(using proof: Library#Proof)(premise: proof.ProofStep | proof.OutsideFact | Int)(bot: Sequent): proof.ProofTacticJudgement =
       proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
 
-    def apply2(using proof: Library#Proof)(premise: proof.ProofStep | proof.OutsideFact | Int)(bot: Sequent): proof.ProofTacticJudgement =
-      proof.ValidProofTactic(Seq(SC.Rewrite(bot, -1)), Seq(premise))
-
   }
 
   object Discharge extends ProofTactic {
@@ -74,8 +71,6 @@ object SimpleDeducedSteps {
       } else {
         val emptyProof = SCProof(IndexedSeq(), IndexedSeq(proof.getSequent(-1)))
         val j = proof.ValidProofTactic(Seq(SC.Rewrite(premiseSequent, -1)), Seq(premise))
-        // some unfortunate code reuse
-        // ProofStep tactics cannot be composed easily at the moment
         val res = t.foldLeft((emptyProof, phi, j: proof.ProofTacticJudgement)) { case ((p, f, j), t) =>
           j match {
             case proof.InvalidProofTactic(_) => (p, f, j) // propagate error
@@ -148,9 +143,6 @@ object SimpleDeducedSteps {
    */
   object PartialCut extends ProofTactic {
     def apply(using proof: Library#Proof)(phi: FOL.Formula, conjunction: FOL.Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
-
-      def invalid(message: String) = proof.InvalidProofTactic(message)
-
       val leftSequent = proof.getSequent(prem1)
       val rightSequent = proof.getSequent(prem2)
 
@@ -203,16 +195,16 @@ object SimpleDeducedSteps {
 
                 proof.ValidProofTactic(IndexedSeq(p0, p1, p2, p3, p4), Seq(prem1, prem2))
               } else {
-                invalid("Input conjunction does not contain the pivot.")
+                proof.InvalidProofTactic("Input conjunction does not contain the pivot.")
               }
             }
-            case _ => invalid("Input not a conjunction.")
+            case _ => proof.InvalidProofTactic("Input not a conjunction.")
           }
         } else {
-          invalid("Input pivot formula not found in right premise.")
+          proof.InvalidProofTactic("Input pivot formula not found in right premise.")
         }
       } else {
-        invalid("Input conjunction not found in first premise.")
+        proof.InvalidProofTactic("Input conjunction not found in first premise.")
       }
     }
   }


### PR DESCRIPTION
Replicating proof checking at the level of construction of `DoubleStep` based proofs. **Supersedes #93 following changes in #99.**

- [implementation] the checks for fully parametrized versions of steps replicate checks from `SCProofChecker`
     - Except in the case of `SUBPROOF`, which implements its own exception-based checking.
- [implementation] where possible, unparameterized versions defer checking by calling the parametrized versions, to centralize checking for a given proof step
- [documentation] error messages have been uniformized in tone and speech patterns where spotted. I have opted for active instead of passive tones wherever applicable, `"x is not y"` instead of `"x must be y"`. Previously, both existed simultaneously. 
- [bug] problems with overload resolution (#100) by removing overloaded instances of `apply` within proof tactics, which are instead replaced with `apply` for the parameterles versions, and `(...).withParameters()` for the explicit version where necessary.

Status:
- :heavy_check_mark: Left propositional rules
- :heavy_check_mark: Right propositional rules
- :heavy_check_mark: Reflexivity rules
- :heavy_check_mark: Substitution rules
- :heavy_check_mark: Instantiation rules
- :heavy_check_mark: Printing abstracted proofs with errors (#85) (Solved with #99)