### PR TITLE
Improve kernel parser exceptions

### DIFF
--- a/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ParserTest.scala
@@ -260,4 +260,27 @@ class ParserTest extends AnyFunSuite with TestUtils {
     assert(parser.parseFormula("(x + y) = (y + x)") == PredicateFormula(equality, Seq(plus(cx, cy), plus(cy, cx))))
     assert(parser.parseFormula("x + y = y + x") == PredicateFormula(equality, Seq(plus(cx, cy), plus(cy, cx))))
   }
+
+  test("parser exception: unexpected input") {
+    try {
+      FOLParser.parseFormula("f(x y)")
+    } catch {
+      case e: UnexpectedInputException => assert(e.getMessage.startsWith("""
+          |f(x y)
+          |    ^
+          |Unexpected input""".stripMargin))
+    }
+  }
+
+  test("parser exception: formula instead of term") {
+    try {
+      FOLParser.parseFormula("x = (a /\\ b)")
+    } catch {
+      case e: UnexpectedInputException =>
+        assert(e.getMessage.startsWith("""
+            |x = (a /\ b)
+            |     ^^^^^^
+            |Unexpected input: expected term""".stripMargin))
+    }
+  }
 }


### PR DESCRIPTION
Most importantly, keep track of positions when parsing and report the error, highlighting the position where it occurred. Two types of errors are reported:
* unexpected input: highlight the unexpected token and suggest expected kinds of input
* expected term, got formula: highlight the unexpected formula

Since applications are eagerly converted to function or predicate application depending on the expected type, "expected formula, got term" error is currently not detected. This can be improved in the future.

Part of #86.