### PR TITLE
Support infix functions and predicates with user-defined priorities

### DIFF
--- a/lisa-front/src/main/scala/lisa/front/proof/state/ProofEnvironmentDefinitions.scala
+++ b/lisa-front/src/main/scala/lisa/front/proof/state/ProofEnvironmentDefinitions.scala
@@ -7,7 +7,7 @@ import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SCProofChecker
 import lisa.kernel.proof.SequentCalculus.SCSubproof
 import lisa.kernel.proof.SequentCalculus.sequentToFormula
-import lisa.utils.Printer
+import lisa.utils.FOLPrinter
 import lisa.utils.ProofsShrink
 
 trait ProofEnvironmentDefinitions extends ProofStateDefinitions {
@@ -62,7 +62,7 @@ trait ProofEnvironmentDefinitions extends ProofStateDefinitions {
           Seq(
             "Error: the theorem was found to produce an invalid proof; this could indicate a problem with a tactic or a bug in the implementation",
             "The produced proof is shown below for reference:",
-            Printer.prettySCProof(judgement)
+            FOLPrinter.prettySCProof(judgement)
           ).mkString("\n")
         )
       }
@@ -211,7 +211,7 @@ trait ProofEnvironmentDefinitions extends ProofStateDefinitions {
         Seq(
           "Error: the reconstructed proof was found to be invalid; this could indicate a bug in the implementation of this very method",
           "The reconstructed proof is shown below for reference:",
-          Printer.prettySCProof(judgement)
+          FOLPrinter.prettySCProof(judgement)
         ).mkString("\n")
       )
     }

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -6,9 +6,7 @@ import lisa.kernel.proof.RunningTheoryJudgement.InvalidJustification
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SCProofCheckerJudgement.SCInvalidProof
 import lisa.kernel.proof.SequentCalculus.*
-import lisa.utils.Parser.parseFormula
-import lisa.utils.Parser.parseSequent
-import lisa.utils.Parser.parseTerm
+import lisa.utils.FOLParser
 
 /**
  * A helper file that provides various syntactic sugars for LISA's FOL and proofs. Best imported through utilities.Helpers
@@ -177,26 +175,19 @@ trait KernelHelpers {
     def followPath(path: Seq[Int]): SCProofStep = SCSubproof(p, p.imports.indices).followPath(path)
   }
 
-  extension (judgement: SCInvalidProof) {
-    def errorMsg: String =
-      s"""Failed to prove
-         |${lisa.utils.Printer.prettySequent(judgement.proof.followPath(judgement.path).bot)}
-         |(step ${judgement.path.mkString("->")}): ${judgement.message}""".stripMargin
-  }
-
   implicit class Parsing(val sc: StringContext) {
 
-    def seq(args: Any*): Sequent = parseSequent(sc.parts.mkString(""))
+    def seq(args: Any*): Sequent = FOLParser.parseSequent(sc.parts.mkString(""))
 
-    def f(args: Any*): Formula = parseFormula(sc.parts.mkString(""))
+    def f(args: Any*): Formula = FOLParser.parseFormula(sc.parts.mkString(""))
 
-    def t(args: Any*): Term = parseTerm(sc.parts.mkString(""))
+    def t(args: Any*): Term = FOLParser.parseTerm(sc.parts.mkString(""))
 
   }
 
-  given Conversion[String, Sequent] = parseSequent(_)
-  given Conversion[String, Formula] = parseFormula(_)
-  given Conversion[String, Term] = parseTerm(_)
+  given Conversion[String, Sequent] = FOLParser.parseSequent(_)
+  given Conversion[String, Formula] = FOLParser.parseFormula(_)
+  given Conversion[String, Term] = FOLParser.parseTerm(_)
   given Conversion[String, VariableLabel] = s => VariableLabel(if (s.head == '?') s.tail else s)
 
   def lambda(x: VariableLabel, t: Term) = LambdaTermTerm(Seq(x), t)

--- a/lisa-utils/src/main/scala/lisa/utils/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Library.scala
@@ -79,7 +79,7 @@ abstract class Library(val theory: RunningTheory) extends lisa.utils.tactics.Wit
      * Syntax: <pre> THEOREM("name") of "the sequent concluding the proof" PROOF { the proof } using (assumptions) </pre>
      */
     infix def of(statement: Sequent): TheoremNameWithStatement = TheoremNameWithStatement(name, statement)
-    infix def of(statement: String): TheoremNameWithStatement = TheoremNameWithStatement(name, Parser.parseSequent(statement))
+    infix def of(statement: String): TheoremNameWithStatement = TheoremNameWithStatement(name, FOLParser.parseSequent(statement))
   }
 
   /**

--- a/lisa-utils/src/main/scala/lisa/utils/LisaException.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/LisaException.scala
@@ -16,7 +16,7 @@ object LisaException {
     def showError: String = "Construction of proof succedded, but the resulting proof or definition has been reported to be faulty. This may be due to an internal bug.\n" +
       "The resulting fauly proof is:\n" +
       s"$underlying.message\n${underlying.error match {
-          case Some(judgement) => Printer.prettySCProof(judgement)
+          case Some(judgement) => FOLPrinter.prettySCProof(judgement)
           case None => ""
         }}"
   }

--- a/lisa-utils/src/main/scala/lisa/utils/Parser.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Parser.scala
@@ -36,8 +36,8 @@ object Parser {
    */
   def getInternalName(id: String): String = SynonymToCanonical.get(id).map(_.internal).getOrElse(id)
   /////////////////////////////////////////////////////////////////////////////////////////////////
-  // TODO: support more infix predicates, potentially determine if a predicate is infix without listing all infix ones
-  def isInfixPredicate(id: String): Boolean = Set("=", "∊", "⊂", "⊆").contains(id)
+  // TODO: support more infix ops, potentially determine if an op is infix without listing all infix ones
+  def isInfix(id: String): Boolean = Set("=", "∊", "⊂", "⊆", "+", "<").contains(id)
 
   class ParserException(msg: String) extends Exception(msg)
   object UnreachableException extends ParserException("Internal error: expected unreachable")
@@ -160,7 +160,7 @@ object Parser {
 
     case object FalseToken extends FormulaToken("⊥")
 
-    case class InfixPredicateToken(id: String) extends FormulaToken(id)
+    case class InfixToken(id: String) extends FormulaToken(id)
 
     // Constant functions and predicates
     case class ConstantToken(id: String) extends FormulaToken(id)
@@ -235,7 +235,7 @@ object Parser {
       lexer(source)
         .filter(_ != SpaceToken)
         .map({
-          case ConstantToken(id) if isInfixPredicate(id) => InfixPredicateToken(id)
+          case ConstantToken(id) if isInfix(id) => InfixToken(id)
           case t => t
         })
     }
@@ -255,11 +255,72 @@ object Parser {
               // space after: separators
               case DotToken | CommaToken | SemicolonToken => l :+ t.toString :+ space
               // space before and after: equality, connectors, sequent symbol
-              case InfixPredicateToken(_) | AndToken | OrToken | ImpliesToken | IffToken | SequentToken => l :+ space :+ t.toString :+ space
+              case InfixToken(_) | AndToken | OrToken | ImpliesToken | IffToken | SequentToken => l :+ space :+ t.toString :+ space
             }
         }
         .mkString
     }
+  }
+
+  /**
+   * Termula represents parser-level union of terms and formulas.
+   * After parsing, the termula can be converted either to a term or to a formula:
+   * <p> - to be converted to a term, termula must consist only of function applications;
+   * <p> - to be converted to a formula, `args` of the termula are interpreted as formulas until a predicate application is observed;
+   * `args` of the predicate application are terms.
+   *
+   * <p> Convention: since the difference between `TermLabel`s and `PredicateLabel`s is purely semantic and Termula needs
+   * FormulaLabels (because of connector and binder labels), all TermLabels are translated to the corresponding
+   * PredicateLabels (see [[toTermula]]).
+   *
+   * @param label `PredicateLabel` for predicates and functions, `ConnectorLabel` or `BinderLabel`
+   * @param args Predicate / function arguments for `PredicateLabel`, connected formulas for `ConnectorLabel`,
+   *             `Seq(VariableFormulaLabel(bound), inner)` for `BinderLabel`
+   */
+  case class Termula(label: FOL.FormulaLabel, args: Seq[Termula]) {
+    def toTerm: Term = label match {
+      case t: ConstantPredicateLabel => Term(ConstantFunctionLabel(t.id, t.arity), args.map(_.toTerm))
+      case t: SchematicPredicateLabel => Term(SchematicFunctionLabel(t.id, t.arity), args.map(_.toTerm))
+      case v: VariableFormulaLabel => Term(VariableLabel(v.id), Seq())
+      case _ => throw ParserException(s"Expected term, got $this")
+    }
+
+    def toFormula: Formula = label match {
+      case p: PredicateLabel => PredicateFormula(p, args.map(_.toTerm))
+      case c: ConnectorLabel => ConnectorFormula(c, args.map(_.toFormula))
+      case b: BinderLabel =>
+        args match {
+          case Seq(Termula(v: VariableFormulaLabel, Seq()), f) => BinderFormula(b, VariableLabel(v.id), f.toFormula)
+          case _ => throw ParserException(s"Wrong binder format: expected 2 arguments: bound VariableFormulaLabel and inner termula, got $args")
+        }
+    }
+  }
+
+  extension (f: Formula) {
+    def toTermula: Termula = f match {
+      case PredicateFormula(label, args) => Termula(label, args.map(_.toTermula))
+      case ConnectorFormula(label, args) => Termula(label, args.map(_.toTermula))
+      case BinderFormula(label, bound, inner) => Termula(label, Seq(Termula(VariableFormulaLabel(bound.id), Seq()), inner.toTermula))
+    }
+  }
+
+  extension (t: Term) {
+    def toTermula: Termula = {
+      val newLabel = t.label match {
+        case ConstantFunctionLabel(id, arity) => ConstantPredicateLabel(id, arity)
+        case SchematicFunctionLabel(id, arity) => SchematicPredicateLabel(id, arity)
+        case VariableLabel(id) => VariableFormulaLabel(id)
+      }
+      Termula(newLabel, t.args.map(_.toTermula))
+    }
+  }
+
+  case class TermulaSequent(left: Set[Termula], right: Set[Termula]) {
+    def toSequent: Sequent = Sequent(left.map(_.toFormula), right.map(_.toFormula))
+  }
+
+  extension (s: Sequent) {
+    def toTermulaSequent: TermulaSequent = TermulaSequent(s.left.map(_.toTermula), s.right.map(_.toTermula))
   }
 
   private[Parser] object SequentParser extends Parsers {
@@ -271,9 +332,9 @@ object Parser {
     case object TopLevelConnectorKind extends TokenKind
     case object NegationKind extends TokenKind
     case object BooleanConstantKind extends TokenKind
-    case object FunctionOrPredicateKind extends TokenKind
-    case object InfixPredicateKind extends TokenKind
     case object SchematicConnectorKind extends TokenKind
+    case object IdKind extends TokenKind
+    case object InfixKind extends TokenKind
     case object CommaKind extends TokenKind
     case class ParenthesisKind(isOpen: Boolean) extends TokenKind
     case object BinderKind extends TokenKind
@@ -295,9 +356,9 @@ object Parser {
       case IffToken | ImpliesToken => TopLevelConnectorKind
       case NegationToken => NegationKind
       case TrueToken | FalseToken => BooleanConstantKind
-      case _: ConstantToken | _: SchematicToken => FunctionOrPredicateKind
-      case _: InfixPredicateToken => InfixPredicateKind
       case _: SchematicConnectorToken => SchematicConnectorKind
+      case _: ConstantToken | _: SchematicToken => IdKind
+      case _: InfixToken => InfixKind
       case CommaToken => CommaKind
       case ParenthesisToken(isOpen) => ParenthesisKind(isOpen)
       case ExistsToken | ExistsOneToken | ForallToken => BinderKind
@@ -317,20 +378,6 @@ object Parser {
 
     val comma: Syntax[Unit] = elem(CommaKind).unit(CommaToken)
 
-    val INFIX_ARITY = 2
-    val infixPredicateLabel: Syntax[ConstantPredicateLabel] = accept(InfixPredicateKind)(
-      {
-        case InfixPredicateToken(id) => ConstantPredicateLabel(getInternalName(id), INFIX_ARITY)
-        case _ => throw UnreachableException
-      },
-      {
-        case ConstantPredicateLabel(id, INFIX_ARITY) if isInfixPredicate(getPrintName(id)) =>
-          val printName = getPrintName(id)
-          Seq(InfixPredicateToken(printName))
-        case _ => throw UnreachableException
-      }
-    )
-
     val semicolon: Syntax[Unit] = elem(SemicolonKind).unit(SemicolonToken)
 
     val sequentSymbol: Syntax[Unit] = elem(SequentSymbolKind).unit(SequentToken)
@@ -349,111 +396,100 @@ object Parser {
     )
 
     val negation: Syntax[Neg.type] = accept(NegationKind)({ case NegationToken => Neg }, { case Neg => Seq(NegationToken) })
-    ///////////////////////////////////////////////////////////////////
 
-    //////////////////////// TERMS ////////////////////////////////////
-    lazy val args: Syntax[Seq[Term]] = recursive(open.skip ~ repsep(term, comma) ~ closed.skip)
-
-    def invertTerm(t: Term): Token ~ Option[Seq[Term]] = t match {
-      case VariableTerm(label) => SchematicToken(label.id) ~ None
-      case Term(label, args) =>
-        val optArgs = args match {
-          case Seq() => None
-          case _ => Some(args)
-        }
-        label match {
-          case ConstantFunctionLabel(id, _) => ConstantToken(id) ~ optArgs
-          case SchematicFunctionLabel(id, _) => SchematicToken(id) ~ optArgs
-        }
-    }
-
-    lazy val term: Syntax[Term] = recursive(
-      (elem(FunctionOrPredicateKind) ~ opt(args)).map(
-        {
-          case ConstantToken(id) ~ maybeArgs =>
-            val args = maybeArgs.getOrElse(Seq())
-            Term(ConstantFunctionLabel(id, args.length), args)
-          case SchematicToken(id) ~ Some(args) => Term(SchematicFunctionLabel(id, args.length), args)
-          case SchematicToken(id) ~ None => VariableTerm(VariableLabel(id))
-          case _ => throw UnreachableException
-        },
-        t => Seq(invertTerm(t))
-      )
+    val INFIX_ARITY = 2
+    val infixLabel: Syntax[ConstantPredicateLabel] = accept(InfixKind)(
+      {
+        case InfixToken(id) => ConstantPredicateLabel(getInternalName(id), INFIX_ARITY)
+        case _ => throw UnreachableException
+      },
+      {
+        case ConstantPredicateLabel(id, INFIX_ARITY) if isInfix(getPrintName(id)) =>
+          val printName = getPrintName(id)
+          Seq(InfixToken(printName))
+        case _ => throw UnreachableException
+      }
     )
     ///////////////////////////////////////////////////////////////////
 
-    //////////////////////// FORMULAS /////////////////////////////////
+    //////////////////////// TERMULAS /////////////////////////////////
     // can appear without parentheses
-    lazy val simpleFormula: Syntax[Formula] = predicate.up[Formula] | negated.up[Formula] | bool.up[Formula] | schematicConnectorFormula.up[Formula]
-    lazy val subformula: Syntax[Formula] = simpleFormula | open.skip ~ formula ~ closed.skip
-
-    def createTerm(label: Token, args: Seq[Term]): Term = label match {
-      case ConstantToken(id) => Term(ConstantFunctionLabel(id, args.size), args)
-      case SchematicToken(id) =>
-        args match {
-          case Seq() => VariableTerm(VariableLabel(id))
-          case _ => Term(SchematicFunctionLabel(id, args.size), args)
+    lazy val simpleTermula: Syntax[Termula] = application | negated | bool | schematicConnectorFormula
+    lazy val subtermula: Syntax[Termula] = simpleTermula | startsWithParenthesis
+    lazy val startsWithParenthesis: Syntax[Termula] = recursive(
+      (open.skip ~ termula ~ closed.skip ~ opt(infixLabel ~ subtermula)).map(
+        {
+          case f ~ None => f
+          case f1 ~ Some(label ~ f2) => Termula(label, Seq(f1, f2))
+        },
+        {
+          case Termula(c @ ConstantPredicateLabel(id, INFIX_ARITY), Seq(f1, f2)) if isInfix(getPrintName(id)) => Seq(f1 ~ Some(c ~ f2))
+          case f => Seq(f ~ None)
         }
+      )
+    )
+
+    val bool: Syntax[Termula] = accept(BooleanConstantKind)(
+      {
+        case TrueToken => Termula(And, Seq())
+        case FalseToken => Termula(Or, Seq())
+      },
+      {
+        case Termula(And, Seq()) => Seq(TrueToken)
+        case Termula(Or, Seq()) => Seq(FalseToken)
+        case _ => throw UnreachableException
+      }
+    )
+
+    lazy val args: Syntax[Seq[Termula]] = recursive(open.skip ~ repsep(termula, comma) ~ closed.skip)
+
+    def reconstructPrefixApplication(t: Termula): Token ~ Option[Seq[Termula]] = t.label match {
+      case VariableFormulaLabel(id) => SchematicToken(id) ~ None
+      case SchematicPredicateLabel(id, _) => SchematicToken(id) ~ Some(t.args)
+      case ConstantPredicateLabel(id, arity) => ConstantToken(getPrintName(id)) ~ (if (arity == 0) None else Some(t.args))
       case _ => throw UnreachableException
     }
 
-    val bool: Syntax[ConnectorFormula] = accept(BooleanConstantKind)(
-      {
-        case TrueToken => ConnectorFormula(And, Seq())
-        case FalseToken => ConnectorFormula(Or, Seq())
+    val prefixApplication: Syntax[Termula] = (elem(IdKind) ~ opt(args)).map(
+      { case p ~ optArgs =>
+        val args = optArgs.getOrElse(Seq())
+        val l = p match {
+          case ConstantToken(id) => ConstantPredicateLabel(getInternalName(id), args.size)
+          case SchematicToken(id) =>
+            if (args.isEmpty) VariableFormulaLabel(id) else SchematicPredicateLabel(id, args.size)
+          case _ => throw UnreachableException
+        }
+        Termula(l, args)
       },
       {
-        case ConnectorFormula(And, Seq()) => Seq(TrueToken)
-        case ConnectorFormula(Or, Seq()) => Seq(FalseToken)
+        case t @ Termula(_: PredicateLabel, _) => Seq(reconstructPrefixApplication(t))
         case _ => throw UnreachableException
       }
     )
 
-    val predicate: Syntax[PredicateFormula] = (elem(FunctionOrPredicateKind) ~ opt(args) ~ opt(infixPredicateLabel ~ term)).map(
-      {
-        // predicate application
-        case ConstantToken(id) ~ maybeArgs ~ None =>
-          val args = maybeArgs.getOrElse(Seq())
-          PredicateFormula(ConstantPredicateLabel(getInternalName(id), args.size), args)
-        case SchematicToken(id) ~ Some(args) ~ None => PredicateFormula(SchematicPredicateLabel(getInternalName(id), args.size), args)
-        case SchematicToken(id) ~ None ~ None =>
-          PredicateFormula(VariableFormulaLabel(getInternalName(id)), Seq())
-
-        // infix relation of two function applications
-        case fun1 ~ args1 ~ Some(pred ~ term2) =>
-          PredicateFormula(pred, Seq(createTerm(fun1, args1.getOrElse(Seq())), term2))
-
-        case _ => throw UnreachableException
-      },
-      {
-        case PredicateFormula(label @ ConstantPredicateLabel(id, INFIX_ARITY), Seq(first, second)) if isInfixPredicate(getPrintName(id)) =>
-          Seq(invertTerm(first) ~ Some(label ~ second))
-        case PredicateFormula(label, args) =>
-          val printName = getPrintName(label.id)
-          if (isInfixPredicate(printName) && args.size == INFIX_ARITY) {
-            args match {
-              case Seq(first, second) => Seq(invertTerm(first) ~ Some(ConstantPredicateLabel(getPrintName(label.id), INFIX_ARITY) ~ second))
-              case _ => throw UnreachableException
-            }
-          } else {
-            val prefixApp = label match {
-              case VariableFormulaLabel(_) => SchematicToken(printName) ~ None
-              case SchematicPredicateLabel(_, _) => SchematicToken(printName) ~ Some(args)
-              case ConstantPredicateLabel(_, 0) => ConstantToken(printName) ~ None
-              case ConstantPredicateLabel(_, _) => ConstantToken(printName) ~ Some(args)
-            }
-            Seq(prefixApp ~ None)
+    lazy val application: Syntax[Termula] =
+      recursive(
+        (prefixApplication ~ opt(infixLabel ~ subtermula)).map(
+          {
+            case p ~ None => p
+            case p1 ~ Some(label ~ p2) => Termula(label, Seq(p1, p2))
+          },
+          {
+            case Termula(c @ ConstantPredicateLabel(id, INFIX_ARITY), Seq(f1 @ Termula(_: PredicateLabel, _), f2)) if isInfix(getPrintName(id)) =>
+              Seq(f1 ~ Some(c ~ f2))
+            case t @ Termula(_: PredicateLabel, _) => Seq(t ~ None)
+            case _ => throw UnreachableException
           }
-      }
-    )
+        )
+      )
 
-    val negated: Syntax[ConnectorFormula] = recursive {
-      (negation ~ subformula).map(
+    val negated: Syntax[Termula] = recursive {
+      (negation ~ subtermula).map(
         { case n ~ f =>
-          ConnectorFormula(n, Seq(f))
+          Termula(n, Seq(f))
         },
         {
-          case ConnectorFormula(Neg, Seq(f)) => Seq(Neg ~ f)
+          case Termula(Neg, Seq(f)) => Seq(Neg ~ f)
           case _ => throw UnreachableException
         }
       )
@@ -482,32 +518,30 @@ object Parser {
     )
 
     // 'and' has higher priority than 'or'
-    val connectorFormula: Syntax[Formula] = operators(subformula)(
+    val connectorTermula: Syntax[Termula] = operators(subtermula)(
       and is LeftAssociative,
       or is LeftAssociative
     )(
-      (l, conn, r) => ConnectorFormula(conn, Seq(l, r)),
+      (l, conn, r) => Termula(conn, Seq(l, r)),
       {
-        case ConnectorFormula(conn, Seq(l, r)) =>
+        case Termula(conn: ConnectorLabel, Seq(l, r)) =>
           (l, conn, r)
-        case ConnectorFormula(conn, l +: rest) if rest.nonEmpty =>
+        case Termula(conn: ConnectorLabel, l +: rest) if rest.nonEmpty =>
           val last = rest.last
           val leftSide = rest.dropRight(1)
           // parser only knows about connector formulas of two arguments, so we unfold the formula of many arguments to
           // multiple nested formulas of two arguments
-          (leftSide.foldLeft(l)((f1, f2) => ConnectorFormula(conn, Seq(f1, f2))), conn, last)
+          (leftSide.foldLeft(l)((f1, f2) => Termula(conn, Seq(f1, f2))), conn, last)
       }
     )
 
-    lazy val formulaArgs: Syntax[Seq[Formula]] = recursive(open.skip ~ repsep(formula, comma) ~ closed.skip)
-
-    lazy val schematicConnectorFormula: Syntax[ConnectorFormula] = (elem(SchematicConnectorKind) ~ formulaArgs).map(
+    lazy val schematicConnectorFormula: Syntax[Termula] = (elem(SchematicConnectorKind) ~ args).map(
       {
-        case SchematicConnectorToken(id) ~ args => ConnectorFormula(SchematicConnectorLabel(id, args.size), args)
+        case SchematicConnectorToken(id) ~ args => Termula(SchematicConnectorLabel(id, args.size), args)
         case _ => throw UnreachableException
       },
       {
-        case ConnectorFormula(SchematicConnectorLabel(id, _), args) => Seq(SchematicConnectorToken(id) ~ args)
+        case Termula(SchematicConnectorLabel(id, _), args) => Seq(SchematicConnectorToken(id) ~ args)
         case _ => throw UnreachableException
       }
     )
@@ -525,74 +559,70 @@ object Parser {
       }
     )
 
-    val boundVariable: Syntax[VariableLabel] = accept(FunctionOrPredicateKind)(
+    val boundVariable: Syntax[VariableFormulaLabel] = accept(IdKind)(
       {
-        case ConstantToken(id) => VariableLabel(id)
-        case SchematicToken(id) => VariableLabel(id)
+        case ConstantToken(id) => VariableFormulaLabel(id)
+        case SchematicToken(id) => VariableFormulaLabel(id)
       },
-      { case VariableLabel(id) =>
+      { case VariableFormulaLabel(id) =>
         Seq(SchematicToken(id))
       }
     )
 
-    val binder: Syntax[BinderLabel ~ VariableLabel] = binderLabel ~ boundVariable ~ elem(DotKind).unit(DotToken).skip
+    val binder: Syntax[BinderLabel ~ VariableFormulaLabel] = binderLabel ~ boundVariable ~ elem(DotKind).unit(DotToken).skip
 
-    val iffImpliesFormula: Syntax[Formula] = (connectorFormula ~ opt(toplevelConnector ~ connectorFormula)).map[Formula](
+    val iffImpliesTermula: Syntax[Termula] = (connectorTermula ~ opt(toplevelConnector ~ connectorTermula)).map[Termula](
       {
-        case left ~ Some(c ~ right) => ConnectorFormula(c, Seq(left, right))
+        case left ~ Some(c ~ right) => Termula(c, Seq(left, right))
         case f ~ None => f
       },
       {
-        case ConnectorFormula(c @ (Iff | Implies), Seq(left, right)) => Seq(left ~ Some(c ~ right))
-        case ConnectorFormula((And | Or), Seq(f)) => Seq(f ~ None)
+        case Termula(c @ (Iff | Implies), Seq(left, right)) => Seq(left ~ Some(c ~ right))
+        case Termula((And | Or), Seq(f)) => Seq(f ~ None)
         case f => Seq(f ~ None)
       }
     )
 
-    lazy val formula: Syntax[Formula] = recursive {
-      prefixes(binder, iffImpliesFormula)(
-        { case (label ~ variable, f) => BinderFormula(label, variable, f) },
-        { case BinderFormula(label, variable, f) =>
+    lazy val termula: Syntax[Termula] = recursive {
+      prefixes(binder, iffImpliesTermula)(
+        { case (label ~ variable, f) => Termula(label, Seq(Termula(variable, Seq()), f)) },
+        { case Termula(label: BinderLabel, Seq(Termula(variable: VariableFormulaLabel, Seq()), f)) =>
           (label ~ variable, f)
         }
       )
     }
     ///////////////////////////////////////////////////////////////////
 
-    val sequent: Syntax[Sequent] = (repsep(formula, semicolon) ~ opt(sequentSymbol.skip ~ repsep(formula, semicolon))).map[Sequent](
+    val sequent: Syntax[TermulaSequent] = (repsep(termula, semicolon) ~ opt(sequentSymbol.skip ~ repsep(termula, semicolon))).map[TermulaSequent](
       {
-        case left ~ Some(right) => Sequent(left.toSet, right.toSet)
-        case right ~ None => Sequent(Set(), right.toSet)
+        case left ~ Some(right) => TermulaSequent(left.toSet, right.toSet)
+        case right ~ None => TermulaSequent(Set(), right.toSet)
       },
       {
-        case Sequent(Seq(), right) => Seq(right.toSeq ~ None)
-        // TODO: use constant
-        case Sequent(left, Seq()) => Seq(left.toSeq ~ Some(Seq(False)))
-        case Sequent(left, right) => Seq(left.toSeq ~ Some(right.toSeq))
+        case TermulaSequent(Seq(), right) => Seq(right.toSeq ~ None)
+        case TermulaSequent(left, Seq()) => Seq(left.toSeq ~ Some(Seq(False.toTermula)))
+        case TermulaSequent(left, right) => Seq(left.toSeq ~ Some(right.toSeq))
       }
     )
 
-    val parser: Parser[Sequent] = Parser(sequent)
-    val printer: PrettyPrinter[Sequent] = PrettyPrinter(sequent)
+    val parser: Parser[TermulaSequent] = Parser(sequent)
+    val printer: PrettyPrinter[TermulaSequent] = PrettyPrinter(sequent)
 
-    val formulaParser: SequentParser.Parser[Formula] = Parser(formula)
-    val formulaPrinter: SequentParser.PrettyPrinter[Formula] = PrettyPrinter(formula)
-
-    val termParser: SequentParser.Parser[Term] = Parser(term)
-    val termPrinter: SequentParser.PrettyPrinter[Term] = PrettyPrinter(term)
+    val termulaParser: SequentParser.Parser[Termula] = Parser(termula)
+    val termulaPrinter: SequentParser.PrettyPrinter[Termula] = PrettyPrinter(termula)
 
     def apply(it: Iterator[Token]): ParseResult[Sequent] = parseSequent(it)
 
     def unapply(s: Sequent): Option[String] = printSequent(s)
 
-    def parseSequent(it: Iterator[Token]): ParseResult[Sequent] = parser(it)
-    def printSequent(s: Sequent): Option[String] = printer(s).map(SequentLexer.unapply)
+    def parseSequent(it: Iterator[Token]): ParseResult[Sequent] = parser(it).map(_.toSequent)
+    def printSequent(s: Sequent): Option[String] = printer(s.toTermulaSequent).map(SequentLexer.unapply)
 
-    def parseFormula(it: Iterator[Token]): ParseResult[Formula] = formulaParser(it)
-    def printFormula(f: Formula): Option[String] = formulaPrinter(f).map(SequentLexer.unapply)
+    def parseFormula(it: Iterator[Token]): ParseResult[Formula] = termulaParser(it).map(_.toFormula)
+    def printFormula(f: Formula): Option[String] = termulaPrinter(f.toTermula).map(SequentLexer.unapply)
 
-    def parseTerm(it: Iterator[Token]): ParseResult[Term] = termParser(it)
+    def parseTerm(it: Iterator[Token]): ParseResult[Term] = termulaParser(it).map(_.toTerm)
 
-    def printTerm(t: Term): Option[String] = termPrinter(t).map(SequentLexer.unapply)
+    def printTerm(t: Term): Option[String] = termulaPrinter(t.toTermula).map(SequentLexer.unapply)
   }
 }

--- a/lisa-utils/src/main/scala/lisa/utils/Parser.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Parser.scala
@@ -24,6 +24,12 @@ object UnreachableException extends ParserException("Internal error: expected un
 
 class PrintFailedException(inp: Sequent | Formula | Term) extends ParserException(s"Printing of $inp failed unexpectedly")
 
+/**
+ * @param synonymToCanonical information about synonyms that correspond to the same FunctionLabel / PredicateLabel.
+ *                           Can be constructed with [[lisa.utils.SynonymInfoBuilder]]
+ * @param infixPredicates list of infix predicates' names in the decreasing order of priority
+ * @param infixFunctions list of infix functions and their associativity in the decreasing order of priority
+ */
 class Parser(
     synonymToCanonical: SynonymInfo,
     infixPredicates: List[String],

--- a/lisa-utils/src/main/scala/lisa/utils/Parser.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Parser.scala
@@ -44,13 +44,13 @@ class Parser(
 
   /**
    * Parses a formula from a string. A formula can be:
-   * <p> - a bound formula: `∀ ?x. f`, `∃ ?x. f`, `∃! ?x. f`. A binder binds the entire formula until the end of the scope (a closing parenthesis or the end of string).
+   * <p> - a bound formula: `∀'x. f`, `∃'x. f`, `∃!'x. f`. A binder binds the entire formula until the end of the scope (a closing parenthesis or the end of string).
    * <p> - two formulas, connected by `↔` or `⇒`. Iff / implies bind less tight than and / or.
    * <p> - a conjunction or disjunction of arbitrary number of formulas. `∧` binds tighter than `∨`.
    * <p> - negated formula.
    * <p> - schematic connector formula: `?c(f1, f2, f3)`.
    * <p> - equality of two formulas: `f1 = f2`.
-   * <p> - a constant `p(a)` or schematic `?p(a)` predicate application to arbitrary number of term arguments.
+   * <p> - a constant `p(a)` or schematic `'p(a)` predicate application to arbitrary number of term arguments.
    * <p> - boolean constant: `⊤` or `⊥`.
    *
    * @param s string representation of the formula
@@ -60,8 +60,8 @@ class Parser(
     extractParseResult(SequentParser.parseFormula(SequentLexer(s.iterator)))
 
   /**
-   * Parses a term from a string. A term is a constant `c`, a schematic variable `?x` or an application of a constant `f(a)`
-   * or a schematic `?f(a)` function to other terms.
+   * Parses a term from a string. A term is a constant `c`, a schematic variable `'x` or an application of a constant `f(a)`
+   * or a schematic `'f(a)` function to other terms.
    *
    * @param s string representation of the term
    * @return parsed term on success, throws an exception when unexpected input or end of input.

--- a/lisa-utils/src/main/scala/lisa/utils/Parser.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Parser.scala
@@ -10,36 +10,38 @@ import scallion.util.Unfolds.unfoldRight
 import silex.*
 
 object Parser {
-  enum Notation {
-    case Prefix, Infix
-  }
+  //////////////////////////////// EQUIVALENT LABELS, INFIX CONTROL ///////////////////////////////
+  case class CanonicalId(print: String, internal: String)
 
-  abstract class Label(val id: String, val notation: Notation)
+  def equivalentLabelsToMap(equivalentLabels: List[String], print: String, internal: String): Map[String, CanonicalId] =
+    (print :: internal :: equivalentLabels).map(_ -> CanonicalId(print, internal)).toMap
 
-  case class InfixLabel(override val id: String) extends Label(id, Notation.Infix)
+  // TODO: grow the mapping as we discover / introduce more synonyms
+  // The mapping stores the information about synonymous strings for the same id, mapping a string to its canonical
+  // form (the id that is used to construct the `ConstantLabel`) and the printable form (the preferred synonym to
+  // display in strings).
+  private val SynonymToCanonical: Map[String, CanonicalId] =
+    equivalentLabelsToMap("elem" :: "in" :: Nil, "∊", "elem") ++
+      equivalentLabelsToMap("subset_of" :: "subset" :: Nil, "⊆", "subset_of") ++
+      equivalentLabelsToMap("sim" :: "same_cardinality" :: Nil, "≈", "same_cardinality")
 
-  case class PrefixLabel(override val id: String) extends Label(id, Notation.Prefix)
+  /**
+   * @return the preferred way to output this id, if available, otherwise the id itself.
+   */
+  def getPrintName(id: String): String = SynonymToCanonical.get(id).map(_.print).getOrElse(id)
 
-  case class CanonicalLabel(print: Label, internal: Label)
-
-  def equivalentLabelsToMap(labels: List[String], print: Label, internal: Label): Map[String, CanonicalLabel] =
-    labels.map(_ -> CanonicalLabel(print, internal)).toMap
-
-  private val mapping: Map[String, CanonicalLabel] =
-    equivalentLabelsToMap("elem" :: "in" :: "∊" :: Nil, InfixLabel("∊"), PrefixLabel("elem")) ++
-      equivalentLabelsToMap("subset_of" :: "subset" :: "⊆" :: Nil, InfixLabel("⊆"), PrefixLabel("subset_of")) ++
-      equivalentLabelsToMap("sim" :: "same_cardinality" :: "≈" :: Nil, InfixLabel("≈"), PrefixLabel("same_cardinality")) ++
-      equivalentLabelsToMap("=" :: Nil, InfixLabel("="), InfixLabel("="))
-
-  def getPrintName(id: String): Option[Label] = mapping.get(id).map(_.print)
-
-  def getInternalName(id: String): String = mapping.get(id).map(_.internal.id).getOrElse(id)
+  /**
+   * @return the synonym of `id` that is used to construct the corresponding `ConstantPredicateLabel` or
+   *         `ConstantFunctionLabel`. If not available, `id` has no known synonyms, so return `id` itself.
+   */
+  def getInternalName(id: String): String = SynonymToCanonical.get(id).map(_.internal).getOrElse(id)
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+  // TODO: support more infix predicates, potentially determine if a predicate is infix without listing all infix ones
+  def isInfixPredicate(id: String): Boolean = Set("=", "∊", "⊂", "⊆").contains(id)
 
   class ParserException(msg: String) extends Exception(msg)
   object UnreachableException extends ParserException("Internal error: expected unreachable")
   class PrintFailedException(inp: Sequent | Formula | Term) extends ParserException(s"Printing of $inp failed unexpectedly")
-
-  def isInfixPredicate(id: String): Boolean = Set("=", "∊", "⊂", "⊆").contains(id)
 
   /**
    * Parses a sequent from a string. A sequent consists of the left and right side, separated by `⊢` or `|-`.
@@ -322,8 +324,8 @@ object Parser {
         case _ => throw UnreachableException
       },
       {
-        case ConstantPredicateLabel(id, INFIX_ARITY) if getPrintName(id).map(_.notation == Notation.Infix).getOrElse(isInfixPredicate(id)) =>
-          val printName = getPrintName(id).map(_.id).getOrElse(id)
+        case ConstantPredicateLabel(id, INFIX_ARITY) if isInfixPredicate(getPrintName(id)) =>
+          val printName = getPrintName(id)
           Seq(InfixPredicateToken(printName))
         case _ => throw UnreachableException
       }
@@ -424,21 +426,21 @@ object Parser {
         case _ => throw UnreachableException
       },
       {
-        case PredicateFormula(label @ ConstantPredicateLabel(id, INFIX_ARITY), Seq(first, second)) if getPrintName(id).map(_.notation == Notation.Infix).getOrElse(isInfixPredicate(id)) =>
+        case PredicateFormula(label @ ConstantPredicateLabel(id, INFIX_ARITY), Seq(first, second)) if isInfixPredicate(getPrintName(id)) =>
           Seq(invertTerm(first) ~ Some(label ~ second))
         case PredicateFormula(label, args) =>
-          val (canonicalId, isInfix) = getPrintName(label.id).map(l => (l.id, l.notation == Notation.Infix)).getOrElse(label.id, false)
-          if (isInfix && args.size == INFIX_ARITY) {
+          val printName = getPrintName(label.id)
+          if (isInfixPredicate(printName) && args.size == INFIX_ARITY) {
             args match {
-              case Seq(first, second) => Seq(invertTerm(first) ~ Some(ConstantPredicateLabel(canonicalId, INFIX_ARITY) ~ second))
+              case Seq(first, second) => Seq(invertTerm(first) ~ Some(ConstantPredicateLabel(getPrintName(label.id), INFIX_ARITY) ~ second))
               case _ => throw UnreachableException
             }
           } else {
             val prefixApp = label match {
-              case VariableFormulaLabel(id) => SchematicToken(canonicalId) ~ None
-              case SchematicPredicateLabel(id, _) => SchematicToken(canonicalId) ~ Some(args)
-              case ConstantPredicateLabel(id, 0) => ConstantToken(canonicalId) ~ None
-              case ConstantPredicateLabel(id, _) => ConstantToken(canonicalId) ~ Some(args)
+              case VariableFormulaLabel(_) => SchematicToken(printName) ~ None
+              case SchematicPredicateLabel(_, _) => SchematicToken(printName) ~ Some(args)
+              case ConstantPredicateLabel(_, 0) => ConstantToken(printName) ~ None
+              case ConstantPredicateLabel(_, _) => ConstantToken(printName) ~ Some(args)
             }
             Seq(prefixApp ~ None)
           }

--- a/lisa-utils/src/main/scala/lisa/utils/ParsingUtils.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/ParsingUtils.scala
@@ -1,0 +1,41 @@
+package lisa.utils
+
+import lisa.utils.ParserException
+import scallion.*
+import scallion.util.Unfolds.unfoldLeft
+
+trait ParsingUtils extends Operators { self: Parsers =>
+  case class PrecedenceLevel[Op](operator: Syntax[Op], associativity: lisa.utils.Associativity)
+
+  implicit class PrecedenceLevelDecorator[Op](operator: Syntax[Op]) {
+
+    /**
+     * Indicates the associativity of the operator.
+     */
+    def has(associativity: lisa.utils.Associativity): PrecedenceLevel[Op] = PrecedenceLevel(operator, associativity)
+  }
+
+  def singleInfix[Op, A](elem: Syntax[A], op: Syntax[Op])(function: (A, Op, A) => A, inverse: PartialFunction[A, (A, Op, A)] = PartialFunction.empty): Syntax[A] =
+    (elem ~ opt(op ~ elem)).map(
+      {
+        case first ~ None => first
+        case first ~ Some(op ~ second) => function(first, op, second)
+      },
+      v =>
+        inverse.lift(v) match {
+          // see the usage of singleInfix in infixOperators: the inverse function is the same for all ops, so it might
+          // or might not be correct to unwrap the current element with the inverse function. Hence, provide both options.
+          case Some(l, op, r) => Seq(l ~ Some(op ~ r), v ~ None)
+          case None => Seq(v ~ None)
+        }
+    )
+
+  def infixOperators[Op, A](elem: Syntax[A])(levels: PrecedenceLevel[Op]*)(function: (A, Op, A) => A, inverse: PartialFunction[A, (A, Op, A)] = PartialFunction.empty): Syntax[A] =
+    levels.foldLeft(elem) { case (currSyntax, PrecedenceLevel(op, assoc)) =>
+      assoc match {
+        case Associativity.Left => infixLeft(currSyntax, op)(function, inverse)
+        case Associativity.Right => infixRight(currSyntax, op)(function, inverse)
+        case Associativity.None => singleInfix(currSyntax, op)(function, inverse)
+      }
+    }
+}

--- a/lisa-utils/src/main/scala/lisa/utils/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/Printer.scala
@@ -6,10 +6,12 @@ import lisa.kernel.proof.SCProofCheckerJudgement
 import lisa.kernel.proof.SCProofCheckerJudgement.*
 import lisa.kernel.proof.SequentCalculus.*
 
+val FOLPrinter = Printer(FOLParser)
+
 /**
  * A set of methods to pretty-print kernel trees.
  */
-object Printer {
+class Printer(parser: Parser) {
 
   private def spaceSeparator(compact: Boolean): String = if (compact) "" else " "
 
@@ -26,7 +28,7 @@ object Printer {
    * @param compact whether spaces should be omitted between tokens
    * @return the string representation of this formula
    */
-  def prettyFormula(formula: Formula, compact: Boolean = false): String = Parser.printFormula(formula)
+  def prettyFormula(formula: Formula, compact: Boolean = false): String = parser.printFormula(formula)
 
   /**
    * Returns a string representation of this term. See also [[prettyFormula]].
@@ -39,7 +41,7 @@ object Printer {
    * @param compact whether spaces should be omitted between tokens
    * @return the string representation of this term
    */
-  def prettyTerm(term: Term, compact: Boolean = false): String = Parser.printTerm(term)
+  def prettyTerm(term: Term, compact: Boolean = false): String = parser.printTerm(term)
 
   /**
    * Returns a string representation of this sequent.
@@ -52,7 +54,7 @@ object Printer {
    * @param compact whether spaces should be omitted between tokens
    * @return the string representation of this sequent
    */
-  def prettySequent(sequent: Sequent, compact: Boolean = false): String = Parser.printSequent(sequent)
+  def prettySequent(sequent: Sequent, compact: Boolean = false): String = parser.printSequent(sequent)
 
   /**
    * Returns a string representation of this proof.

--- a/lisa-utils/src/main/scala/lisa/utils/ProofPrinter.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/ProofPrinter.scala
@@ -53,7 +53,7 @@ object ProofPrinter {
             showErrorForLine,
             prefixString,
             Seq(stepName, topSteps.mkString(commaSeparator(compact = false))).filter(_.nonEmpty).mkString(" "),
-            Printer.prettySequent(imp._2)
+            FOLPrinter.prettySequent(imp._2)
           )
 
         Seq(pretty("Import", 0))
@@ -72,7 +72,7 @@ object ProofPrinter {
             showErrorForLine,
             prefixString,
             Seq(stepName, topSteps.mkString(commaSeparator(compact = false))).filter(_.nonEmpty).mkString(" "),
-            Printer.prettySequent(step.bot)
+            FOLPrinter.prettySequent(step.bot)
           )
 
         step.tactic match {

--- a/lisa-utils/src/main/scala/lisa/utils/SecondOrderMatcher.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/SecondOrderMatcher.scala
@@ -1,0 +1,17 @@
+package lisa.utils
+
+import lisa.kernel.fol.FOL.*
+
+// TODO: connectors?
+
+object SecondOrderMatcher {
+  case class Matching(predicates: Map[SchematicPredicateLabel, LambdaTermTerm], functions: Map[SchematicFunctionLabel, LambdaTermFormula])
+
+  private case class Renaming()
+
+//  def findMatching(patterns: Seq[Formula], target: Seq[Formula]): Option[Matching] = {}
+
+  // TODO: error reporting?
+  private def isCorrectInput(patterns: Seq[Formula], target: Seq[Formula]): Boolean = ???
+
+}

--- a/lisa-utils/src/main/scala/lisa/utils/SynonymInfo.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/SynonymInfo.scala
@@ -1,0 +1,34 @@
+package lisa.utils
+
+import scala.collection.mutable
+
+case class CanonicalId(internal: String, print: String)
+
+case class SynonymInfo(private val synonymToCanonical: Map[String, CanonicalId]) {
+
+  /**
+   * @return the preferred way to output this id, if available, otherwise the id itself.
+   */
+  def getPrintName(id: String): String = synonymToCanonical.get(id).map(_.print).getOrElse(id)
+
+  /**
+   * @return the synonym of `id` that is used to construct the corresponding `ConstantPredicateLabel` or
+   *         `ConstantFunctionLabel`. If not available, `id` has no known synonyms, so return `id` itself.
+   */
+  def getInternalName(id: String): String = synonymToCanonical.get(id).map(_.internal).getOrElse(id)
+}
+
+object SynonymInfo {
+  val empty: SynonymInfo = SynonymInfo(Map.empty[String, CanonicalId])
+}
+
+class SynonymInfoBuilder {
+  private val mapping: mutable.Map[String, CanonicalId] = mutable.Map()
+
+  def addSynonyms(internal: String, print: String, equivalentLabels: List[String] = Nil): SynonymInfoBuilder = {
+    (print :: internal :: equivalentLabels).foreach(mapping(_) = CanonicalId(internal, print))
+    this
+  }
+
+  def build: SynonymInfo = SynonymInfo(mapping.toMap)
+}

--- a/lisa-utils/src/main/scala/lisa/utils/TheoriesHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/TheoriesHelpers.scala
@@ -29,7 +29,7 @@ trait TheoriesHelpers extends KernelHelpers {
     def theorem(name: String, statement: Sequent, proof: SCProof, justifications: Seq[theory.Justification]): RunningTheoryJudgement[theory.Theorem] = {
       if (statement == proof.conclusion) theory.makeTheorem(name, statement, proof, justifications)
       else if (isSameSequent(statement, proof.conclusion)) theory.makeTheorem(name, statement, proof.appended(Rewrite(statement, proof.length - 1)), justifications)
-      else InvalidJustification(s"The proof proves ${Printer.prettySequent(proof.conclusion)} instead of claimed ${Printer.prettySequent(statement)}", None)
+      else InvalidJustification(s"The proof proves ${FOLPrinter.prettySequent(proof.conclusion)} instead of claimed ${FOLPrinter.prettySequent(statement)}", None)
     }
 
     /**
@@ -65,14 +65,14 @@ trait TheoriesHelpers extends KernelHelpers {
 
   extension (just: RunningTheory#Justification) {
     def repr: String = just match {
-      case thm: RunningTheory#Theorem => s" Theorem ${thm.name} := ${Printer.prettySequent(thm.proposition)}\n"
-      case axiom: RunningTheory#Axiom => s" Axiom ${axiom.name} := ${Printer.prettyFormula(axiom.ax)}\n"
+      case thm: RunningTheory#Theorem => s" Theorem ${thm.name} := ${FOLPrinter.prettySequent(thm.proposition)}\n"
+      case axiom: RunningTheory#Axiom => s" Axiom ${axiom.name} := ${FOLPrinter.prettyFormula(axiom.ax)}\n"
       case d: RunningTheory#Definition =>
         d match {
           case pd: RunningTheory#PredicateDefinition =>
-            s" Definition of predicate symbol ${pd.label.id} := ${Printer.prettyFormula(pd.label(pd.expression.vars.map(VariableTerm.apply)*) <=> pd.expression.body)}\n"
+            s" Definition of predicate symbol ${pd.label.id} := ${FOLPrinter.prettyFormula(pd.label(pd.expression.vars.map(VariableTerm.apply)*) <=> pd.expression.body)}\n"
           case fd: RunningTheory#FunctionDefinition =>
-            s" Definition of function symbol ${Printer.prettyTerm(fd.label(fd.expression.vars.map(VariableTerm.apply)*))} := the ${fd.out.id} such that ${Printer
+            s" Definition of function symbol ${FOLPrinter.prettyTerm(fd.label(fd.expression.vars.map(VariableTerm.apply)*))} := the ${fd.out.id} such that ${FOLPrinter
                 .prettyFormula((fd.out === fd.label(fd.expression.vars.map(VariableTerm.apply)*)) <=> fd.expression.body)})\n"
         }
     }
@@ -99,7 +99,7 @@ trait TheoriesHelpers extends KernelHelpers {
           just.repr
         case InvalidJustification(message, error) =>
           s"$message\n${error match {
-              case Some(judgement) => Printer.prettySCProof(judgement)
+              case Some(judgement) => FOLPrinter.prettySCProof(judgement)
               case None => ""
             }}"
       }
@@ -123,7 +123,7 @@ trait TheoriesHelpers extends KernelHelpers {
           just.show
         case InvalidJustification(message, error) =>
           om.output(s"$message\n${error match {
-              case Some(judgement) => Printer.prettySCProof(judgement)
+              case Some(judgement) => FOLPrinter.prettySCProof(judgement)
               case None => ""
             }}")
           om.finishOutput(InvalidJustificationException(message, error))
@@ -140,10 +140,10 @@ trait TheoriesHelpers extends KernelHelpers {
     def showAndGet(using om: OutputManager): SCProof = {
       proofJudgement match {
         case SCProofCheckerJudgement.SCValidProof(proof) =>
-          om.output(Printer.prettySCProof(proofJudgement))
+          om.output(FOLPrinter.prettySCProof(proofJudgement))
           proof
         case ip @ SCProofCheckerJudgement.SCInvalidProof(proof, path, message) =>
-          om.output(s"$message\n${Printer.prettySCProof(proofJudgement)}")
+          om.output(s"$message\n${FOLPrinter.prettySCProof(proofJudgement)}")
           om.finishOutput(InvalidJustificationException("", Some(ip)))
       }
     }
@@ -156,7 +156,7 @@ trait TheoriesHelpers extends KernelHelpers {
    */
   def checkProof(proof: SCProof, output: String => Unit = println): Unit = {
     val judgement = SCProofChecker.checkSCProof(proof)
-    output(Printer.prettySCProof(judgement))
+    output(FOLPrinter.prettySCProof(judgement))
   }
 
 }

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -694,7 +694,7 @@ object BasicStepTactic {
       extends ProofTactic {
     val bot: Sequent = statement match {
       case s: Sequent => s
-      case s: String => lisa.utils.Parser.parseSequent(s)
+      case s: String => lisa.utils.FOLParser.parseSequent(s)
     }
 
     val iProof: proof.InnerProof = new proof.InnerProof(bot)

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/ProofsHelpers.scala
@@ -6,7 +6,6 @@ import lisa.kernel.proof.SCProofChecker
 import lisa.kernel.proof.SequentCalculus.*
 import lisa.utils.Library
 import lisa.utils.OutputManager
-import lisa.utils.Parser.*
 import lisa.utils.ProofPrinter
 import lisa.utils.tactics.ProofTacticLib.*
 import lisa.utils.tactics.SimpleDeducedSteps.*
@@ -62,7 +61,7 @@ trait ProofsHelpers {
   /**
    * Claim the given Sequent as a ProofTactic, which may require a justification by a proof tactic and premises.
    */
-  def have(using proof: library.Proof)(res: String): HaveSequent = HaveSequent(parseSequent(res))
+  def have(using proof: library.Proof)(res: String): HaveSequent = HaveSequent(lisa.utils.FOLParser.parseSequent(res))
 
   /**
    * Claim the given known Theorem, Definition or Axiom as a Sequent.
@@ -97,7 +96,7 @@ trait ProofsHelpers {
     f
   }
   def assume(using proof: library.Proof)(fstring: String): Formula = {
-    val f = lisa.utils.Parser.parseFormula(fstring)
+    val f = lisa.utils.FOLParser.parseFormula(fstring)
     assume(f)
   }
   /*

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/WithTheorems.scala
@@ -235,7 +235,7 @@ trait WithTheorems {
 
     val goal: Sequent = statement match {
       case s: Sequent => s
-      case s: String => lisa.utils.Parser.parseSequent(s)
+      case s: String => lisa.utils.FOLParser.parseSequent(s)
     }
     val name: String = fullName
 
@@ -244,7 +244,7 @@ trait WithTheorems {
 
     def repr: String = (
       " Theorem " + name + " := " + (statement match {
-        case s: Sequent => lisa.utils.Printer.prettySequent(s)
+        case s: Sequent => lisa.utils.FOLPrinter.prettySequent(s)
         case s: String => s
       })
     )

--- a/lisa-utils/src/test/scala/lisa/kernel/EquivalenceCheckerTests.scala
+++ b/lisa-utils/src/test/scala/lisa/kernel/EquivalenceCheckerTests.scala
@@ -2,8 +2,8 @@ package lisa.kernel
 
 import lisa.kernel.fol.FOL
 import lisa.kernel.fol.FOL.*
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.*
-import lisa.utils.Printer
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.collection.MapView
@@ -18,14 +18,14 @@ class EquivalenceCheckerTests extends AnyFunSuite {
   def checkEquivalence(left: Formula, right: Formula): Unit = {
     assert(
       isSame(left, right),
-      s"Couldn't prove the equivalence between ${Printer.prettyFormula(left)} and ${Printer.prettyFormula(right)}\nLeft tree: ${left}\nRight tree: ${right}"
+      s"Couldn't prove the equivalence between ${FOLPrinter.prettyFormula(left)} and ${FOLPrinter.prettyFormula(right)}\nLeft tree: ${left}\nRight tree: ${right}"
     )
   }
 
   def checkNonEquivalence(left: Formula, right: Formula): Unit = {
     assert(
       !isSame(left, right),
-      s"Expected the checker to not be able to show equivalence between ${Printer.prettyFormula(left)} and ${Printer.prettyFormula(right)}\nLeft tree: ${left}\nRight tree: ${right}"
+      s"Expected the checker to not be able to show equivalence between ${FOLPrinter.prettyFormula(left)} and ${FOLPrinter.prettyFormula(right)}\nLeft tree: ${left}\nRight tree: ${right}"
     )
   }
 
@@ -124,13 +124,13 @@ class EquivalenceCheckerTests extends AnyFunSuite {
           checkEquivalence(left, right)
           checkEquivalence(right, left)
           if (verbose) {
-            println(s"${Printer.prettyFormula(left)}  <==>  ${Printer.prettyFormula(right)}")
+            println(s"${FOLPrinter.prettyFormula(left)}  <==>  ${FOLPrinter.prettyFormula(right)}")
           }
         } else {
           checkNonEquivalence(left, right)
           checkNonEquivalence(right, left)
           if (verbose) {
-            println(s"${Printer.prettyFormula(left)}  <!=>  ${Printer.prettyFormula(right)}")
+            println(s"${FOLPrinter.prettyFormula(left)}  <!=>  ${FOLPrinter.prettyFormula(right)}")
           }
         }
       }

--- a/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
+++ b/lisa-utils/src/test/scala/lisa/test/ProofCheckerSuite.scala
@@ -6,13 +6,14 @@ import lisa.kernel.proof.SCProofCheckerJudgement
 import lisa.kernel.proof.SCProofCheckerJudgement.SCInvalidProof
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus.isSameSequent
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.{_, given}
 import lisa.utils.Printer
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.adhocExtensions
 
-abstract class ProofCheckerSuite extends AnyFunSuite {
+abstract class ProofCheckerSuite(printer: Printer = FOLPrinter) extends AnyFunSuite {
 
   import lisa.kernel.fol.FOL.*
 
@@ -42,19 +43,19 @@ abstract class ProofCheckerSuite extends AnyFunSuite {
 
   def checkProof(proof: SCProof): Unit = {
     val judgement = checkSCProof(proof)
-    assert(judgement.isValid, Printer.prettySCProof(judgement, true))
+    assert(judgement.isValid, printer.prettySCProof(judgement, true))
   }
 
   def checkProof(proof: SCProof, expected: Sequent): Unit = {
     val judgement = checkSCProof(proof)
-    assert(judgement.isValid, "\n" + Printer.prettySCProof(judgement))
-    assert(isSameSequent(proof.conclusion, expected), s"(${Printer.prettySequent(proof.conclusion)} did not equal ${Printer.prettySequent(expected)})")
+    assert(judgement.isValid, "\n" + printer.prettySCProof(judgement))
+    assert(isSameSequent(proof.conclusion, expected), s"(${printer.prettySequent(proof.conclusion)} did not equal ${printer.prettySequent(expected)})")
   }
 
   def checkIncorrectProof(incorrectProof: SCProof): Unit = {
     assert(
       !checkSCProof(incorrectProof).isValid,
-      s"(incorrect proof with conclusion '${Printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
+      s"(incorrect proof with conclusion '${printer.prettySequent(incorrectProof.conclusion)}' was accepted by the proof checker)\nSequent: ${incorrectProof.conclusion}"
     )
   }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
@@ -227,12 +227,26 @@ class ParserTest extends AnyFunSuite with TestUtils {
   }
 
   test("equivalent names") {
-    val in = ConstantPredicateLabel("elem", 2)
     assert(Parser.parseFormula("x∊y") == PredicateFormula(in, Seq(cx, cy)))
     assert(Parser.parseFormula("x ∊ y") == PredicateFormula(in, Seq(cx, cy)))
     assert(Parser.parseFormula("'x ∊ 'y") == PredicateFormula(in, Seq(x, y)))
     assert(Parser.parseFormula("('x ∊ 'y) /\\ a") == ConnectorFormula(And, Seq(PredicateFormula(in, Seq(x, y)), a)))
     assert(Parser.parseFormula("a \\/ ('x ∊ 'y)") == ConnectorFormula(Or, Seq(a, PredicateFormula(in, Seq(x, y)))))
+  }
+
+  test("infix functions") {
+    assert(Parser.parseTerm("x + y") == Term(plus, Seq(cx, cy)))
+    assert(Parser.parseTerm("(x + y) + z") == Term(plus, Seq(Term(plus, Seq(cx, cy)), cz)))
+  }
+
+  test("mix of infix functions and infix predicates") {
+    assert(Parser.parseFormula("(x + y) ∊ z") == PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
+    assert(
+      Parser.parseFormula("x ∊ y /\\ x ∊ z /\\ (x + y) ∊ z") == ConnectorFormula(
+        And,
+        Seq(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(cx, cy)), PredicateFormula(in, Seq(cx, cz)))), PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
+      )
+    )
 
   }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
@@ -2,159 +2,160 @@ package lisa.utils
 
 import lisa.kernel.fol.FOL._
 import lisa.kernel.proof.SequentCalculus.Sequent
+import lisa.utils.FOLParser
 import lisa.utils.Helpers.*
 import org.scalatest.funsuite.AnyFunSuite
 
 class ParserTest extends AnyFunSuite with TestUtils {
   test("constant") {
-    assert(Parser.parseTerm("x") == Term(cx, Seq()))
+    assert(FOLParser.parseTerm("x") == Term(cx, Seq()))
   }
 
   test("variable") {
-    assert(Parser.parseTerm("'x") == VariableTerm(x))
+    assert(FOLParser.parseTerm("'x") == VariableTerm(x))
   }
 
   test("constant function application") {
-    assert(Parser.parseTerm("f()") == Term(f0, Seq()))
-    assert(Parser.parseTerm("f(x)") == Term(f1, Seq(cx)))
-    assert(Parser.parseTerm("f(x, y)") == Term(f2, Seq(cx, cy)))
-    assert(Parser.parseTerm("f(x, y, z)") == Term(f3, Seq(cx, cy, cz)))
+    assert(FOLParser.parseTerm("f()") == Term(f0, Seq()))
+    assert(FOLParser.parseTerm("f(x)") == Term(f1, Seq(cx)))
+    assert(FOLParser.parseTerm("f(x, y)") == Term(f2, Seq(cx, cy)))
+    assert(FOLParser.parseTerm("f(x, y, z)") == Term(f3, Seq(cx, cy, cz)))
 
-    assert(Parser.parseTerm("f('x)") == Term(f1, Seq(x)))
-    assert(Parser.parseTerm("f('x, 'y)") == Term(f2, Seq(x, y)))
-    assert(Parser.parseTerm("f('x, 'y, 'z)") == Term(f3, Seq(x, y, z)))
+    assert(FOLParser.parseTerm("f('x)") == Term(f1, Seq(x)))
+    assert(FOLParser.parseTerm("f('x, 'y)") == Term(f2, Seq(x, y)))
+    assert(FOLParser.parseTerm("f('x, 'y, 'z)") == Term(f3, Seq(x, y, z)))
   }
 
   test("schematic function application") {
-    // Parser.parseTerm("?f()") -- schematic functions of 0 arguments do not exist, those are variables
-    assert(Parser.parseTerm("'f(x)") == Term(sf1, Seq(cx)))
-    assert(Parser.parseTerm("'f(x, y)") == Term(sf2, Seq(cx, cy)))
-    assert(Parser.parseTerm("'f(x, y, z)") == Term(sf3, Seq(cx, cy, cz)))
+    // FOLParser.parseTerm("?f()") -- schematic functions of 0 arguments do not exist, those are variables
+    assert(FOLParser.parseTerm("'f(x)") == Term(sf1, Seq(cx)))
+    assert(FOLParser.parseTerm("'f(x, y)") == Term(sf2, Seq(cx, cy)))
+    assert(FOLParser.parseTerm("'f(x, y, z)") == Term(sf3, Seq(cx, cy, cz)))
 
-    assert(Parser.parseTerm("'f('x)") == Term(sf1, Seq(x)))
-    assert(Parser.parseTerm("'f('x, 'y)") == Term(sf2, Seq(x, y)))
-    assert(Parser.parseTerm("'f('x, 'y, 'z)") == Term(sf3, Seq(x, y, z)))
+    assert(FOLParser.parseTerm("'f('x)") == Term(sf1, Seq(x)))
+    assert(FOLParser.parseTerm("'f('x, 'y)") == Term(sf2, Seq(x, y)))
+    assert(FOLParser.parseTerm("'f('x, 'y, 'z)") == Term(sf3, Seq(x, y, z)))
   }
 
   test("nested function application") {
-    assert(Parser.parseTerm("'f('f('x), 'y)") == Term(sf2, Seq(Term(sf1, Seq(x)), y)))
+    assert(FOLParser.parseTerm("'f('f('x), 'y)") == Term(sf2, Seq(Term(sf1, Seq(x)), y)))
   }
 
   test("0-ary predicate") {
-    assert(Parser.parseFormula("a") == PredicateFormula(ConstantPredicateLabel("a", 0), Seq()))
-    assert(Parser.parseFormula("a()") == PredicateFormula(ConstantPredicateLabel("a", 0), Seq()))
+    assert(FOLParser.parseFormula("a") == PredicateFormula(ConstantPredicateLabel("a", 0), Seq()))
+    assert(FOLParser.parseFormula("a()") == PredicateFormula(ConstantPredicateLabel("a", 0), Seq()))
   }
 
   test("boolean constants") {
-    assert(Parser.parseFormula("true") == True)
-    assert(Parser.parseFormula("True") == True)
-    assert(Parser.parseFormula("T") == True)
-    assert(Parser.parseFormula("⊤") == True)
+    assert(FOLParser.parseFormula("true") == True)
+    assert(FOLParser.parseFormula("True") == True)
+    assert(FOLParser.parseFormula("T") == True)
+    assert(FOLParser.parseFormula("⊤") == True)
 
-    assert(Parser.parseFormula("false") == False)
-    assert(Parser.parseFormula("False") == False)
-    assert(Parser.parseFormula("F") == False)
-    assert(Parser.parseFormula("⊥") == False)
+    assert(FOLParser.parseFormula("false") == False)
+    assert(FOLParser.parseFormula("False") == False)
+    assert(FOLParser.parseFormula("F") == False)
+    assert(FOLParser.parseFormula("⊥") == False)
   }
 
   test("predicate application") {
-    assert(Parser.parseFormula("p(x, y, z)") == PredicateFormula(ConstantPredicateLabel("p", 3), Seq(cx, cy, cz)))
-    assert(Parser.parseFormula("p('x, 'y, 'z)") == PredicateFormula(ConstantPredicateLabel("p", 3), Seq(x, y, z)))
+    assert(FOLParser.parseFormula("p(x, y, z)") == PredicateFormula(ConstantPredicateLabel("p", 3), Seq(cx, cy, cz)))
+    assert(FOLParser.parseFormula("p('x, 'y, 'z)") == PredicateFormula(ConstantPredicateLabel("p", 3), Seq(x, y, z)))
   }
 
   test("equality") {
-    assert(Parser.parseFormula("(x = x)") == PredicateFormula(equality, Seq(cx, cx)))
-    assert(Parser.parseFormula("x = x") == PredicateFormula(equality, Seq(cx, cx)))
-    assert(Parser.parseFormula("a ∧ ('x = 'x)") == ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x)))))
+    assert(FOLParser.parseFormula("(x = x)") == PredicateFormula(equality, Seq(cx, cx)))
+    assert(FOLParser.parseFormula("x = x") == PredicateFormula(equality, Seq(cx, cx)))
+    assert(FOLParser.parseFormula("a ∧ ('x = 'x)") == ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x)))))
   }
 
   test("unicode connectors") {
-    assert(Parser.parseFormula("¬a") == ConnectorFormula(Neg, Seq(a)))
-    assert(Parser.parseFormula("a ∧ b") == ConnectorFormula(And, Seq(a, b)))
-    assert(Parser.parseFormula("a ∨ b") == ConnectorFormula(Or, Seq(a, b)))
-    assert(Parser.parseFormula("a ⇒ b") == ConnectorFormula(Implies, Seq(a, b)))
-    assert(Parser.parseFormula("a ↔ b") == ConnectorFormula(Iff, Seq(a, b)))
-    assert(Parser.parseFormula("a ⇔ b") == ConnectorFormula(Iff, Seq(a, b)))
+    assert(FOLParser.parseFormula("¬a") == ConnectorFormula(Neg, Seq(a)))
+    assert(FOLParser.parseFormula("a ∧ b") == ConnectorFormula(And, Seq(a, b)))
+    assert(FOLParser.parseFormula("a ∨ b") == ConnectorFormula(Or, Seq(a, b)))
+    assert(FOLParser.parseFormula("a ⇒ b") == ConnectorFormula(Implies, Seq(a, b)))
+    assert(FOLParser.parseFormula("a ↔ b") == ConnectorFormula(Iff, Seq(a, b)))
+    assert(FOLParser.parseFormula("a ⇔ b") == ConnectorFormula(Iff, Seq(a, b)))
   }
 
   test("ascii connectors") {
-    assert(Parser.parseFormula("!a") == ConnectorFormula(Neg, Seq(a)))
-    assert(Parser.parseFormula("a /\\ b") == ConnectorFormula(And, Seq(a, b)))
-    assert(Parser.parseFormula("a \\/ b") == ConnectorFormula(Or, Seq(a, b)))
-    assert(Parser.parseFormula("a => b") == ConnectorFormula(Implies, Seq(a, b)))
-    assert(Parser.parseFormula("a ==> b") == ConnectorFormula(Implies, Seq(a, b)))
-    assert(Parser.parseFormula("a <=> b") == ConnectorFormula(Iff, Seq(a, b)))
+    assert(FOLParser.parseFormula("!a") == ConnectorFormula(Neg, Seq(a)))
+    assert(FOLParser.parseFormula("a /\\ b") == ConnectorFormula(And, Seq(a, b)))
+    assert(FOLParser.parseFormula("a \\/ b") == ConnectorFormula(Or, Seq(a, b)))
+    assert(FOLParser.parseFormula("a => b") == ConnectorFormula(Implies, Seq(a, b)))
+    assert(FOLParser.parseFormula("a ==> b") == ConnectorFormula(Implies, Seq(a, b)))
+    assert(FOLParser.parseFormula("a <=> b") == ConnectorFormula(Iff, Seq(a, b)))
   }
 
   test("connector associativity") {
-    assert(Parser.parseFormula("a ∧ b ∧ c") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c)))
-    assert(Parser.parseFormula("a ∨ b ∨ c") == ConnectorFormula(Or, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∧ b ∧ c") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∨ b ∨ c") == ConnectorFormula(Or, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
   }
 
   test("connector priority") {
     // a ∨ (b ∧ c)
-    assert(Parser.parseFormula("a ∨ b ∧ c") == ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c)))))
+    assert(FOLParser.parseFormula("a ∨ b ∧ c") == ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c)))))
     // (a ∧ b) ∨ c
-    assert(Parser.parseFormula("a ∧ b ∨ c") == ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∧ b ∨ c") == ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c)))
 
     // (a ∧ b) => c
-    assert(Parser.parseFormula("a ∧ b => c") == ConnectorFormula(Implies, Seq(ConnectorFormula(And, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∧ b => c") == ConnectorFormula(Implies, Seq(ConnectorFormula(And, Seq(a, b)), c)))
     // a => (b ∧ c)
-    assert(Parser.parseFormula("a => b ∧ c") == ConnectorFormula(Implies, Seq(a, ConnectorFormula(And, Seq(b, c)))))
+    assert(FOLParser.parseFormula("a => b ∧ c") == ConnectorFormula(Implies, Seq(a, ConnectorFormula(And, Seq(b, c)))))
     // (a ∨ b) => c
-    assert(Parser.parseFormula("a ∨ b => c") == ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∨ b => c") == ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
     // a => (b ∨ c)
-    assert(Parser.parseFormula("a => b ∨ c") == ConnectorFormula(Implies, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
+    assert(FOLParser.parseFormula("a => b ∨ c") == ConnectorFormula(Implies, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
 
     // (a ∧ b) <=> c
-    assert(Parser.parseFormula("a ∧ b <=> c") == ConnectorFormula(Iff, Seq(ConnectorFormula(And, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∧ b <=> c") == ConnectorFormula(Iff, Seq(ConnectorFormula(And, Seq(a, b)), c)))
     // a <=> (b ∧ c)
-    assert(Parser.parseFormula("a <=> b ∧ c") == ConnectorFormula(Iff, Seq(a, ConnectorFormula(And, Seq(b, c)))))
+    assert(FOLParser.parseFormula("a <=> b ∧ c") == ConnectorFormula(Iff, Seq(a, ConnectorFormula(And, Seq(b, c)))))
     // (a ∨ b) <=> c
-    assert(Parser.parseFormula("a ∨ b <=> c") == ConnectorFormula(Iff, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∨ b <=> c") == ConnectorFormula(Iff, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
     // a <=> (b ∨ c)
-    assert(Parser.parseFormula("a <=> b ∨ c") == ConnectorFormula(Iff, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
+    assert(FOLParser.parseFormula("a <=> b ∨ c") == ConnectorFormula(Iff, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
   }
 
   test("connector parentheses") {
-    assert(Parser.parseFormula("(a ∨ b) ∧ c") == ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
-    assert(Parser.parseFormula("a ∧ (b ∨ c)") == ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
+    assert(FOLParser.parseFormula("(a ∨ b) ∧ c") == ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c)))
+    assert(FOLParser.parseFormula("a ∧ (b ∨ c)") == ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c)))))
   }
 
   test("schematic connectors") {
-    assert(Parser.parseFormula("?c(p(x), p(y))") == ConnectorFormula(sc2, Seq(p(cx), p(cy))))
-    assert(Parser.parseFormula("?c('phi('x)) <=> ?c('phi('y))") == iff(sc1(sPhi1(x)), sc1(sPhi1(y))))
-    assert(Parser.parseFormula("?c(p(x), p(x)) /\\ ?c(p(y), p(y))") == and(sc2(p(cx), p(cx)), sc2(p(cy), p(cy))))
+    assert(FOLParser.parseFormula("?c(p(x), p(y))") == ConnectorFormula(sc2, Seq(p(cx), p(cy))))
+    assert(FOLParser.parseFormula("?c('phi('x)) <=> ?c('phi('y))") == iff(sc1(sPhi1(x)), sc1(sPhi1(y))))
+    assert(FOLParser.parseFormula("?c(p(x), p(x)) /\\ ?c(p(y), p(y))") == and(sc2(p(cx), p(cx)), sc2(p(cy), p(cy))))
   }
 
   test("quantifiers") {
-    assert(Parser.parseFormula("∀ 'x. (p)") == BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
-    assert(Parser.parseFormula("∃ 'x. (p)") == BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
-    assert(Parser.parseFormula("∃! 'x. (p)") == BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∀ 'x. (p)") == BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∃ 'x. (p)") == BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∃! 'x. (p)") == BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
 
-    assert(Parser.parseFormula("∀ 'x. p") == BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
-    assert(Parser.parseFormula("∃ 'x. p") == BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
-    assert(Parser.parseFormula("∃! 'x. p") == BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∀ 'x. p") == BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∃ 'x. p") == BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
+    assert(FOLParser.parseFormula("∃! 'x. p") == BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq())))
   }
 
   test("nested quantifiers") {
-    assert(Parser.parseFormula("∀x. ∃y. ∃!z. a") == BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a))))
+    assert(FOLParser.parseFormula("∀x. ∃y. ∃!z. a") == BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a))))
   }
 
   test("quantifier parentheses") {
-    assert(Parser.parseFormula("∀x. b ∧ a") == BinderFormula(Forall, x, ConnectorFormula(And, Seq(b, a))))
+    assert(FOLParser.parseFormula("∀x. b ∧ a") == BinderFormula(Forall, x, ConnectorFormula(And, Seq(b, a))))
     assert(
-      Parser.parseFormula("∀ 'x. p('x) ∧ q('x)") == BinderFormula(
+      FOLParser.parseFormula("∀ 'x. p('x) ∧ q('x)") == BinderFormula(
         Forall,
         x,
         ConnectorFormula(And, Seq(PredicateFormula(ConstantPredicateLabel("p", 1), Seq(x)), PredicateFormula(ConstantPredicateLabel("q", 1), Seq(x))))
       )
     )
 
-    assert(Parser.parseFormula("(∀x. b) ∧ a") == ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a)))
+    assert(FOLParser.parseFormula("(∀x. b) ∧ a") == ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a)))
 
     assert(
-      Parser.parseFormula("(∀ 'x. p('x)) ∧ q('x)") == ConnectorFormula(
+      FOLParser.parseFormula("(∀ 'x. p('x)) ∧ q('x)") == ConnectorFormula(
         And,
         Seq(
           BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 1), Seq(x))),
@@ -163,39 +164,41 @@ class ParserTest extends AnyFunSuite with TestUtils {
       )
     )
 
-    assert(Parser.parseFormula("a ∧ (∀x. b) ∨ a") == ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a)))
-    assert(Parser.parseFormula("(a ∧ (∀x. b)) ∧ a") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a)))
+    assert(FOLParser.parseFormula("a ∧ (∀x. b) ∨ a") == ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a)))
+    assert(FOLParser.parseFormula("(a ∧ (∀x. b)) ∧ a") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a)))
   }
 
   test("complex formulas with connectors") {
-    assert(Parser.parseFormula("¬(a ∨ b)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Or, Seq(a, b)))))
-    assert(Parser.parseFormula("¬(¬a)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a)))))
-    assert(Parser.parseFormula("¬¬a") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a)))))
-    assert(Parser.parseFormula("¬¬(a ∧ b)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b)))))))
-    assert(Parser.parseFormula("¬a ∧ ¬b ∧ ¬c") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c)))))
+    assert(FOLParser.parseFormula("¬(a ∨ b)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Or, Seq(a, b)))))
+    assert(FOLParser.parseFormula("¬(¬a)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a)))))
+    assert(FOLParser.parseFormula("¬¬a") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a)))))
+    assert(FOLParser.parseFormula("¬¬(a ∧ b)") == ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b)))))))
+    assert(
+      FOLParser.parseFormula("¬a ∧ ¬b ∧ ¬c") == ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c))))
+    )
   }
 
   test("complex formulas") {
-    assert(Parser.parseFormula("∀x. 'x = 'x") == BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x))))
+    assert(FOLParser.parseFormula("∀x. 'x = 'x") == BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x))))
   }
 
   test("parser limitations") {
     // TODO: more specific error reporting check
-    assertThrows[Parser.ParserException](Parser.parseFormula("(a ∧ ∀x. b) ∧ a"))
+    assertThrows[ParserException](FOLParser.parseFormula("(a ∧ ∀x. b) ∧ a"))
 
   }
 
   test("sequent") {
     val forallEq = BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))
-    assert(Parser.parseSequent("∀x. 'x = 'x") == Sequent(Set(), Set(forallEq)))
-    assert(Parser.parseSequent("⊢ ∀x. 'x = 'x") == Sequent(Set(), Set(forallEq)))
-    assert(Parser.parseSequent("∀x. 'x = 'x ⊢ ∀x. 'x = 'x") == Sequent(Set(forallEq), Set(forallEq)))
+    assert(FOLParser.parseSequent("∀x. 'x = 'x") == Sequent(Set(), Set(forallEq)))
+    assert(FOLParser.parseSequent("⊢ ∀x. 'x = 'x") == Sequent(Set(), Set(forallEq)))
+    assert(FOLParser.parseSequent("∀x. 'x = 'x ⊢ ∀x. 'x = 'x") == Sequent(Set(forallEq), Set(forallEq)))
     val existsXEq = BinderFormula(Exists, x, PredicateFormula(equality, Seq(x, x)))
-    assert(Parser.parseSequent("∀x. 'x = 'x ⊢ ∃x. 'x = 'x") == Sequent(Set(forallEq), Set(existsXEq)))
+    assert(FOLParser.parseSequent("∀x. 'x = 'x ⊢ ∃x. 'x = 'x") == Sequent(Set(forallEq), Set(existsXEq)))
     val existsYEq = BinderFormula(Exists, y, PredicateFormula(equality, Seq(y, y)))
-    assert(Parser.parseSequent("∀x. 'x = 'x ⊢ ∃x. 'x = 'x; ∃y. 'y = 'y") == Sequent(Set(forallEq), Set(existsYEq, existsXEq)))
+    assert(FOLParser.parseSequent("∀x. 'x = 'x ⊢ ∃x. 'x = 'x; ∃y. 'y = 'y") == Sequent(Set(forallEq), Set(existsYEq, existsXEq)))
     assert(
-      Parser.parseSequent("p ; ∀x. 'x = 'x ⊢ ∃x. 'x = 'x; ∃y. 'y = 'y") ==
+      FOLParser.parseSequent("p ; ∀x. 'x = 'x ⊢ ∃x. 'x = 'x; ∃y. 'y = 'y") ==
         Sequent(Set(forallEq, PredicateFormula(ConstantPredicateLabel("p", 0), Seq())), Set(existsYEq, existsXEq))
     )
   }
@@ -203,23 +206,23 @@ class ParserTest extends AnyFunSuite with TestUtils {
   test("sequents from Mapping and SetTheory") {
     val va = VariableLabel("a")
     val leftAndRight = BinderFormula(ExistsOne, x, PredicateFormula(sPhi2, Seq(x, va)))
-    assert(Parser.parseSequent("∃!x. 'phi('x, 'a) ⊢ ∃!x. 'phi('x, 'a)") == Sequent(Set(leftAndRight), Set(leftAndRight)))
+    assert(FOLParser.parseSequent("∃!x. 'phi('x, 'a) ⊢ ∃!x. 'phi('x, 'a)") == Sequent(Set(leftAndRight), Set(leftAndRight)))
 
     assert(
-      Parser.parseSequent("∀x. ('x = 'x1) ↔ 'phi('x) ⊢ ('z = 'f('x1)) ⇒ (∃x. ('z = 'f('x)) ∧ 'phi('x))") == Sequent(
+      FOLParser.parseSequent("∀x. ('x = 'x1) ↔ 'phi('x) ⊢ ('z = 'f('x1)) ⇒ (∃x. ('z = 'f('x)) ∧ 'phi('x))") == Sequent(
         Set(BinderFormula(Forall, x, ConnectorFormula(Iff, Seq(x === x1, sPhi1(x))))),
         Set((z === sf1(x1)) ==> exists(x, (z === sf1(x)) /\ sPhi1(x)))
       )
     )
     assert(
-      Parser.parseSequent("∃x1. ∀x. ('x = 'x1) ↔ 'phi('x) ⊢ ∃z1. ∀z. ('z = 'z1) ↔ (∃x. ('z = 'f('x)) ∧ 'phi('x))") == (exists(x1, forall(x, (x === x1) <=> (sPhi1(x)))) |- exists(
+      FOLParser.parseSequent("∃x1. ∀x. ('x = 'x1) ↔ 'phi('x) ⊢ ∃z1. ∀z. ('z = 'z1) ↔ (∃x. ('z = 'f('x)) ∧ 'phi('x))") == (exists(x1, forall(x, (x === x1) <=> (sPhi1(x)))) |- exists(
         z1,
         forall(z, (z === z1) <=> exists(x, (z === sf1(x)) /\ sPhi1(x)))
       ))
     )
-    assert(Parser.parseSequent("⊢ ('x = 'x) ∨ ('x = 'y)") == (() |- (x === x) \/ (x === y)))
+    assert(FOLParser.parseSequent("⊢ ('x = 'x) ∨ ('x = 'y)") == (() |- (x === x) \/ (x === y)))
     assert(
-      Parser.parseSequent("('x = 'x) ∨ ('x = 'y); ('x = 'x) ∨ ('x = 'y) ↔ ('x = 'x1) ∨ ('x = 'y1) ⊢ ('x = 'x1) ∨ ('x = 'y1)") == (Set(
+      FOLParser.parseSequent("('x = 'x) ∨ ('x = 'y); ('x = 'x) ∨ ('x = 'y) ↔ ('x = 'x1) ∨ ('x = 'y1) ⊢ ('x = 'x1) ∨ ('x = 'y1)") == (Set(
         (x === x) \/ (x === y),
         ((x === x) \/ (x === y)) <=> ((x === x1) \/ (x === y1))
       ) |- (x === x1) \/ (x === y1))
@@ -227,26 +230,34 @@ class ParserTest extends AnyFunSuite with TestUtils {
   }
 
   test("equivalent names") {
-    assert(Parser.parseFormula("x∊y") == PredicateFormula(in, Seq(cx, cy)))
-    assert(Parser.parseFormula("x ∊ y") == PredicateFormula(in, Seq(cx, cy)))
-    assert(Parser.parseFormula("'x ∊ 'y") == PredicateFormula(in, Seq(x, y)))
-    assert(Parser.parseFormula("('x ∊ 'y) /\\ a") == ConnectorFormula(And, Seq(PredicateFormula(in, Seq(x, y)), a)))
-    assert(Parser.parseFormula("a \\/ ('x ∊ 'y)") == ConnectorFormula(Or, Seq(a, PredicateFormula(in, Seq(x, y)))))
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(in.id, "∊").build, "∊" :: Nil, Nil)
+    assert(parser.parseFormula("x∊y") == PredicateFormula(in, Seq(cx, cy)))
+    assert(parser.parseFormula("x ∊ y") == PredicateFormula(in, Seq(cx, cy)))
+    assert(parser.parseFormula("'x ∊ 'y") == PredicateFormula(in, Seq(x, y)))
+    assert(parser.parseFormula("('x ∊ 'y) /\\ a") == ConnectorFormula(And, Seq(PredicateFormula(in, Seq(x, y)), a)))
+    assert(parser.parseFormula("a \\/ ('x ∊ 'y)") == ConnectorFormula(Or, Seq(a, PredicateFormula(in, Seq(x, y)))))
   }
 
   test("infix functions") {
-    assert(Parser.parseTerm("x + y") == Term(plus, Seq(cx, cy)))
-    assert(Parser.parseTerm("(x + y) + z") == Term(plus, Seq(Term(plus, Seq(cx, cy)), cz)))
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(plus.id, "+").build, Nil, ("+", Associativity.Left) :: Nil)
+    assert(parser.parseTerm("x + y") == Term(plus, Seq(cx, cy)))
+    assert(parser.parseTerm("(x + y) + z") == Term(plus, Seq(Term(plus, Seq(cx, cy)), cz)))
   }
 
   test("mix of infix functions and infix predicates") {
-    assert(Parser.parseFormula("(x + y) ∊ z") == PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(in.id, "∊").addSynonyms(plus.id, "+").build, "∊" :: Nil, ("+", Associativity.Left) :: Nil)
+    assert(parser.parseFormula("(x + y) ∊ z") == PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
     assert(
-      Parser.parseFormula("x ∊ y /\\ x ∊ z /\\ (x + y) ∊ z") == ConnectorFormula(
+      parser.parseFormula("x ∊ y /\\ x ∊ z /\\ (x + y) ∊ z") == ConnectorFormula(
         And,
         Seq(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(cx, cy)), PredicateFormula(in, Seq(cx, cz)))), PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
       )
     )
+  }
 
+  test("infix function and predicate priority") {
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(plus.id, "+").build, equality.id :: Nil, ("+", Associativity.Left) :: Nil)
+    assert(parser.parseFormula("(x + y) = (y + x)") == PredicateFormula(equality, Seq(plus(cx, cy), plus(cy, cx))))
+    assert(parser.parseFormula("x + y = y + x") == PredicateFormula(equality, Seq(plus(cx, cy), plus(cy, cx))))
   }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
@@ -276,4 +276,22 @@ class PrinterTest extends AnyFunSuite with TestUtils {
     assert(Parser.printFormula(ConnectorFormula(And, Seq(PredicateFormula(prefixIn, Seq(x, y)), a))) == "'x ∊ 'y ∧ a")
     assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, PredicateFormula(prefixIn, Seq(x, y))))) == "a ∨ 'x ∊ 'y")
   }
+
+  test("infix functions") {
+    assert(Parser.printTerm(Term(plus, Seq(cx, cy))) == "x + y")
+    assert(Parser.printTerm(Term(plus, Seq(Term(plus, Seq(cx, cy)), cz))) == "(x + y) + z")
+  }
+
+  test("mix of infix functions and infix predicates") {
+    assert(Parser.printFormula(PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz))) == "(x + y) ∊ z")
+    assert(
+      Parser.printFormula(
+        ConnectorFormula(
+          And,
+          Seq(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(cx, cy)), PredicateFormula(in, Seq(cx, cz)))), PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
+        )
+      ) == "x ∊ y ∧ x ∊ z ∧ (x + y) ∊ z"
+    )
+
+  }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/PrinterTest.scala
@@ -2,9 +2,8 @@ package lisa.utils
 
 import lisa.kernel.fol.FOL.*
 import lisa.kernel.proof.SequentCalculus.Sequent
+import lisa.utils.FOLParser
 import lisa.utils.Helpers.*
-import lisa.utils.Parser
-import lisa.utils.Printer.*
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.adhocExtensions
@@ -12,165 +11,172 @@ import scala.language.adhocExtensions
 class PrinterTest extends AnyFunSuite with TestUtils {
 
   test("Minimal parenthesization") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, b))) == "a ∧ b")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∧ (b ∧ c)")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∨ b ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∨ c")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "(a ∨ b) ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ∧ (b ∨ c)")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, b))) == "a ∧ b")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∧ (b ∧ c)")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∨ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "(a ∨ b) ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ∧ (b ∨ c)")
 
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(a))) == "¬a")
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a))))) == "¬¬a")
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b))))))) == "¬¬(a ∧ b)")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(b)), ConnectorFormula(Neg, Seq(c))))))) == "¬a ∧ (¬b ∧ ¬c)")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c))))) == "¬a ∧ ¬b ∧ ¬c")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(a))) == "¬a")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a))))) == "¬¬a")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b))))))) == "¬¬(a ∧ b)")
+    assert(
+      FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(b)), ConnectorFormula(Neg, Seq(c))))))) == "¬a ∧ (¬b ∧ ¬c)"
+    )
+    assert(
+      FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c))))) == "¬a ∧ ¬b ∧ ¬c"
+    )
 
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ 'x = 'x")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ 'x = 'x")
 
-    assert(Parser.printFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀'x. 'x = 'x")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))))) == "a ∧ (∀'x. 'x = 'x)")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a))) == "(∀'x. b) ∧ a")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∧ a")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∨ a")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀'x. 'x = 'x")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))))) == "a ∧ (∀'x. 'x = 'x)")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a))) == "(∀'x. b) ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∨ a")
 
-    assert(Parser.printFormula(BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a)))) == "∀'x. ∃'y. ∃!'z. a")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a)))) == "∀'x. ∃'y. ∃!'z. a")
 
-    assert(Parser.printFormula(PredicateFormula(ConstantPredicateLabel("f", 3), Seq(x, y, z))) == "f('x, 'y, 'z)")
+    assert(FOLParser.printFormula(PredicateFormula(ConstantPredicateLabel("f", 3), Seq(x, y, z))) == "f('x, 'y, 'z)")
   }
 
   test("constant") {
-    assert(Parser.printTerm(Term(cx, Seq())) == "x")
+    assert(FOLParser.printTerm(Term(cx, Seq())) == "x")
   }
 
   test("variable") {
-    assert(Parser.printTerm(VariableTerm(x)) == "'x")
+    assert(FOLParser.printTerm(VariableTerm(x)) == "'x")
   }
 
   test("constant function application") {
-    assert(Parser.printTerm(Term(f1, Seq(cx))) == "f(x)")
-    assert(Parser.printTerm(Term(f2, Seq(cx, cy))) == "f(x, y)")
-    assert(Parser.printTerm(Term(f3, Seq(cx, cy, cz))) == "f(x, y, z)")
+    assert(FOLParser.printTerm(Term(f1, Seq(cx))) == "f(x)")
+    assert(FOLParser.printTerm(Term(f2, Seq(cx, cy))) == "f(x, y)")
+    assert(FOLParser.printTerm(Term(f3, Seq(cx, cy, cz))) == "f(x, y, z)")
 
-    assert(Parser.printTerm(Term(f1, Seq(x))) == "f('x)")
-    assert(Parser.printTerm(Term(f2, Seq(x, y))) == "f('x, 'y)")
-    assert(Parser.printTerm(Term(f3, Seq(x, y, z))) == "f('x, 'y, 'z)")
+    assert(FOLParser.printTerm(Term(f1, Seq(x))) == "f('x)")
+    assert(FOLParser.printTerm(Term(f2, Seq(x, y))) == "f('x, 'y)")
+    assert(FOLParser.printTerm(Term(f3, Seq(x, y, z))) == "f('x, 'y, 'z)")
   }
 
   test("schematic function application") {
-    assert(Parser.printTerm(Term(sf1, Seq(cx))) == "'f(x)")
-    assert(Parser.printTerm(Term(sf2, Seq(cx, cy))) == "'f(x, y)")
-    assert(Parser.printTerm(Term(sf3, Seq(cx, cy, cz))) == "'f(x, y, z)")
+    assert(FOLParser.printTerm(Term(sf1, Seq(cx))) == "'f(x)")
+    assert(FOLParser.printTerm(Term(sf2, Seq(cx, cy))) == "'f(x, y)")
+    assert(FOLParser.printTerm(Term(sf3, Seq(cx, cy, cz))) == "'f(x, y, z)")
 
-    assert(Parser.printTerm(Term(sf1, Seq(x))) == "'f('x)")
-    assert(Parser.printTerm(Term(sf2, Seq(x, y))) == "'f('x, 'y)")
-    assert(Parser.printTerm(Term(sf3, Seq(x, y, z))) == "'f('x, 'y, 'z)")
+    assert(FOLParser.printTerm(Term(sf1, Seq(x))) == "'f('x)")
+    assert(FOLParser.printTerm(Term(sf2, Seq(x, y))) == "'f('x, 'y)")
+    assert(FOLParser.printTerm(Term(sf3, Seq(x, y, z))) == "'f('x, 'y, 'z)")
   }
 
   test("nested function application") {
-    assert(Parser.printTerm(Term(sf2, Seq(Term(sf1, Seq(x)), y))) == "'f('f('x), 'y)")
+    assert(FOLParser.printTerm(Term(sf2, Seq(Term(sf1, Seq(x)), y))) == "'f('f('x), 'y)")
   }
 
   test("0-ary predicate") {
-    assert(Parser.printFormula(PredicateFormula(ConstantPredicateLabel("a", 0), Seq())) == "a")
+    assert(FOLParser.printFormula(PredicateFormula(ConstantPredicateLabel("a", 0), Seq())) == "a")
   }
 
   test("predicate application") {
-    assert(Parser.printFormula(PredicateFormula(ConstantPredicateLabel("p", 3), Seq(cx, cy, cz))) == "p(x, y, z)")
-    assert(Parser.printFormula(PredicateFormula(ConstantPredicateLabel("p", 3), Seq(x, y, z))) == "p('x, 'y, 'z)")
+    assert(FOLParser.printFormula(PredicateFormula(ConstantPredicateLabel("p", 3), Seq(cx, cy, cz))) == "p(x, y, z)")
+    assert(FOLParser.printFormula(PredicateFormula(ConstantPredicateLabel("p", 3), Seq(x, y, z))) == "p('x, 'y, 'z)")
   }
 
   test("equality") {
-    assert(Parser.printFormula(PredicateFormula(equality, Seq(cx, cx))) == "x = x")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ 'x = 'x")
+    assert(FOLParser.printFormula(PredicateFormula(equality, Seq(cx, cx))) == "x = x")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, PredicateFormula(equality, Seq(x, x))))) == "a ∧ 'x = 'x")
+  }
+
+  test("toplevel connectors") {
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(a, b))) == "a ⇒ b")
+    assert(FOLParser.printFormula(ConnectorFormula(Iff, Seq(a, b))) == "a ⇔ b")
   }
 
   test("unicode connectors") {
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(a))) == "¬a")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, b))) == "a ∧ b")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, b))) == "a ∨ b")
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(a, b))) == "a ⇒ b")
-    assert(Parser.printFormula(ConnectorFormula(Iff, Seq(a, b))) == "a ⇔ b")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(a))) == "¬a")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, b))) == "a ∧ b")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a, b))) == "a ∨ b")
   }
 
   test("connector associativity") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ∨ c")
   }
 
   test("and/or of 1 argument") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a))) == "a")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a))) == "a")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a))) == "a")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a))) == "a")
 
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a)), ConnectorFormula(And, Seq(a))))) == "(a) ⇒ (a)")
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(a, a))) == "a ⇒ a")
-    assert(Parser.printFormula(BinderFormula(Forall, x, ConnectorFormula(Or, Seq(a)))) == "∀'x. a")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a)), ConnectorFormula(And, Seq(a))))) == "a ⇒ a")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(a, a))) == "a ⇒ a")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, ConnectorFormula(Or, Seq(a)))) == "∀'x. a")
   }
 
   test("connectors of >2 arguments") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, b, c))) == "a ∧ b ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, b, c))) == "a ∨ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, b, c))) == "a ∧ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a, b, c))) == "a ∨ b ∨ c")
 
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, b, c, a))) == "a ∧ b ∧ c ∧ a")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, b, c, b))) == "a ∨ b ∨ c ∨ b")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, b, c, a))) == "a ∧ b ∧ c ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a, b, c, b))) == "a ∨ b ∨ c ∨ b")
 
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b, c)), ConnectorFormula(And, Seq(c, b, a))))) == "a ∧ b ∧ c ∨ c ∧ b ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b, c)), ConnectorFormula(And, Seq(c, b, a))))) == "a ∧ b ∧ c ∨ c ∧ b ∧ a")
   }
 
   test("connectors with no arguments") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq())) == "⊤")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq())) == "⊥")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq())) == "⊤")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq())) == "⊥")
   }
 
   test("connector priority") {
     // a ∨ (b ∧ c)
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∨ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ∨ b ∧ c")
     // (a ∧ b) ∨ c
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ∨ c")
 
     // (a ∧ b) => c
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ⇒ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ⇒ c")
     // a => (b ∧ c)
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ⇒ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ⇒ b ∧ c")
     // (a ∨ b) => c
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ⇒ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ⇒ c")
     // a => (b ∨ c)
-    assert(Parser.printFormula(ConnectorFormula(Implies, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ⇒ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Implies, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ⇒ b ∨ c")
 
     // (a ∧ b) <=> c
-    assert(Parser.printFormula(ConnectorFormula(Iff, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ⇔ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Iff, Seq(ConnectorFormula(And, Seq(a, b)), c))) == "a ∧ b ⇔ c")
     // a <=> (b ∧ c)
-    assert(Parser.printFormula(ConnectorFormula(Iff, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ⇔ b ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Iff, Seq(a, ConnectorFormula(And, Seq(b, c))))) == "a ⇔ b ∧ c")
     // (a ∨ b) <=> c
-    assert(Parser.printFormula(ConnectorFormula(Iff, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ⇔ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Iff, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "a ∨ b ⇔ c")
     // a <=> (b ∨ c)
-    assert(Parser.printFormula(ConnectorFormula(Iff, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ⇔ b ∨ c")
+    assert(FOLParser.printFormula(ConnectorFormula(Iff, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ⇔ b ∨ c")
   }
 
   test("connector parentheses") {
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "(a ∨ b) ∧ c")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ∧ (b ∨ c)")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(Or, Seq(a, b)), c))) == "(a ∨ b) ∧ c")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(a, ConnectorFormula(Or, Seq(b, c))))) == "a ∧ (b ∨ c)")
   }
 
   test("schematic connectors") {
-    assert(Parser.printFormula(sc1(p(x))) == "?c(p('x))")
-    assert(Parser.printFormula(iff(sc1(p(x)), sc2(p(y), p(y)))) == "?c(p('x)) ⇔ ?c(p('y), p('y))")
+    assert(FOLParser.printFormula(sc1(p(x))) == "?c(p('x))")
+    assert(FOLParser.printFormula(iff(sc1(p(x)), sc2(p(y), p(y)))) == "?c(p('x)) ⇔ ?c(p('y), p('y))")
   }
 
   test("quantifiers") {
-    assert(Parser.printFormula(BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∀'x. p")
-    assert(Parser.printFormula(BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∃'x. p")
-    assert(Parser.printFormula(BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∃!'x. p")
+    assert(FOLParser.printFormula(BinderFormula(Forall, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∀'x. p")
+    assert(FOLParser.printFormula(BinderFormula(Exists, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∃'x. p")
+    assert(FOLParser.printFormula(BinderFormula(ExistsOne, VariableLabel("x"), PredicateFormula(ConstantPredicateLabel("p", 0), Seq()))) == "∃!'x. p")
   }
 
   test("nested quantifiers") {
-    assert(Parser.printFormula(BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a)))) == "∀'x. ∃'y. ∃!'z. a")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, BinderFormula(Exists, y, BinderFormula(ExistsOne, z, a)))) == "∀'x. ∃'y. ∃!'z. a")
   }
 
   test("quantifier parentheses") {
-    assert(Parser.printFormula(BinderFormula(Forall, x, ConnectorFormula(And, Seq(b, a)))) == "∀'x. b ∧ a")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, ConnectorFormula(And, Seq(b, a)))) == "∀'x. b ∧ a")
     assert(
-      Parser.printFormula(
+      FOLParser.printFormula(
         BinderFormula(
           Forall,
           x,
@@ -179,10 +185,10 @@ class PrinterTest extends AnyFunSuite with TestUtils {
       ) == "∀'x. p('x) ∧ q('x)"
     )
 
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a))) == "(∀'x. b) ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(BinderFormula(Forall, x, b), a))) == "(∀'x. b) ∧ a")
 
     assert(
-      Parser.printFormula(
+      FOLParser.printFormula(
         ConnectorFormula(
           And,
           Seq(
@@ -193,27 +199,29 @@ class PrinterTest extends AnyFunSuite with TestUtils {
       ) == "(∀'x. p('x)) ∧ q('x)"
     )
 
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∨ a")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∧ a")
+    assert(FOLParser.printFormula(ConnectorFormula(Or, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∨ a")
+    assert(FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(a, BinderFormula(Forall, x, b))), a))) == "a ∧ (∀'x. b) ∧ a")
   }
 
   test("complex formulas with connectors") {
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Or, Seq(a, b))))) == "¬(a ∨ b)")
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a))))) == "¬¬a")
-    assert(Parser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b))))))) == "¬¬(a ∧ b)")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c))))) == "¬a ∧ ¬b ∧ ¬c")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Or, Seq(a, b))))) == "¬(a ∨ b)")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(a))))) == "¬¬a")
+    assert(FOLParser.printFormula(ConnectorFormula(Neg, Seq(ConnectorFormula(Neg, Seq(ConnectorFormula(And, Seq(a, b))))))) == "¬¬(a ∧ b)")
+    assert(
+      FOLParser.printFormula(ConnectorFormula(And, Seq(ConnectorFormula(And, Seq(ConnectorFormula(Neg, Seq(a)), ConnectorFormula(Neg, Seq(b)))), ConnectorFormula(Neg, Seq(c))))) == "¬a ∧ ¬b ∧ ¬c"
+    )
   }
 
   test("complex formulas") {
-    assert(Parser.printFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀'x. 'x = 'x")
+    assert(FOLParser.printFormula(BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))) == "∀'x. 'x = 'x")
   }
 
   test("sequent") {
     val forallEq = BinderFormula(Forall, x, PredicateFormula(equality, Seq(x, x)))
-    assert(Parser.printSequent(Sequent(Set(), Set(forallEq))) == "⊢ ∀'x. 'x = 'x")
-    assert(Parser.printSequent(Sequent(Set(forallEq), Set(forallEq))) == "∀'x. 'x = 'x ⊢ ∀'x. 'x = 'x")
+    assert(FOLParser.printSequent(Sequent(Set(), Set(forallEq))) == "⊢ ∀'x. 'x = 'x")
+    assert(FOLParser.printSequent(Sequent(Set(forallEq), Set(forallEq))) == "∀'x. 'x = 'x ⊢ ∀'x. 'x = 'x")
     val existsXEq = BinderFormula(Exists, x, PredicateFormula(equality, Seq(x, x)))
-    assert(Parser.printSequent(Sequent(Set(forallEq), Set(existsXEq))) == "∀'x. 'x = 'x ⊢ ∃'x. 'x = 'x")
+    assert(FOLParser.printSequent(Sequent(Set(forallEq), Set(existsXEq))) == "∀'x. 'x = 'x ⊢ ∃'x. 'x = 'x")
   }
 
   // warning: this test might be flaky because formula order is not fixed in sequents but fixed in the string representation
@@ -222,11 +230,11 @@ class PrinterTest extends AnyFunSuite with TestUtils {
     val existsXEq = BinderFormula(Exists, x, PredicateFormula(equality, Seq(x, x)))
     val existsYEq = BinderFormula(Exists, y, PredicateFormula(equality, Seq(y, y)))
     assert(
-      Parser.printSequent(Sequent(Set(forallEq), Set(existsYEq, existsXEq))) == "∀'x. 'x = 'x ⊢ ∃'y. 'y = 'y; " +
+      FOLParser.printSequent(Sequent(Set(forallEq), Set(existsYEq, existsXEq))) == "∀'x. 'x = 'x ⊢ ∃'y. 'y = 'y; " +
         "∃'x. 'x = 'x"
     )
     assert(
-      Parser.printSequent(Sequent(Set(forallEq, PredicateFormula(ConstantPredicateLabel("p", 0), Seq())), Set(existsYEq, existsXEq))) == "∀'x. 'x = 'x; p ⊢ ∃'y. 'y = 'y; ∃'x. 'x = 'x"
+      FOLParser.printSequent(Sequent(Set(forallEq, PredicateFormula(ConstantPredicateLabel("p", 0), Seq())), Set(existsYEq, existsXEq))) == "∀'x. 'x = 'x; p ⊢ ∃'y. 'y = 'y; ∃'x. 'x = 'x"
     )
   }
 
@@ -234,10 +242,10 @@ class PrinterTest extends AnyFunSuite with TestUtils {
   test("sequents from Mapping and SetTheory") {
     val va = VariableLabel("a")
     val leftAndRight = BinderFormula(ExistsOne, x, PredicateFormula(sPhi2, Seq(x, va)))
-    assert(Parser.printSequent(Sequent(Set(leftAndRight), Set(leftAndRight))) == "∃!'x. 'phi('x, 'a) ⊢ ∃!'x. 'phi('x, 'a)")
+    assert(FOLParser.printSequent(Sequent(Set(leftAndRight), Set(leftAndRight))) == "∃!'x. 'phi('x, 'a) ⊢ ∃!'x. 'phi('x, 'a)")
 
     assert(
-      Parser.printSequent(
+      FOLParser.printSequent(
         Sequent(
           Set(BinderFormula(Forall, x, ConnectorFormula(Iff, Seq(x === x1, sPhi1(x))))),
           Set((z === sf1(x1)) ==> exists(x, (z === sf1(x)) /\ sPhi1(x)))
@@ -245,16 +253,16 @@ class PrinterTest extends AnyFunSuite with TestUtils {
       ) == "∀'x. 'x = 'x1 ⇔ 'phi('x) ⊢ 'z = 'f('x1) ⇒ (∃'x. 'z = 'f('x) ∧ 'phi('x))"
     )
     assert(
-      Parser.printSequent(
+      FOLParser.printSequent(
         exists(x1, forall(x, (x === x1) <=> (sPhi1(x)))) |- exists(
           z1,
           forall(z, (z === z1) <=> exists(x, (z === sf1(x)) /\ sPhi1(x)))
         )
       ) == "∃'x1. ∀'x. 'x = 'x1 ⇔ 'phi('x) ⊢ ∃'z1. ∀'z. 'z = 'z1 ⇔ (∃'x. 'z = 'f('x) ∧ 'phi('x))"
     )
-    assert(Parser.printSequent((() |- (x === x) \/ (x === y))) == "⊢ 'x = 'x ∨ 'x = 'y")
+    assert(FOLParser.printSequent((() |- (x === x) \/ (x === y))) == "⊢ 'x = 'x ∨ 'x = 'y")
     assert(
-      Parser.printSequent(
+      FOLParser.printSequent(
         Set(
           (x === x) \/ (x === y),
           ((x === x) \/ (x === y)) <=> ((x === xPrime) \/ (x === yPrime))
@@ -266,31 +274,34 @@ class PrinterTest extends AnyFunSuite with TestUtils {
   test("infix predicates") {
     val in = ConstantPredicateLabel("∊", 2)
     val prefixIn = ConstantPredicateLabel("elem", 2)
-    assert(Parser.printFormula(PredicateFormula(in, Seq(cx, cy))) == "x ∊ y")
-    assert(Parser.printFormula(PredicateFormula(in, Seq(x, y))) == "'x ∊ 'y")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(x, y)), a))) == "'x ∊ 'y ∧ a")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, PredicateFormula(in, Seq(x, y))))) == "a ∨ 'x ∊ 'y")
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(prefixIn.id, in.id).build, in.id :: Nil, Nil)
+    assert(parser.printFormula(PredicateFormula(in, Seq(cx, cy))) == "x ∊ y")
+    assert(parser.printFormula(PredicateFormula(in, Seq(x, y))) == "'x ∊ 'y")
+    assert(parser.printFormula(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(x, y)), a))) == "'x ∊ 'y ∧ a")
+    assert(parser.printFormula(ConnectorFormula(Or, Seq(a, PredicateFormula(in, Seq(x, y))))) == "a ∨ 'x ∊ 'y")
 
-    assert(Parser.printFormula(PredicateFormula(prefixIn, Seq(cx, cy))) == "x ∊ y")
-    assert(Parser.printFormula(PredicateFormula(prefixIn, Seq(x, y))) == "'x ∊ 'y")
-    assert(Parser.printFormula(ConnectorFormula(And, Seq(PredicateFormula(prefixIn, Seq(x, y)), a))) == "'x ∊ 'y ∧ a")
-    assert(Parser.printFormula(ConnectorFormula(Or, Seq(a, PredicateFormula(prefixIn, Seq(x, y))))) == "a ∨ 'x ∊ 'y")
+    assert(parser.printFormula(PredicateFormula(prefixIn, Seq(cx, cy))) == "x ∊ y")
+    assert(parser.printFormula(PredicateFormula(prefixIn, Seq(x, y))) == "'x ∊ 'y")
+    assert(parser.printFormula(ConnectorFormula(And, Seq(PredicateFormula(prefixIn, Seq(x, y)), a))) == "'x ∊ 'y ∧ a")
+    assert(parser.printFormula(ConnectorFormula(Or, Seq(a, PredicateFormula(prefixIn, Seq(x, y))))) == "a ∨ 'x ∊ 'y")
   }
 
   test("infix functions") {
-    assert(Parser.printTerm(Term(plus, Seq(cx, cy))) == "x + y")
-    assert(Parser.printTerm(Term(plus, Seq(Term(plus, Seq(cx, cy)), cz))) == "(x + y) + z")
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(plus.id, "+").build, Nil, ("+", Associativity.Left) :: Nil)
+    assert(parser.printTerm(Term(plus, Seq(cx, cy))) == "x + y")
+    assert(parser.printTerm(Term(plus, Seq(Term(plus, Seq(cx, cy)), cz))) == "x + y + z")
   }
 
   test("mix of infix functions and infix predicates") {
-    assert(Parser.printFormula(PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz))) == "(x + y) ∊ z")
+    val parser = Parser(SynonymInfoBuilder().addSynonyms(in.id, "∊").addSynonyms(plus.id, "+").build, "∊" :: Nil, ("+", Associativity.Left) :: Nil)
+    assert(parser.printFormula(PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz))) == "x + y ∊ z")
     assert(
-      Parser.printFormula(
+      parser.printFormula(
         ConnectorFormula(
           And,
           Seq(ConnectorFormula(And, Seq(PredicateFormula(in, Seq(cx, cy)), PredicateFormula(in, Seq(cx, cz)))), PredicateFormula(in, Seq(Term(plus, Seq(cx, cy)), cz)))
         )
-      ) == "x ∊ y ∧ x ∊ z ∧ (x + y) ∊ z"
+      ) == "x ∊ y ∧ x ∊ z ∧ x + y ∊ z"
     )
 
   }

--- a/lisa-utils/src/test/scala/lisa/utils/SCProofStepFinderTests.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/SCProofStepFinderTests.scala
@@ -170,7 +170,7 @@ class SCProofStepFinderTests extends AnyFunSuite {
           SCProofChecker.checkSCProof(proof) match {
             case SCValidProof(_) => // OK
               println(testname)
-              println(Printer.prettySCProof(proof))
+              println(FOLPrinter.prettySCProof(proof))
               println()
               // Dirty, but only way to test that
               val proofWithoutLast = proof.copy(steps = proof.steps.init)
@@ -180,7 +180,7 @@ class SCProofStepFinderTests extends AnyFunSuite {
                   assert(view.exists(filter), s"The proof step finder was not able to find the step '$testname'")
                 case SCExplicitProofStep(step) => assert(false)
               }
-            case invalid: SCInvalidProof => throw new AssertionError(s"The reconstructed proof for '$testname' is incorrect:\n${Printer.prettySCProof(invalid)}")
+            case invalid: SCInvalidProof => throw new AssertionError(s"The reconstructed proof for '$testname' is incorrect:\n${FOLPrinter.prettySCProof(invalid)}")
           }
         case Failure(exception) => throw new AssertionError(s"Couldn't reconstruct the proof for '$testname'", exception) // Couldn't reconstruct this proof
       }

--- a/lisa-utils/src/test/scala/lisa/utils/TestUtils.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/TestUtils.scala
@@ -14,6 +14,7 @@ trait TestUtils {
   val (sf1, sf2, sf3) = (SchematicFunctionLabel("f", 1), SchematicFunctionLabel("f", 2), SchematicFunctionLabel("f", 3))
   val (sPhi1, sPhi2) = (SchematicPredicateLabel("phi", 1), SchematicPredicateLabel("phi", 2))
   val (sc1, sc2) = (SchematicConnectorLabel("c", 1), SchematicConnectorLabel("c", 2))
+  val (in, plus) = (ConstantPredicateLabel("elem", 2), ConstantFunctionLabel("+", 2))
 
   given Conversion[PredicateLabel, PredicateFormula] = PredicateFormula(_, Seq.empty)
 

--- a/src/main/scala/lisa/automation/kernel/ProofTactics.scala
+++ b/src/main/scala/lisa/automation/kernel/ProofTactics.scala
@@ -3,8 +3,8 @@ package lisa.automation.kernel
 import lisa.kernel.fol.FOL.*
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SequentCalculus.*
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.{_, given}
-import lisa.utils.Printer.*
 
 /**
  * SCProof tactics are a set of strategies that help the user write proofs in a more expressive way

--- a/src/main/scala/lisa/automation/kernel/SimplePropositionalSolver.scala
+++ b/src/main/scala/lisa/automation/kernel/SimplePropositionalSolver.scala
@@ -3,9 +3,9 @@ package lisa.automation.kernel
 import lisa.kernel.fol.FOL.*
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SequentCalculus.*
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.{_, given}
 import lisa.utils.Library
-import lisa.utils.Printer
 import lisa.utils.tactics.ProofTacticLib.ParameterlessAndThen
 import lisa.utils.tactics.ProofTacticLib.ParameterlessHave
 import lisa.utils.tactics.ProofTacticLib.ProofTactic
@@ -236,7 +236,7 @@ object SimplePropositionalSolver {
         val premsFormulas = premises.map(p => (p, sequentToFormula(proof.getSequent(p)))).zipWithIndex
         val initProof = premsFormulas.map(s => Rewrite(() |- s._1._2, -(1 + s._2))).toList
         val sqToProve = bot ++< (premsFormulas.map(s => s._1._2).toSet |- ())
-        println(Printer.prettySequent(sqToProve))
+        println(FOLPrinter.prettySequent(sqToProve))
         val subpr = SCSubproof(solveSequent(sqToProve))
         checkProof(subpr.sp)
         val stepsList = premsFormulas.foldLeft[List[SCProofStep]](List(subpr))((prev: List[SCProofStep], cur) => {

--- a/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
+++ b/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
@@ -3,8 +3,8 @@ package lisa.automation.kernel
 import lisa.kernel.fol.FOL.*
 import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SequentCalculus.*
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.*
-import lisa.utils.Printer
 import lisa.utils.tactics.ProofTacticLib.*
 
 import scala.collection
@@ -118,7 +118,7 @@ object SimpleSimplifier {
           val isolatedLeft = originSequent.left.filterNot(f => isSame(f, phi)).map(f => (f, findSubterm(f, IndexedSeq(v -> left))))
           val isolatedRight = originSequent.right.map(f => (f, findSubterm(f, IndexedSeq(v -> left))))
           if (isolatedLeft.forall(_._2.isEmpty) && isolatedRight.forall(_._2.isEmpty))
-            return proof.InvalidProofTactic(s"There is no instance of ${Printer.prettyTerm(left)} to replace.")
+            return proof.InvalidProofTactic(s"There is no instance of ${FOLPrinter.prettyTerm(left)} to replace.")
 
           val leftForm = ConnectorFormula(And, isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
           val rightForm = ConnectorFormula(Or, isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
@@ -145,7 +145,7 @@ object SimpleSimplifier {
           val isolatedLeft = originSequent.left.filterNot(f => isSame(f, phi)).map(f => (f, findSubformula(f, IndexedSeq(H -> left))))
           val isolatedRight = originSequent.right.map(f => (f, findSubformula(f, IndexedSeq(H -> left))))
           if (isolatedLeft.forall(_._2.isEmpty) && isolatedRight.forall(_._2.isEmpty))
-            return proof.InvalidProofTactic(s"There is no instance of ${Printer.prettyFormula(left)} to replace.")
+            return proof.InvalidProofTactic(s"There is no instance of ${FOLPrinter.prettyFormula(left)} to replace.")
 
           val leftForm = ConnectorFormula(And, isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
           val rightForm = ConnectorFormula(Or, isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)

--- a/src/main/scala/lisa/proven/peano_example/Peano.scala
+++ b/src/main/scala/lisa/proven/peano_example/Peano.scala
@@ -37,22 +37,22 @@ object Peano { /*
   }
 
   def applyInduction(baseProof: SC.SCSubproof, inductionStepProof: SC.SCSubproof, inductionInstance: SCProofStep): IndexedSeq[SCProofStep] = {
-    require(baseProof.bot.right.size == 1, s"baseProof should prove exactly one formula, got ${Printer.prettySequent(baseProof.bot)}")
-    require(inductionStepProof.bot.right.size == 1, s"inductionStepProof should prove exactly one formula, got ${Printer.prettySequent(inductionStepProof.bot)}")
+    require(baseProof.bot.right.size == 1, s"baseProof should prove exactly one formula, got ${FOLPrinter.prettySequent(baseProof.bot)}")
+    require(inductionStepProof.bot.right.size == 1, s"inductionStepProof should prove exactly one formula, got ${FOLPrinter.prettySequent(inductionStepProof.bot)}")
     require(
       inductionInstance.bot.left.isEmpty && inductionInstance.bot.right.size == 1,
-      s"induction instance step should have nothing on the left and exactly one formula on the right, got ${Printer.prettySequent(inductionInstance.bot)}"
+      s"induction instance step should have nothing on the left and exactly one formula on the right, got ${FOLPrinter.prettySequent(inductionInstance.bot)}"
     )
     val (premise, conclusion) = (inductionInstance.bot.right.head match {
       case ConnectorFormula(Implies, Seq(premise, conclusion)) => (premise, conclusion)
-      case _ => require(false, s"induction instance should be of the form A => B, got ${Printer.prettyFormula(inductionInstance.bot.right.head)}")
+      case _ => require(false, s"induction instance should be of the form A => B, got ${FOLPrinter.prettyFormula(inductionInstance.bot.right.head)}")
     }): @unchecked
     val baseFormula = baseProof.bot.right.head
     val stepFormula = inductionStepProof.bot.right.head
     require(
       isSame(baseFormula /\ stepFormula, premise),
       "induction instance premise should be of the form base /\\ step, got " +
-        s"premise: ${Printer.prettyFormula(premise)}, base: ${Printer.prettyFormula(baseFormula)}, step: ${Printer.prettyFormula(stepFormula)}"
+        s"premise: ${FOLPrinter.prettyFormula(premise)}, base: ${FOLPrinter.prettyFormula(baseFormula)}, step: ${FOLPrinter.prettyFormula(stepFormula)}"
     )
 
     val lhs: Set[Formula] = baseProof.bot.left ++ inductionStepProof.bot.left

--- a/src/test/scala/lisa/automation/ProofTests.scala
+++ b/src/test/scala/lisa/automation/ProofTests.scala
@@ -3,7 +3,7 @@ package lisa.automation
 import lisa.automation.Proof2.*
 import lisa.front.fol.FOL.*
 import lisa.kernel.proof.SCProofChecker
-import lisa.utils.Printer
+import lisa.utils.FOLPrinter
 import org.scalatest.Ignore
 import org.scalatest.funsuite.AnyFunSuite
 
@@ -23,11 +23,11 @@ class ProofTests extends AnyFunSuite {
     assert(result.nonEmpty, s"kernel proof was empty for $proof")
     val scProof = result.get._1
     val judgement = SCProofChecker.checkSCProof(scProof)
-    assert(judgement.isValid, Printer.prettySCProof(judgement))
-    assert(scProof.imports.isEmpty, s"proof unexpectedly uses imports: ${Printer.prettySCProof(judgement)}")
+    assert(judgement.isValid, FOLPrinter.prettySCProof(judgement))
+    assert(scProof.imports.isEmpty, s"proof unexpectedly uses imports: ${FOLPrinter.prettySCProof(judgement)}")
     assert(
       lisa.kernel.proof.SequentCalculus.isSameSequent(scProof.conclusion, proof.initialState.goals.head),
-      s"proof does not prove ${Printer.prettySequent(proof.initialState.goals.head)}:\nPrinter.prettySCProof(judgement)"
+      s"proof does not prove ${FOLPrinter.prettySequent(proof.initialState.goals.head)}:\nPrinter.prettySCProof(judgement)"
     )
   }
 

--- a/src/test/scala/lisa/proven/SimpleProverTests.scala
+++ b/src/test/scala/lisa/proven/SimpleProverTests.scala
@@ -7,9 +7,8 @@ import lisa.kernel.proof.RunningTheory.PredicateLogic
 import lisa.kernel.proof.SCProofChecker
 import lisa.tptp.KernelParser.*
 import lisa.tptp.ProblemGatherer.getPRPproblems
+import lisa.utils.FOLPrinter
 import lisa.utils.Helpers.*
-import lisa.utils.Printer
-import lisa.utils.Printer.*
 import org.scalatest.funsuite.AnyFunSuite
 
 import scala.language.adhocExtensions
@@ -22,7 +21,7 @@ class SimpleProverTests extends AnyFunSuite {
         problems.foreach( pr => {
             println("--- Problem "+pr.file)
             val sq = problemToSequent(pr)
-            println(prettySequent(sq))
+            println(FOLPrinter.prettySequent(sq))
             val proof = SPS.solveSequent(sq)
             if (!Seq("Unsatisfiable", "Theorem", "Satisfiable").contains(pr.status)) println("Unknown status: "+pr.status+", "+pr.file)
 


### PR DESCRIPTION
1. Introduce Termula type, which doesn't distinguish function application from predicate application. A string is parsed into a Termula, which then gets converted into a Formula or a Term, with the appropriate checks.
Telling apart infix function and predicate application in LL1 parser does not appear feasible: consider two inputs, (x + y) < z and (a /\ b) /\ c. The parser is parsing a formula and observes '(' as the first token. It can either mean a subformula or a subterm with an infix operator, and this conflict seems fundamental. With the introduction of Termula, '(' corresponds to a start of subtermula, and the rest of the inputs is parsed either into a connector termula or an (infix) application termula.

2. Turn the parser into a class, which takes in its constructor the information about synonymous names, infix function names with associativity information in decreasing order of priority, and infix predicate names in decreasing order of priority.

3. Create the parser and printer for first order logic, which are not aware of any synonyms nor infix functions and know of only one infix predicate: equality. Use those instances wherever the parser or printer objects used to be used.

Fixes #75 