### PR TITLE
QuickFix: remove occurences of _ in set theory definitions causing identifier errors

### DIFF
--- a/lisa-examples/src/main/scala/Exercise.scala
+++ b/lisa-examples/src/main/scala/Exercise.scala
@@ -22,7 +22,7 @@ object Exercise extends lisa.Main {
     have("'P('x) ==> 'P('f('f('x)))") subproof {
       assume("∀'x. 'P('x) ⇒ 'P('f('x))")
       have("'P('f('x)) ==> 'P('f('f('x))) |- 'P('x) ==> 'P('f('f('x)))") by LeftForall(x)(base)
-      andThen("∀'x. 'P('x) ⇒ 'P('f('x))|- 'P('x) ==> 'P('f('f('x)))") by LeftForall(f(f(x)))
+      andThen("∀'x. 'P('x) ⇒ 'P('f('x))|- 'P('x) ==> 'P('f('f('x)))") by LeftForall(f(x))
     }
     showCurrentProof()
   }

--- a/lisa-theories/src/main/scala/lisa/settheory/SetTheoryDefinitions.scala
+++ b/lisa-theories/src/main/scala/lisa/settheory/SetTheoryDefinitions.scala
@@ -21,12 +21,12 @@ private[settheory] trait SetTheoryDefinitions {
   /**
    * The symbol for the subset predicate.
    */
-  final val subset = ConstantPredicateLabel("subset_of", 2)
+  final val subset = ConstantPredicateLabel("subsetOf", 2)
 
   /**
    * The symbol for the equicardinality predicate. Needed for Tarski's axiom.
    */
-  final val sim = ConstantPredicateLabel("same_cardinality", 2) // Equicardinality
+  final val sim = ConstantPredicateLabel("sameCardinality", 2) // Equicardinality
   /**
    * Set Theory basic predicates
    */
@@ -37,17 +37,17 @@ private[settheory] trait SetTheoryDefinitions {
   /**
    * The symbol for the empty set constant.
    */
-  final val emptySet = ConstantFunctionLabel("empty_set", 0)
+  final val emptySet = ConstantFunctionLabel("emptySet", 0)
 
   /**
    * The symbol for the unordered pair function.
    */
-  final val unorderedPair = ConstantFunctionLabel("unordered_pair", 2)
+  final val unorderedPair = ConstantFunctionLabel("unorderedPair", 2)
 
   /**
    * The symbol for the powerset function.
    */
-  final val powerSet = ConstantFunctionLabel("power_set", 1)
+  final val powerSet = ConstantFunctionLabel("powerSet", 1)
 
   /**
    * The symbol for the set union function.

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -18,7 +18,7 @@ object SetTheory extends lisa.Main {
   show
 
   THEOREM("unorderedPair_symmetry") of
-    "⊢ ∀'y. ∀'x. unordered_pair('x, 'y) = unordered_pair('y, 'x)" PROOF2 {
+    "⊢ ∀'y. ∀'x. unorderedPair('x, 'y) = unorderedPair('y, 'x)" PROOF2 {
       val x = VariableLabel("x")
       val y = VariableLabel("y")
       val z = VariableLabel("z")
@@ -72,7 +72,7 @@ object SetTheory extends lisa.Main {
 
   // This proof is old and very unoptimised
   THEOREM("unorderedPair_deconstruction") of
-    "⊢ ∀'x. ∀'y. ∀ 'x1. ∀ 'y1. unordered_pair('x, 'y) = unordered_pair('x1, 'y1) ⇒ 'y1 = 'y ∧ 'x1 = 'x ∨ 'x = 'y1 ∧ 'y = 'x1" PROOF2 {
+    "⊢ ∀'x. ∀'y. ∀ 'x1. ∀ 'y1. unorderedPair('x, 'y) = unorderedPair('x1, 'y1) ⇒ 'y1 = 'y ∧ 'x1 = 'x ∨ 'x = 'y1 ∧ 'y = 'x1" PROOF2 {
       val x = VariableLabel("x")
       val y = VariableLabel("y")
       val x1 = VariableLabel("x'")


### PR DESCRIPTION
Changed names in definitions of standard set theoretic functions and predicates, e.g. `power_set` to `powerSet` to fix an error caused by `Identifier` checking for occurrences of `_` as a separator.  Relevant references (though in some currently commented proofs) were also changed. 

Side benefit: the string versions now match the Scala versions of the definitions :partying_face: .