### PR TITLE
Tests for proof tactics

### DIFF
--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -944,9 +944,9 @@ object BasicStepTactic {
 
   /**
    * <pre>
-   *    Γ, φ(s1,...,sn) |- Δ
-   * ---------------------
-   *  Γ, s1=-1, ..., sn=tn, φ(-1,...tn) |- Δ
+   *           Γ, φ(s1,...,sn) |- Δ
+   * ----------------------------------------
+   *  Γ, s1=t1, ..., sn=tn, φ(t1,...tn) |- Δ
    * </pre>
    */
   object LeftSubstEq extends ProofTactic {
@@ -971,9 +971,9 @@ object BasicStepTactic {
 
   /**
    * <pre>
-   *    Γ |- φ(s1,...,sn), Δ
-   * ---------------------
-   *  Γ, s1=-1, ..., sn=tn |- φ(-1,...tn), Δ
+   *          Γ |- φ(s1,...,sn), Δ
+   * ----------------------------------------
+   *  Γ, s1=t1, ..., sn=tn |- φ(t1,...tn), Δ
    * </pre>
    */
   object RightSubstEq extends ProofTactic {
@@ -987,8 +987,8 @@ object BasicStepTactic {
       if (!isSameSet(bot.left, premiseSequent.left ++ equalities))
         proof.InvalidProofTactic("Left-hand side of the conclusion is not the same as the left-hand side of the premise + (s=t)_.")
       else if (
-        !isSameSet(bot.left + phi_s, premiseSequent.left + phi_t) &&
-        !isSameSet(bot.left + phi_t, premiseSequent.left + phi_s)
+        !isSameSet(bot.right + phi_s, premiseSequent.right + phi_t) &&
+        !isSameSet(bot.right + phi_t, premiseSequent.right + phi_s)
       )
         proof.InvalidProofTactic("Right-hand side of the conclusion + φ(s_) is not the same as right-hand side of the premise + φ(t_) (or with s_ and t_ swapped).")
       else
@@ -998,8 +998,8 @@ object BasicStepTactic {
 
   /**
    * <pre>
-   *    Γ, φ(a1,...an) |- Δ
-   * ---------------------
+   *           Γ, φ(a1,...an) |- Δ
+   * ----------------------------------------
    *  Γ, a1↔b1, ..., an↔bn, φ(b1,...bn) |- Δ
    * </pre>
    */
@@ -1025,8 +1025,8 @@ object BasicStepTactic {
 
   /**
    * <pre>
-   *    Γ |- φ(a1,...an), Δ
-   * ---------------------
+   *           Γ |- φ(a1,...an), Δ
+   * ----------------------------------------
    *  Γ, a1↔b1, ..., an↔bn |- φ(b1,...bn), Δ
    * </pre>
    */

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -159,16 +159,14 @@ object BasicStepTactic {
       lazy val premiseSequents = premises.map(proof.getSequent(_))
       lazy val pivots = premiseSequents.map(_.left.diff(bot.left))
 
-      if (premises.length == 0)
-        proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
+      if (premises.length == 0) proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
       else if (pivots.exists(_.isEmpty)) {
         val emptyIndex = pivots.indexWhere(_.isEmpty)
         if (isSubset(premiseSequents(emptyIndex).left, bot.left))
           unwrapTactic(Weakening(premises(emptyIndex))(bot))("Attempted weakening on trivial premise for LeftOr failed.")
         else
           proof.InvalidProofTactic("Right-hand side of conclusion is not a superset of the one of the premises.")
-      }
-      else if (pivots.forall(_.tail.isEmpty))
+      } else if (pivots.forall(_.tail.isEmpty))
         LeftOr.withParameters(pivots.map(_.head): _*)(premises: _*)(bot)
       else
         // some extraneous formulae
@@ -495,16 +493,14 @@ object BasicStepTactic {
       lazy val premiseSequents = premises.map(proof.getSequent(_))
       lazy val pivots = premiseSequents.map(_.right.diff(bot.right))
 
-      if (premises.length == 0)
-        proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
+      if (premises.length == 0) proof.InvalidProofTactic(s"Premises expected, ${premises.length} received.")
       else if (pivots.exists(_.isEmpty)) {
         val emptyIndex = pivots.indexWhere(_.isEmpty)
         if (isSubset(premiseSequents(emptyIndex).left, bot.left))
           unwrapTactic(Weakening(premises(emptyIndex))(bot))("Attempted weakening on trivial premise for RightAnd failed.")
         else
           proof.InvalidProofTactic("Left-hand side of conclusion is not a superset of the one of the premises.")
-      }
-      else if (pivots.forall(_.tail.isEmpty))
+      } else if (pivots.forall(_.tail.isEmpty))
         RightAnd.withParameters(pivots.map(_.head): _*)(premises: _*)(bot)
       else
         // some extraneous formulae

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -1041,8 +1041,8 @@ object BasicStepTactic {
       if (!isSameSet(bot.left, premiseSequent.left ++ implications))
         proof.InvalidProofTactic("Left-hand side of the conclusion is not the same as the left-hand side of the premise + (ψ ↔ τ)_.")
       else if (
-        !isSameSet(bot.left + phi_psi, premiseSequent.left + phi_tau) &&
-        !isSameSet(bot.left + phi_tau, premiseSequent.left + phi_psi)
+        !isSameSet(bot.right + phi_psi, premiseSequent.right + phi_tau) &&
+        !isSameSet(bot.right + phi_tau, premiseSequent.right + phi_psi)
       )
         proof.InvalidProofTactic("Right-hand side of the conclusion + φ(ψ_) is not the same as right-hand side of the premise + φ(τ_) (or with ψ_ and τ_ swapped).")
       else

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
@@ -7,9 +7,9 @@ import lisa.kernel.proof.SequentCalculus.RewriteTrue
 import lisa.kernel.proof.SequentCalculus.SCProofStep
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus as SC
+import lisa.utils.FOLParser
 import lisa.utils.Helpers.{_, given}
 import lisa.utils.Library
-import lisa.utils.FOLParser
 import lisa.utils.LisaException
 import lisa.utils.OutputManager
 import lisa.utils.tactics.ProofTacticLib.{_, given}

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/SimpleDeducedSteps.scala
@@ -9,6 +9,7 @@ import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus as SC
 import lisa.utils.Helpers.{_, given}
 import lisa.utils.Library
+import lisa.utils.FOLParser
 import lisa.utils.LisaException
 import lisa.utils.OutputManager
 import lisa.utils.tactics.ProofTacticLib.{_, given}
@@ -64,12 +65,12 @@ object SimpleDeducedSteps {
    * Returns a subproof containing the instantiation steps
    */
   object InstantiateForall extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: FOL.Formula, t: FOL.Term*)(premise: proof.Fact): proof.ProofTacticJudgement = {
+    def apply(using proof: Library#Proof)(phi: FOL.Formula, t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val premiseSequent = proof.getSequent(premise)
       if (!premiseSequent.right.contains(phi)) {
         proof.InvalidProofTactic("Input formula was not found in the RHS of the premise sequent.")
       } else {
-        val emptyProof = SCProof(IndexedSeq(), IndexedSeq(proof.getSequent(-1)))
+        val emptyProof = SCProof(IndexedSeq(), IndexedSeq(proof.getSequent(premise)))
         val j = proof.ValidProofTactic(Seq(SC.Rewrite(premiseSequent, -1)), Seq(premise))
         val res = t.foldLeft((emptyProof, phi, j: proof.ProofTacticJudgement)) { case ((p, f, j), t) =>
           j match {
@@ -83,17 +84,17 @@ object SimpleDeducedSteps {
                   val tempVar = FOL.VariableLabel(freshId(psi.freeVariables.map(_.id), x.id))
                   // instantiate the formula with input
                   val in = instantiateBinder(psi, t)
-                  val bot = p.conclusion -> f +> in
+                  val con = p.conclusion -> f +> in
                   // construct proof
                   val p0 = SC.Hypothesis(in |- in, in)
                   val p1 = SC.LeftForall(f |- in, 0, instantiateBinder(psi, tempVar), tempVar, t)
-                  val p2 = SC.Cut(bot, -1, 1, f)
+                  val p2 = SC.Cut(con, -1, 1, f)
 
                   /**
                    * in  = ψ[t/x]
                    *
                    * s1  = Γ ⊢ ∀x.ψ, Δ        Premise
-                   * bot = Γ ⊢ ψ[t/x], Δ      Result
+                   * con = Γ ⊢ ψ[t/x], Δ      Result
                    *
                    * p0  = ψ[t/x] ⊢ ψ[t/x]    Hypothesis
                    * p1  = ∀x.ψ ⊢ ψ[t/x]      LeftForall p0
@@ -113,16 +114,21 @@ object SimpleDeducedSteps {
 
         res._3 match {
           case proof.InvalidProofTactic(_) => res._3
-          case proof.ValidProofTactic(_, _) => proof.ValidProofTactic(Seq(SC.SCSubproof(res._1, Seq(-1))), Seq(premise))
+          case proof.ValidProofTactic(_, _) => {
+            if (SC.isSameSequent(res._1.conclusion, bot))
+              proof.ValidProofTactic(Seq(SC.SCSubproof(res._1, Seq(-1))), Seq(premise))
+            else
+              proof.InvalidProofTactic(s"InstantiateForall proved \n\t${FOLParser.printSequent(res._1.conclusion)}\ninstead of input sequent\n\t${bot}")
+          }
         }
       }
     }
 
-    def apply(using proof: Library#Proof)(t: FOL.Term*)(premise: proof.Fact): proof.ProofTacticJudgement = {
+    def apply(using proof: Library#Proof)(t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val prem = proof.getSequent(premise)
       if (prem.right.tail.isEmpty) {
         // well formed
-        apply(using proof)(prem.right.head, t*)(premise): proof.ProofTacticJudgement
+        apply(using proof)(prem.right.head, t*)(premise)(bot): proof.ProofTacticJudgement
       } else proof.InvalidProofTactic("RHS of premise sequent is not a singleton.")
     }
   }

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -920,7 +920,46 @@ class BasicTacticTest extends ProofTacticTestLib {
       Weakening(prem)(stmt2)
     }
   }
+
   // left refl
+  test("Tactic Tests: Left Refl - Parameter Inference") {
+    val correct = List(
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z) |- 'P('x)"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)"),
+    )
+
+    val incorrect = List(
+      ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z) |- 'P('x)"),
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'x |- 'P('x)"),
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)"),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftRefl(prem)(stmt2)
+    }
+  }
+
+  test("Tactic Tests: Left Refl - Explicit Parameters") {
+    val correct = List(
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'x = 'x"),
+    )
+
+    val incorrect = List(
+      ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'y"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'y = 'y"),
+      ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)", "'x = 'x"),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form) =>
+      val prem = introduceSequent(stmt1)
+      LeftRefl.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
+    }
+  }
   // right refl
 
   // left substeq

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -896,6 +896,30 @@ class BasicTacticTest extends ProofTacticTestLib {
     }
   }
 
+  // weakening
+  test("Tactic Tests: Weakening") {
+    val correct = List(
+      ("'P('x) |- ", "'P('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
+      ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
+      ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x); 'Q('z)"),
+      ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)"),
+    )
+
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'P('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'P('x) |- "),
+      ("'P('x); 'S('y) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
+      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
+      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      Weakening(prem)(stmt2)
+    }
+  }
   // left refl
   // right refl
 

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1,11 +1,12 @@
 package lisa.utils
 
-import lisa.utils.tactics.BasicStepTactic.*
-import lisa.utils.tactics.ProofTacticLib
 import lisa.kernel.proof.{SequentCalculus as SC}
 import lisa.utils.Library
-import scala.collection.immutable.LazyList
+import lisa.utils.tactics.BasicStepTactic.*
+import lisa.utils.tactics.ProofTacticLib
 import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.immutable.LazyList
 
 class BasicTacticTest extends AnyFunSuite with BasicMain {
 

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1049,7 +1049,44 @@ class BasicTacticTest extends ProofTacticTestLib {
       LeftSubstEq(forms.map((a, b) => (FOLParser.parseTerm(a), FOLParser.parseTerm(b))), ltf)(prem)(stmt2)
     }
   }
+
   // right substeq
+  test("Tactic Tests: Right SubstEq") {
+    val q = variable
+    val w = variable
+    val e = variable
+    val r = variable
+    val t = variable
+    val y = variable
+    val Y = predicate(6)
+    val Y1 = LambdaTermFormula(Seq(q), Y(q, w, e, r, t, y))
+    val Y2 = LambdaTermFormula(Seq(q, w), Y(q, w, e, r, t, y))
+    val Y5 = LambdaTermFormula(Seq(q, w, e, r, t, y), Y(q, w, e, r, t, y))
+
+    val correct = List(
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 's = 'w |- 'R('x); 'Y('a, 's, 'e, 'r, 't, 'y)", List(("'a", "'q"), ("'s", "'w")), Y2),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+    )
+
+    val incorrect = List(
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x) |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'w |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 'S('x) |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 'S('x) |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'S('x); 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
+      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
+      val prem = introduceSequent(stmt1)
+      RightSubstEq(forms.map((a, b) => (FOLParser.parseTerm(a), FOLParser.parseTerm(b))), ltf)(prem)(stmt2)
+    }
+  }
 
   // left substiff
   // right substiff

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -2,10 +2,10 @@ package lisa.utils
 
 import lisa.kernel.proof.{SequentCalculus as SC}
 import lisa.utils.Library
+import lisa.utils.ProofTacticTestLib
 import lisa.utils.tactics.BasicStepTactic.*
 import lisa.utils.tactics.ProofTacticLib
 import org.scalatest.funsuite.AnyFunSuite
-import lisa.utils.ProofTacticTestLib
 
 class BasicTacticTest extends ProofTacticTestLib {
 

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -704,7 +704,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'P('x); 'Q('x) <=> 'S('x)"),
       ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'Q('x) <=> 'T('x)"),
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
-      ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)"),
+      ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
@@ -901,7 +901,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
       ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
       ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x); 'Q('z)"),
-      ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)"),
+      ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)")
     )
 
     val incorrect = List(
@@ -909,7 +909,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "'P('x) |- "),
       ("'P('x); 'S('y) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
       ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
-      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
+      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
@@ -922,14 +922,14 @@ class BasicTacticTest extends ProofTacticTestLib {
   test("Tactic Tests: Left Refl - Parameter Inference") {
     val correct = List(
       ("'R('z); 'x = 'x |- 'P('x)", "'R('z) |- 'P('x)"),
-      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)")
     )
 
     val incorrect = List(
       ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)"),
       ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z) |- 'P('x)"),
       ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'x |- 'P('x)"),
-      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)"),
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
@@ -941,7 +941,7 @@ class BasicTacticTest extends ProofTacticTestLib {
   test("Tactic Tests: Left Refl - Explicit Parameters") {
     val correct = List(
       ("'R('z); 'x = 'x |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
-      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'x = 'x"),
+      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'x = 'x")
     )
 
     val incorrect = List(
@@ -949,7 +949,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'y = 'y"),
       ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
       ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
-      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)", "'x = 'x"),
+      ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)", "'x = 'x")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, form) =>
@@ -965,7 +965,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       (" |- 'x = 'x; 'P('x)"),
       ("'P('x) |- 'x = 'x"),
       ("'P('x) |- 'x = 'x; 'R('x)"),
-      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x"),
+      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x")
     )
 
     val incorrect = List(
@@ -973,7 +973,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       (" |- 'P('x)"),
       (" |- 'x = 'y"),
       ("'P('x) |- 'x = 'y"),
-      ("'P('x) |- 'x = 'y; 'R('x)"),
+      ("'P('x) |- 'x = 'y; 'R('x)")
     )
 
     testTacticCases(correct, incorrect) { (stmt) =>
@@ -987,7 +987,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       (" |- 'x = 'x; 'P('x)", "'x = 'x"),
       ("'P('x) |- 'x = 'x", "'x = 'x"),
       ("'P('x) |- 'x = 'x; 'R('x)", "'x = 'x"),
-      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x", "'x = 'x"),
+      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x", "'x = 'x")
     )
 
     val incorrect = List(
@@ -1001,7 +1001,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'x = 'y", "'x = 'x"),
       ("'P('x) |- 'x = 'y", "'x = 'y"),
       ("'P('x) |- 'x = 'y; 'R('x)", "'x = 'x"),
-      ("'P('x) |- 'x = 'y; 'R('x)", "'x = 'y"),
+      ("'P('x) |- 'x = 'y; 'R('x)", "'x = 'y")
     )
 
     testTacticCases(correct, incorrect) { (stmt, form) =>
@@ -1026,7 +1026,12 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 's = 'w; 'Y('a, 's, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q"), ("'s", "'w")), Y2),
-      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+      (
+        "'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")),
+        Y5
+      )
     )
 
     val incorrect = List(
@@ -1036,9 +1041,24 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'S('x); 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'S('x); 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
       ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'S('x); 'R('x)", List(("'a", "'q")), Y1),
-      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
-      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
-      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+      (
+        "'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")),
+        Y5
+      ),
+      (
+        "'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")),
+        Y5
+      ),
+      (
+        "'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")),
+        Y5
+      )
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
@@ -1064,7 +1084,12 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 's = 'w |- 'R('x); 'Y('a, 's, 'e, 'r, 't, 'y)", List(("'a", "'q"), ("'s", "'w")), Y2),
-      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+      (
+        "'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)",
+        "'P('x); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")),
+        Y5
+      )
     )
 
     val incorrect = List(
@@ -1074,9 +1099,24 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 'S('x) |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q; 'S('x) |- 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
       ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('x); 'a = 'q |- 'S('x); 'R('x); 'Y('a, 'w, 'e, 'r, 't, 'y)", List(("'a", "'q")), Y1),
-      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
-      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
-      ("'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+      (
+        "'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")),
+        Y5
+      ),
+      (
+        "'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")),
+        Y5
+      ),
+      (
+        "'P('x) |- 'R('x); 'Y('q, 'w, 'e, 'r, 't, 'y)",
+        "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't |- 'R('x); 'Y('a, 's, 'd, 'f, 'g, 'h)",
+        List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")),
+        Y5
+      )
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
@@ -1110,22 +1150,77 @@ class BasicTacticTest extends ProofTacticTestLib {
     val Y5 = LambdaFormulaFormula(Seq(z, x, c, v, b, n), z /\ x /\ c /\ v /\ b /\ n)
 
     val correct = List(
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q), (s, w)), Y2),
-      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q), (s, w)),
+        Y2
+      ),
+      (
+        "'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)),
+        Y5
+      )
     )
 
     val incorrect = List(
       ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
       ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'W('w)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
-      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'S('x); 'R('x)", List((a, q)), Y1),
-      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
-      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
-      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'W('w)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'S('x); 'R('x)",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)),
+        Y5
+      ),
+      (
+        "'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)),
+        Y5
+      ),
+      (
+        "'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)),
+        Y5
+      )
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
@@ -1159,22 +1254,77 @@ class BasicTacticTest extends ProofTacticTestLib {
     val Y5 = LambdaFormulaFormula(Seq(z, x, c, v, b, n), z /\ x /\ c /\ v /\ b /\ n)
 
     val correct = List(
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q), (s, w)), Y2),
-      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q), (s, w)),
+        Y2
+      ),
+      (
+        "'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)),
+        Y5
+      )
     )
 
     val incorrect = List(
       ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
       ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'S('x); 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
-      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
-      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
-      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('x); ('A('a) <=> 'Q('q)) |- 'S('x); 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        List((a, q)),
+        Y1
+      ),
+      (
+        "'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)),
+        Y5
+      ),
+      (
+        "'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)),
+        Y5
+      ),
+      (
+        "'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))",
+        "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))",
+        List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)),
+        Y5
+      )
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
@@ -1199,7 +1349,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'Q('h('x, 'y)) |- 'R('y)", "'P('x); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
       ("'P('h('y, 'y)); 'Q('h('x, 'y)) |- 'R('y)", "'P('g('y, 'y)); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
       ("'P('x); 'Q('g('x, 'y)) |- 'R('y)", "'P('x); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
-      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z, f -> Y)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z, f -> Y))
     )
 
     val incorrect = List(
@@ -1209,7 +1359,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('h('y, 'y)); 'Q('h('x, 'y)) |- 'R('y)", "'P('g('y, 'y)); 'Q('g('y, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
       ("'P('x); 'Q('g('x, 'y)) |- 'R('y)", "'P('x); 'Q('h('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
       ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'z", Map[SchematicTermLabel, LambdaTermTerm](h -> Z, f -> Y)),
-      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z))
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, termMap) =>
@@ -1234,7 +1384,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'h('x, 'y) |- 'R('y)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
       ("'h('y, 'y); 'h('x, 'y) |- 'R('y)", "'g('y, 'y); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
       ("'P('x); 'g('x, 'y) |- 'R('y)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
-      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 'x", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 'x", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y))
     )
 
     val incorrect = List(
@@ -1245,7 +1395,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'g('x, 'y) |- 'R('y)", "'P('x); 'h('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
       ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 't", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
       ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 'x", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
-      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y))
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, termMap) =>

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -10,934 +10,935 @@ import org.scalatest.funsuite.AnyFunSuite
 
 class BasicTacticTest extends ProofTacticTestLib {
 
-    // hypothesis
-    test("Tactic Tests: Hypothesis") {
-        val correct = List(
-            ("'P('x) |- 'P('x)"), 
-            ("'P('x) |- 'P('x); 'Q('x)"),
-            ("'P('x); 'Q('x) |- 'P('x); 'Q('x)"),
-            ("'P('x); 'Q('x) |- 'P('x)"),
-        )
+  // hypothesis
+  test("Tactic Tests: Hypothesis") {
+    val correct = List(
+      ("'P('x) |- 'P('x)"),
+      ("'P('x) |- 'P('x); 'Q('x)"),
+      ("'P('x); 'Q('x) |- 'P('x); 'Q('x)"),
+      ("'P('x); 'Q('x) |- 'P('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- "),
-            (" |- 'P('x)"),
-            (" |- 'P('x); 'Q('x)"),
-            ("'Q('x) |- "),
-        )
+    val incorrect = List(
+      ("'P('x) |- "),
+      (" |- 'P('x)"),
+      (" |- 'P('x); 'Q('x)"),
+      ("'Q('x) |- ")
+    )
 
-        val testProof = generateTestProof()
+    val testProof = generateTestProof()
 
-        testTacticCases(correct, incorrect){
-            Hypothesis(_)
-        }
+    testTacticCases(correct, incorrect) {
+      Hypothesis(_)
     }
+  }
 
-    // rewrite
-    // TODO: make this use equivalence checker tests
-    test("Tactic Tests: Rewrite") {
-        val correct = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) /\\ 'Q('x) |- 'R('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)"),
-        )
+  // rewrite
+  // TODO: make this use equivalence checker tests
+  test("Tactic Tests: Rewrite") {
+    val correct = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) /\\ 'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) ")
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) ")
+    )
 
-        val testProof = generateTestProof()
+    val testProof = generateTestProof()
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            Rewrite(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      Rewrite(prem)(stmt2)
     }
+  }
 
-    // cut
-    test("Tactic Tests: Cut - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
-            // ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"), // can't infer params out of conjunctions yet
-            // ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
-            ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)")
-        )
+  // cut
+  test("Tactic Tests: Cut - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+      // ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"), // can't infer params out of conjunctions yet
+      // ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+      ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)")
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)")
+    )
 
-        val testProof = generateTestProof()
+    val testProof = generateTestProof()
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            Cut(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      Cut(prem1, prem2)(stmt3)
     }
+  }
 
-    test("Tactic Tests: Cut - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
-            ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)", "'R('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)", "'R('x)")
-        )
+  test("Tactic Tests: Cut - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
+      ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)", "'R('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)", "'R('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)", "'R('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
-            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'P('x)"),
-            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x) /\\ 'P('x)"),
-            ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)", "'R('x)")
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)", "'R('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
+      ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'P('x)"),
+      ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x) /\\ 'P('x)"),
+      ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)", "'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3, form) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            Cut.withParameters(FOLParser.parseFormula(form))(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3, form) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      Cut.withParameters(FOLParser.parseFormula(form))(prem1, prem2)(stmt3)
     }
+  }
 
-    // left rules
+  // left rules
 
-    //     left and
-    test("Tactic Tests: Left And - Parameter Inference") {
-        val correct = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x); 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)"),
-        )
+  //     left and
+  test("Tactic Tests: Left And - Parameter Inference") {
+    val correct = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x); 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            LeftAnd(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftAnd(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left And - Explicit Parameters") {
-        val correct = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
-        )
+  test("Tactic Tests: Left And - Explicit Parameters") {
+    val correct = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
+      ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
-            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x)"),
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
+      ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, phi, psi) =>
-            val prem = introduceSequent(stmt1)
-            LeftAnd.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, phi, psi) =>
+      val prem = introduceSequent(stmt1)
+      LeftAnd.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
     }
+  }
 
-    //     left or
-    test("Tactic Tests: Left Or - Parameter Inference") {
-        val correct = List(
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)"),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'E('x) \\/ 'T('x); 'P('x) |- 'Q('x); 'S('x)"),
-            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)"),
-        )
+  //     left or
+  test("Tactic Tests: Left Or - Parameter Inference") {
+    val correct = List(
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)"),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'E('x) \\/ 'T('x); 'P('x) |- 'Q('x); 'S('x)"),
+      (List("'P('x) |- 'S('x)"), "'P('x) |- 'S('x)")
+    )
 
-        val incorrect = List(
-            (List(),  "'P('x) |- 'S('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'T('x); 'S('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'T('x) |- 'Q('x); 'S('x)"),
-        )
+    val incorrect = List(
+      (List(), "'P('x) |- 'S('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x) |- 'T('x); 'S('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x); 'T('x) |- 'Q('x); 'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmts, stmt2) =>
-            val prems = stmts.map(introduceSequent(_))
-            LeftOr(prems: _*)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmts, stmt2) =>
+      val prems = stmts.map(introduceSequent(_))
+      LeftOr(prems: _*)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left Or - Explicit Parameters") {
-        val correct = List(
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)", List("'P('x)")),
-        )
+  test("Tactic Tests: Left Or - Explicit Parameters") {
+    val correct = List(
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)"), "'P('x) |- 'S('x)", List("'P('x)"))
+    )
 
-        val incorrect = List(
-            (List(),  "'P('x) |- 'S('x)", List()),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'Q('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'E('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'E('x) \\/ 'T('x) |- 'Q('x); 'S('x)", List("'E('x)", "'T('x)")),
-        )
+    val incorrect = List(
+      (List(), "'P('x) |- 'S('x)", List()),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'Q('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x) \\/ 'R('x); 'O('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'E('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'E('x) \\/ 'T('x) |- 'Q('x); 'S('x)", List("'E('x)", "'T('x)"))
+    )
 
-        testTacticCases(correct, incorrect){ (stmts, stmt2, forms) =>
-            val prems = stmts.map(introduceSequent(_))
-            LeftOr.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmts, stmt2, forms) =>
+      val prems = stmts.map(introduceSequent(_))
+      LeftOr.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
     }
+  }
 
-    //     left implies
+  //     left implies
 
-    test("Tactic Tests: Left Implies - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x) |- 'Q('x); 'R('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x); 'S('x) |- 'Q('x); 'T('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)"),
-        )
+  test("Tactic Tests: Left Implies - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x) |- 'Q('x); 'R('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x); 'S('x) |- 'Q('x); 'T('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            LeftImplies(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      LeftImplies(prem1, prem2)(stmt3)
     }
+  }
 
-    test("Tactic Tests: Left Implies - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-        )
+  test("Tactic Tests: Left Implies - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'P('x)"),
-            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'P('x)", "'Q('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)", "'S('x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'P('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'P('x)", "'Q('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+      ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)", "'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3, form1, form2) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            LeftImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3, form1, form2) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      LeftImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
     }
+  }
 
-    //     left iff
-    test("Tactic Tests: Left Iff - Parameter Inference") {
-        val correct = List(
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
-        )
+  //     left iff
+  test("Tactic Tests: Left Iff - Parameter Inference") {
+    val correct = List(
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)")
+    )
 
-        val incorrect = List(
-            // TODO: FIX AND UNCOMMENT THESE TESTS
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)"),
-        )
+    val incorrect = List(
+      // TODO: FIX AND UNCOMMENT THESE TESTS
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            LeftIff(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftIff(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left Iff - Explicit Parameters") {
-        val correct = List(
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-        )
+  test("Tactic Tests: Left Iff - Explicit Parameters") {
+    val correct = List(
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'R('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'S('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'T('x)"),
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'R('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'T('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form1, form2) =>
-            val prem = introduceSequent(stmt1)
-            LeftIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form1, form2) =>
+      val prem = introduceSequent(stmt1)
+      LeftIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
     }
+  }
 
-    //     left not
-    test("Tactic Tests: Left Not - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
-        )
+  //     left not
+  test("Tactic Tests: Left Not - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)")
+    )
 
-        val incorrect = List(
-            // TODO: FIX AND UNCOMMENT THESE TESTS
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
-            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
-            // TODO: should this be allowed::
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)"),
-        )
+    val incorrect = List(
+      // TODO: FIX AND UNCOMMENT THESE TESTS
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
+      ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
+      // TODO: should this be allowed::
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            LeftNot(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftNot(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left Not - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'Q('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)"),
-        )
+  test("Tactic Tests: Left Not - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'Q('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'Q('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'P('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'P('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form) =>
-            val prem = introduceSequent(stmt1)
-            LeftNot.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form) =>
+      val prem = introduceSequent(stmt1)
+      LeftNot.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
     }
+  }
 
-    //     left forall
-    test("Tactic Tests: Left Forall - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('x) |- 'R('x)", "'x"),
-            ("'A('x, 'x) |- 'R('x)", "∀y. 'A('y, 'x) |- 'R('x)", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∀x. 'P('x); 'Q('x) |- 'R('x)", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x)", "∀x. ('P('x) /\\ 'Q('x))|- 'R('x)", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'f('g('x, 'y), 'z, 'h, 'j)"),
-        )
+  //     left forall
+  test("Tactic Tests: Left Forall - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('x) |- 'R('x)", "'x"),
+      ("'A('x, 'x) |- 'R('x)", "∀y. 'A('y, 'x) |- 'R('x)", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∀x. 'P('x); 'Q('x) |- 'R('x)", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x)", "∀x. ('P('x) /\\ 'Q('x))|- 'R('x)", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'f('g('x, 'y), 'z, 'h, 'j)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
-            // TODO: should this be allowed?
-            ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∀y. 'P('x); 'Q('y) |- 'R('x)", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'f('g('x, 'x), 'j, 'z, 'h)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
+      // TODO: should this be allowed?
+      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∀y. 'P('x); 'Q('y) |- 'R('x)", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'f('g('x, 'x), 'j, 'z, 'h)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, term) =>
-            val prem = introduceSequent(stmt1)
-            LeftForall(FOLParser.parseTerm(term))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, term) =>
+      val prem = introduceSequent(stmt1)
+      LeftForall(FOLParser.parseTerm(term))(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left Forall - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'P('x)", "x", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('x)", "'P('y)", "y", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('x) |- 'R('x)", "'P('x)", "y", "'x"),
-            ("'A('x, 'x) |- 'R('x)", "∀y. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "y", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∀x. 'P('x); 'Q('x) |- 'R('x)", "'P('x)", "x", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x)", "∀x. ('P('x) /\\ 'Q('x))|- 'R('x)", "('P('x) /\\ 'Q('x))", "x", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('x)", "x", "'f('g('x, 'y), 'z, 'h, 'j)"),
-        )
+  test("Tactic Tests: Left Forall - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'P('x)", "x", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('x)", "'P('y)", "y", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('x) |- 'R('x)", "'P('x)", "y", "'x"),
+      ("'A('x, 'x) |- 'R('x)", "∀y. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "y", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∀x. 'P('x); 'Q('x) |- 'R('x)", "'P('x)", "x", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x)", "∀x. ('P('x) /\\ 'Q('x))|- 'R('x)", "('P('x) /\\ 'Q('x))", "x", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('x)", "x", "'f('g('x, 'y), 'z, 'h, 'j)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'P('x)", "x", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'P('x)", "y", "'x"),
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'Q('x)", "x", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'P('x)", "x", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∀y. 'P('x); 'Q('y) |- 'R('x)", "'P('x)", "y", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('x)", "x", "'f('g('x, 'x), 'j, 'z, 'h)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'P('x)", "x", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'P('x)", "y", "'x"),
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'Q('x)", "x", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'P('x)", "x", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∀y. 'P('x); 'Q('y) |- 'R('x)", "'P('x)", "y", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('x)", "x", "'f('g('x, 'x), 'j, 'z, 'h)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable, term) =>
-            val prem = introduceSequent(stmt1)
-            LeftForall.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable, term) =>
+      val prem = introduceSequent(stmt1)
+      LeftForall.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
     }
+  }
 
-    //     left exists
-    test("Tactic Tests: Left Exists - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)"),
-            ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)"),
-            ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))"),
-        )
+  //     left exists
+  test("Tactic Tests: Left Exists - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)"),
+      ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)"),
+      ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))")
+    )
 
-        val incorrect = List(
-            // TODO: FIX or kernel error
-            ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
-            ("'P('x) |- 'R('y)", "∃y. 'P('x) |- 'R('y)"),
-            // TODO: should we allow this? ::
-            ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
-            ("'P('x) |- 'R('x)", "∃x. 'P('x) |- 'R('x)"),
-            ("'A('y, 'x) |- 'R('x)", "∃x. 'A('y, 'x) |- 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('y))|- 'R('y)"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'j, 'h))"),
-        )
+    val incorrect = List(
+      // TODO: FIX or kernel error
+      ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
+      ("'P('x) |- 'R('y)", "∃y. 'P('x) |- 'R('y)"),
+      // TODO: should we allow this? ::
+      ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
+      ("'P('x) |- 'R('x)", "∃x. 'P('x) |- 'R('x)"),
+      ("'A('y, 'x) |- 'R('x)", "∃x. 'A('y, 'x) |- 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('y))|- 'R('y)"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'j, 'h))")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            LeftExists(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftExists(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left Exists - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)", "'P('x)", "x"),
-            ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "y"),
-            ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('z)", "z"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)", "('P('x) /\\ 'Q('x))", "x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "j"),
-        )
+  test("Tactic Tests: Left Exists - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)", "'P('x)", "x"),
+      ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "y"),
+      ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('z)", "z"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)", "('P('x) /\\ 'Q('x))", "x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "j")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)", "'P('y)", "x"),
-            ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)", "'A('y, 'y)", "y"),
-            ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('x)", "z"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)", "('P('x) /\\ 'Q('y))", "x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "h"),
-            ("'P('x) |- 'R('y)", "∃y. 'P('x) |- 'R('y)", "'P('x)", "y"),
-            ("'P('x) |- 'R('x)", "∃x. 'P('x) |- 'R('x)", "'P('x)", "x"),
-            ("'A('y, 'x) |- 'R('x)", "∃x. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('z)", "z"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('y))|- 'R('y)", "('P('x) /\\ 'Q('y))", "x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'j, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "j"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('y)", "∃x. 'P('x) |- 'R('y)", "'P('y)", "x"),
+      ("'A('y, 'x) |- 'R('x)", "∃y. 'A('y, 'x) |- 'R('x)", "'A('y, 'y)", "y"),
+      ("'P('z); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('x)", "z"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('x))|- 'R('y)", "('P('x) /\\ 'Q('y))", "x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "h"),
+      ("'P('x) |- 'R('y)", "∃y. 'P('x) |- 'R('y)", "'P('x)", "y"),
+      ("'P('x) |- 'R('x)", "∃x. 'P('x) |- 'R('x)", "'P('x)", "x"),
+      ("'A('y, 'x) |- 'R('x)", "∃x. 'A('y, 'x) |- 'R('x)", "'A('y, 'x)", "x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)", "'P('z)", "z"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y)", "∃x. ('P('x) /\\ 'Q('y))|- 'R('y)", "('P('x) /\\ 'Q('y))", "x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∃j. 'P('f('g('x, 'y), 'z, 'h, 'j))|- 'R('f('g('x, 'x), 'e, 'j, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))", "j")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable) =>
-            val prem = introduceSequent(stmt1)
-            LeftExists.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable) =>
+      val prem = introduceSequent(stmt1)
+      LeftExists.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
     }
+  }
 
-    //     left existsone
-    test("Tactic Tests: Left ExistsOne - Parameter Inference") {
-        val correct = List(
-            ("∃x.∀y. ('y = 'x <=> 'P('y)) |- 'R('z)", "∃!y. 'P('y) |- 'R('z)"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('z)", "∃!y. 'P('w) |- 'R('z)"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('y)"),
-        )
+  //     left existsone
+  test("Tactic Tests: Left ExistsOne - Parameter Inference") {
+    val correct = List(
+      ("∃x.∀y. ('y = 'x <=> 'P('y)) |- 'R('z)", "∃!y. 'P('y) |- 'R('z)"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('z)", "∃!y. 'P('w) |- 'R('z)"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('y)")
+    )
 
-        val incorrect = List(
-            // TODO: FIX or KERNEL ERROR
-            ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)"),
-            ("∃x.∀y. ('y = 'x <=> 'P('x)) |- 'R('y)", "∃!x. 'P('x) |- 'R('y)"),
-        )
+    val incorrect = List(
+      // TODO: FIX or KERNEL ERROR
+      ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)"),
+      ("∃x.∀y. ('y = 'x <=> 'P('x)) |- 'R('y)", "∃!x. 'P('x) |- 'R('y)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            LeftExistsOne(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      LeftExistsOne(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Left ExistsOne - Explicit Parameters") {
-        val correct = List(
-            ("∃y.∀x.( ('x = 'y) <=> 'P('z)) |- 'R('w)", "∃!x. 'P('z) |- 'R('w)", "'P('z)", "x"),
-            ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('w)", "∃!x. 'P('x) |- 'R('w)", "'P('x)", "x"),
-            ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('x)", "∃!x. 'P('x) |- 'R('x)", "'P('x)", "x"),
-        )
+  test("Tactic Tests: Left ExistsOne - Explicit Parameters") {
+    val correct = List(
+      ("∃y.∀x.( ('x = 'y) <=> 'P('z)) |- 'R('w)", "∃!x. 'P('z) |- 'R('w)", "'P('z)", "x"),
+      ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('w)", "∃!x. 'P('x) |- 'R('w)", "'P('x)", "x"),
+      ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('x)", "∃!x. 'P('x) |- 'R('x)", "'P('x)", "x")
+    )
 
-        val incorrect = List(
-            ("∃y.∀x.( ('x = 'y) <=> 'P('z)) |- 'R('w)", "∃!x. 'P('z) |- 'R('y)", "'P('z)", "x"),
-            // TODO: this looks v broken::
-            ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('w)", "∃!x. 'P('x) |- 'R('w)", "'P('x)", "z"),
-            ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('x)", "∃!x. 'P('z) |- 'R('x)", "'P('z)", "x"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)", "'P('w)", "w"),
-            ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)", "'P('y)", "y"),
-            ("∃x.∀y. ('y = 'x <=> 'P('x)) |- 'R('y)", "∃!x. 'P('x) |- 'R('y)", "'P('x)", "x"),
-        )
+    val incorrect = List(
+      ("∃y.∀x.( ('x = 'y) <=> 'P('z)) |- 'R('w)", "∃!x. 'P('z) |- 'R('y)", "'P('z)", "x"),
+      // TODO: this looks v broken::
+      ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('w)", "∃!x. 'P('x) |- 'R('w)", "'P('x)", "z"),
+      ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('x)", "∃!x. 'P('z) |- 'R('x)", "'P('z)", "x"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)", "'P('w)", "w"),
+      ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)", "'P('y)", "y"),
+      ("∃x.∀y. ('y = 'x <=> 'P('x)) |- 'R('y)", "∃!x. 'P('x) |- 'R('y)", "'P('x)", "x")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable) =>
-            val prem = introduceSequent(stmt1)
-            LeftExistsOne.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable) =>
+      val prem = introduceSequent(stmt1)
+      LeftExistsOne.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
     }
+  }
 
-    // right rules
+  // right rules
 
-    //     right and
-    test("Tactic Tests: Right And - Parameter Inference") {
-        val correct = List(
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)"),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'R('x); 'P('x) |- 'Q('x) /\\ 'S('x); 'Q('x)"),
-            // TODO: should this be allowed? ::
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) |- 'Q('x); 'S('x); 'E('x) \\/ 'T('x)"),
-            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)"),
-        )
+  //     right and
+  test("Tactic Tests: Right And - Parameter Inference") {
+    val correct = List(
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)"),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'R('x); 'P('x) |- 'Q('x) /\\ 'S('x); 'Q('x)"),
+      // TODO: should this be allowed? ::
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) |- 'Q('x); 'S('x); 'E('x) \\/ 'T('x)"),
+      (List("'P('x) |- 'S('x)"), "'P('x) |- 'S('x)")
+    )
 
-        val incorrect = List(
-            (List(),  "'P('x) |- 'S('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'T('x) |- 'Q('x) /\\'S('x)"),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x); 'T('x) |- 'Q('x) /\\ 'S('x)"),
-        )
+    val incorrect = List(
+      (List(), "'P('x) |- 'S('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'T('x) |- 'Q('x) /\\'S('x)"),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x); 'T('x) |- 'Q('x) /\\ 'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmts, stmt2) =>
-            val prems = stmts.map(introduceSequent(_))
-            RightAnd(prems: _*)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmts, stmt2) =>
+      val prems = stmts.map(introduceSequent(_))
+      RightAnd(prems: _*)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right And - Explicit Parameters") {
-        val correct = List(
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'Q('x)", "'S('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'S('x)", "'Q('x)")),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'Q('x)", "'S('x)")),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'S('x)", "'Q('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x); 'S('x)", List("'Q('x)", "'S('x)")),
-            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)", List("'P('x)")),
-        )
+  test("Tactic Tests: Right And - Explicit Parameters") {
+    val correct = List(
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'Q('x)", "'S('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'S('x)", "'Q('x)")),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'Q('x)", "'S('x)")),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'S('x)", "'Q('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x); 'S('x)", List("'Q('x)", "'S('x)")),
+      (List("'P('x) |- 'S('x)"), "'P('x) |- 'S('x)", List("'P('x)"))
+    )
 
-        val incorrect = List(
-            (List(),  "'P('x) |- 'S('x)", List()),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)", "'Q('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
-            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x) |- 'Q('x) \\/ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'R('x); 'P('x) |- 'Q('x) \\/ 'S('x); 'S('x)", List("'E('x)", "'R('x)")),
-            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'E('x) \\/ 'T('x)", List("'E('x)", "'T('x)")),
-        )
+    val incorrect = List(
+      (List(), "'P('x) |- 'S('x)", List()),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)", "'Q('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+      (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x) |- 'Q('x) \\/ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'R('x); 'P('x) |- 'Q('x) \\/ 'S('x); 'S('x)", List("'E('x)", "'R('x)")),
+      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'E('x) \\/ 'T('x)", List("'E('x)", "'T('x)"))
+    )
 
-        testTacticCases(correct, incorrect){ (stmts, stmt2, forms) =>
-            val prems = stmts.map(introduceSequent(_))
-            RightAnd.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmts, stmt2, forms) =>
+      val prems = stmts.map(introduceSequent(_))
+      RightAnd.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
     }
+  }
 
-    //     right or
-    test("Tactic Tests: Right Or - Parameter Inference") {
-        val correct = List(
-            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x); 'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))"),
-        )
+  //     right or
+  test("Tactic Tests: Right Or - Parameter Inference") {
+    val correct = List(
+      ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x); 'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))")
+    )
 
-        val incorrect = List(
-            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x); 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x)"),
-        )
+    val incorrect = List(
+      ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x); 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            RightOr(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      RightOr(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right Or - Explicit Parameters") {
-        val correct = List(
-            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x) \\/ 'A('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)", "'Q('x)", "'S('x) \\/ 'A('x)"),
-        )
+  test("Tactic Tests: Right Or - Explicit Parameters") {
+    val correct = List(
+      ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x) \\/ 'A('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)", "'Q('x)", "'S('x) \\/ 'A('x)")
+    )
 
-        val incorrect = List(
-            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'P('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'P('x)", "'S('x)"),
-            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x)"),
-        )
+    val incorrect = List(
+      ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'P('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'P('x)", "'S('x)"),
+      ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, phi, psi) =>
-            val prem = introduceSequent(stmt1)
-            RightOr.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, phi, psi) =>
+      val prem = introduceSequent(stmt1)
+      RightOr.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
     }
+  }
 
-    //     right implies
-    test("Tactic Tests: Right Implies - Parameter Inference") {
-        val correct = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)"),
-            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)"),
-        )
+  //     right implies
+  test("Tactic Tests: Right Implies - Parameter Inference") {
+    val correct = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)"),
+      ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)"),
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            RightImplies(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      RightImplies(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right Implies - Explicit Parameters") {
-        val correct = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
-            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)"),
-        )
+  test("Tactic Tests: Right Implies - Explicit Parameters") {
+    val correct = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+      ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'P('x)"),
-            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'P('x)", "'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'P('x)", "'S('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'R('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
-            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
-        )
+    val incorrect = List(
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'P('x)"),
+      ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'P('x)", "'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'P('x)", "'S('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'R('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+      ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form1, form2) =>
-            val prem = introduceSequent(stmt1)
-            RightImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form1, form2) =>
+      val prem = introduceSequent(stmt1)
+      RightImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
     }
+  }
 
-    //     right iff
-    test("Tactic Tests: Right Iff - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
-        )
+  //     right iff
+  test("Tactic Tests: Right Iff - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)")
+    )
 
-        val incorrect = List(
-            // TODO: asymmetric! shoud we allow this? ::
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) ==> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'S('x) ==> 'Q('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)"),
-        )
+    val incorrect = List(
+      // TODO: asymmetric! shoud we allow this? ::
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) ==> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'S('x) ==> 'Q('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            RightIff(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      RightIff(prem1, prem2)(stmt3)
     }
+  }
 
-    test("Tactic Tests: Right Iff - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-        )
+  test("Tactic Tests: Right Iff - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+      ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'S('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'R('x)", "'R('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'P('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'T('x)", "'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'W('x)", "'S('x)"),
-            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'T('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'S('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'R('x)", "'R('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'P('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'T('x)", "'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'W('x)", "'S('x)"),
+      ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'T('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+      ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3, form1, form2) =>
-            val prem1 = introduceSequent(stmt1)
-            val prem2 = introduceSequent(stmt2)
-            RightIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3, form1, form2) =>
+      val prem1 = introduceSequent(stmt1)
+      val prem2 = introduceSequent(stmt2)
+      RightIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
     }
+  }
 
-    //     right not
-    test("Tactic Tests: Right Not - Parameter Inference") {
-        val correct = List(
-            ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
-            ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)"),
-            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)"),
-        )
+  //     right not
+  test("Tactic Tests: Right Not - Parameter Inference") {
+    val correct = List(
+      ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
+      ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)"),
+      ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)")
+    )
 
-        val incorrect = List(
-            // TODO: FIX AND UNCOMMENT THESE TESTS
-            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x); !'Q('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'P('x); 'Q('x) <=> 'S('x)"),
-            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'Q('x) <=> 'T('x)"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
-            ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)"),
-            // TODO: should this be allowed::
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)"),
-        )
+    val incorrect = List(
+      // TODO: FIX AND UNCOMMENT THESE TESTS
+      ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x); !'Q('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'P('x); 'Q('x) <=> 'S('x)"),
+      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'Q('x) <=> 'T('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
+      ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)"),
+      // TODO: should this be allowed::
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            RightNot(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      RightNot(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right Not - Explicit Parameters") {
-        val correct = List(
-            ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
-            ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); ! ! !'Q('x)", "'Q('x)"),
-            ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)", "'Q('x)"),
-            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)", "'Q('x)"),
-        )
+  test("Tactic Tests: Right Not - Explicit Parameters") {
+    val correct = List(
+      ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
+      ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); ! ! !'Q('x)", "'Q('x)"),
+      ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)", "'Q('x)"),
+      ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)", "'Q('x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)", "'Q('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'P('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
-            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x)"),
-            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)", "'Q('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'P('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
+      ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x)"),
+      ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form) =>
-            val prem = introduceSequent(stmt1)
-            RightNot.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form) =>
+      val prem = introduceSequent(stmt1)
+      RightNot.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
     }
+  }
 
-    //     right forall
-    test("Tactic Tests: Right Forall - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)"),
-            ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)"),
-            ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))"),
-        )
+  //     right forall
+  test("Tactic Tests: Right Forall - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)"),
+      ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)"),
+      ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))")
+    )
 
-        val incorrect = List(
-            // TODO: FIX or kernel error
-            ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
-            ("∃y. 'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
-            // TODO: should we allow this? ::
-            ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
-            ("'P('y) |- 'R('y)", "'P('y) |- ∀y. 'R('y)"),
-            ("'P('x) |- 'R('y)", "'T('x) |- ∀y. 'R('y)"),
-            ("'P('x) |- 'R('y)", "'P('x) |- "),
-            ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'Q('y)"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) \\/ 'S('x))"),
-        )
+    val incorrect = List(
+      // TODO: FIX or kernel error
+      ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
+      ("∃y. 'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
+      // TODO: should we allow this? ::
+      ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
+      ("'P('y) |- 'R('y)", "'P('y) |- ∀y. 'R('y)"),
+      ("'P('x) |- 'R('y)", "'T('x) |- ∀y. 'R('y)"),
+      ("'P('x) |- 'R('y)", "'P('x) |- "),
+      ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'Q('y)"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) \\/ 'S('x))")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            RightForall(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      RightForall(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right Forall - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)", "'R('y)", "y"),
-            ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)", "'R('z)", "z"),
-            ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)", "'R('y)", "y"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))", "'R('y) /\\ 'S('x)", "y"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))", "'R('f('g('x, 'x), 'e, 'z, 'h))", "e"),
-        )
+  test("Tactic Tests: Right Forall - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)", "'R('y)", "y"),
+      ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)", "'R('z)", "z"),
+      ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)", "'R('y)", "y"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))", "'R('y) /\\ 'S('x)", "y"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))", "'R('f('g('x, 'x), 'e, 'z, 'h))", "e")
+    )
 
-        val incorrect = List(
-            ("'P('y) |- 'R('y)", "'P('y) |- ∀y. 'R('y)", "'R('y)", "y"),
-            ("'P('x) |- 'R('y)", "'T('x) |- ∀y. 'R('y)", "'R('y)", "y"),
-            ("'P('x) |- 'R('y)", "'P('x) |- ", "'R('y)", "y"),
-            ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'Q('y)", "'R('y)", "y"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) \\/ 'S('x))", "'R('y) /\\ 'S('x)", "y"),
-            ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)", "'R('y)", "x"),
-            ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)", "'Q('z)", "z"),
-            ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)", "'R('z)", "y"),
-            ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))", "'R('y) \\/ 'S('x)", "y"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))", "'R('f('g('y, 'y), 'e, 'z, 'h))", "e"),
-        )
+    val incorrect = List(
+      ("'P('y) |- 'R('y)", "'P('y) |- ∀y. 'R('y)", "'R('y)", "y"),
+      ("'P('x) |- 'R('y)", "'T('x) |- ∀y. 'R('y)", "'R('y)", "y"),
+      ("'P('x) |- 'R('y)", "'P('x) |- ", "'R('y)", "y"),
+      ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'Q('y)", "'R('y)", "y"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) \\/ 'S('x))", "'R('y) /\\ 'S('x)", "y"),
+      ("'P('x) |- 'R('y)", "'P('x) |- ∀y. 'R('y)", "'R('y)", "x"),
+      ("'A('y, 'x) |- 'R('z)", "'A('y, 'x) |- ∀z. 'R('z)", "'Q('z)", "z"),
+      ("'P('z); 'Q('x) |- 'R('y)", "'P('z); 'Q('x) |- ∀y. 'R('y)", "'R('z)", "y"),
+      ("'P('x) /\\ 'Q('x) |- 'R('y) /\\ 'S('x)", "('P('x) /\\ 'Q('x))|- ∀y. ('R('y) /\\ 'S('x))", "'R('y) \\/ 'S('x)", "y"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'e, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∀e. 'R('f('g('x, 'x), 'e, 'z, 'h))", "'R('f('g('y, 'y), 'e, 'z, 'h))", "e")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable) =>
-            val prem = introduceSequent(stmt1)
-            RightForall.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable) =>
+      val prem = introduceSequent(stmt1)
+      RightForall.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
     }
+  }
 
-    //     right exists
-    test("Tactic Tests: Right Exists - Parameter Inference") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'x"),
-            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'g('x, 'x)"),
-        )
+  //     right exists
+  test("Tactic Tests: Right Exists - Parameter Inference") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'x"),
+      (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'g('x, 'x)")
+    )
 
-        val incorrect = List(
-            // TODO: fix these:
-            ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
-            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
-            // TODO: should this be allowed?
-            ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'y"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'z"),
-            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'g('x, 'x)"),
-        )
+    val incorrect = List(
+      // TODO: fix these:
+      ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
+      ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
+      // TODO: should this be allowed?
+      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'y"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'z"),
+      (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'g('x, 'x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, term) =>
-            val prem = introduceSequent(stmt1)
-            RightExists(FOLParser.parseTerm(term))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, term) =>
+      val prem = introduceSequent(stmt1)
+      RightExists(FOLParser.parseTerm(term))(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right Exists - Explicit Parameters") {
-        val correct = List(
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'R('x)", "y", "'x"),
-            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'A('y, 'x)", "y", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x) /\\ 'Q('x)", "x", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'R('f('x, 'j, 'z, 'h))", "x", "'g('x, 'x)"),
-        )
+  test("Tactic Tests: Right Exists - Explicit Parameters") {
+    val correct = List(
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'R('x)", "y", "'x"),
+      (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'A('y, 'x)", "y", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x) /\\ 'Q('x)", "x", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'R('f('x, 'j, 'z, 'h))", "x", "'g('x, 'x)")
+    )
 
-        val incorrect = List(
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'y"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'R('y)", "x", "'x"),
-            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'R('z)", "y", "'z"),
-            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'A('z, 'y)", "y", "'x"),
-            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
-            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x)", "x", "'x"),
-            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'R('x)", "x", "'g('x, 'x)"),
-        )
+    val incorrect = List(
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'y"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'R('y)", "x", "'x"),
+      ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'R('z)", "y", "'z"),
+      (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'A('z, 'y)", "y", "'x"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+      ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x)", "x", "'x"),
+      ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'R('x)", "x", "'g('x, 'x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable, term) =>
-            val prem = introduceSequent(stmt1)
-            RightExists.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable, term) =>
+      val prem = introduceSequent(stmt1)
+      RightExists.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
     }
+  }
 
-    //     right existsone
-    test("Tactic Tests: Right ExistsOne - Parameter Inference") {
-        val correct = List(
-            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('y))", "'R('z) |- ∃!y. 'P('y)"),
-            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
-            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
-        )
+  //     right existsone
+  test("Tactic Tests: Right ExistsOne - Parameter Inference") {
+    val correct = List(
+      ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('y))", "'R('z) |- ∃!y. 'P('y)"),
+      ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
+      ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)")
+    )
 
-        val incorrect = List(
-            // TODO: FIX or KERNEL ERROR
-            ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)"),
-        )
+    val incorrect = List(
+      // TODO: FIX or KERNEL ERROR
+      ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
-            val prem = introduceSequent(stmt1)
-            RightExistsOne(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
+      val prem = introduceSequent(stmt1)
+      RightExistsOne(prem)(stmt2)
     }
+  }
 
-    test("Tactic Tests: Right ExistsOne - Explicit Parameters") {
-        val correct = List(
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('y) |- ∃!x. 'P('z)", "'P('z)", "x"),
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x"),
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x"),
-        )
+  test("Tactic Tests: Right ExistsOne - Explicit Parameters") {
+    val correct = List(
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('y) |- ∃!x. 'P('z)", "'P('z)", "x"),
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x"),
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x")
+    )
 
-        val incorrect = List(
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('w) |- ∃!x. 'P('z)", "'P('z)", "x"),
-            // TODO: this looks v broken::
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'T('y) |- ∃!x. 'P('x)", "'P('x)", "z"),
-            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('z) |- ∃!x. 'P('z)", "'P('z)", "x"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)", "'P('w)", "w"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)", "'P('y)", "y"),
-            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('w) |- ∃!x. 'P('x)", "'P('x)", "x"),
-        )
+    val incorrect = List(
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('w) |- ∃!x. 'P('z)", "'P('z)", "x"),
+      // TODO: this looks v broken::
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'T('y) |- ∃!x. 'P('x)", "'P('x)", "z"),
+      ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('z) |- ∃!x. 'P('z)", "'P('z)", "x"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)", "'P('w)", "w"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)", "'P('y)", "y"),
+      ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('w) |- ∃!x. 'P('x)", "'P('x)", "x")
+    )
 
-        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable) =>
-            val prem = introduceSequent(stmt1)
-            RightExistsOne.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
-        }
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, form, variable) =>
+      val prem = introduceSequent(stmt1)
+      RightExistsOne.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
     }
+  }
 
-    // left refl
-    // right refl
+  // left refl
+  // right refl
 
-    // left substeq
-    // right substeq
+  // left substeq
+  // right substeq
 
-    // left substiff
-    // right substiff
+  // left substiff
+  // right substiff
 
-    // instfunschema
-    // instpredschema 
+  // instfunschema
+  // instpredschema
 
-    // subproof  
+  // subproof
 }

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -482,8 +482,6 @@ class BasicTacticTest extends ProofTacticTestLib {
 
     val incorrect = List(
       ("∃y.∀x.( ('x = 'y) <=> 'P('z)) |- 'R('w)", "∃!x. 'P('z) |- 'R('y)", "'P('z)", "x"),
-      // TODO: this looks v broken::
-      ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('w)", "∃!x. 'P('x) |- 'R('w)", "'P('x)", "z"),
       ("∃y.∀x.( ('x = 'y) <=> 'P('x)) |- 'R('x)", "∃!x. 'P('z) |- 'R('x)", "'P('z)", "x"),
       ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)", "'P('w)", "w"),
       ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)", "'P('y)", "y"),
@@ -882,7 +880,6 @@ class BasicTacticTest extends ProofTacticTestLib {
 
     val incorrect = List(
       ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('w) |- ∃!x. 'P('z)", "'P('z)", "x"),
-      // TODO: this looks v broken::
       ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'T('y) |- ∃!x. 'P('x)", "'P('x)", "z"),
       ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('z) |- ∃!x. 'P('z)", "'P('z)", "x"),
       ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)", "'P('w)", "w"),

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -960,7 +960,57 @@ class BasicTacticTest extends ProofTacticTestLib {
       LeftRefl.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
     }
   }
+
   // right refl
+  test("Tactic Tests: Right Refl - Parameter Inference") {
+    val correct = List(
+      (" |- 'x = 'x"),
+      (" |- 'x = 'x; 'P('x)"),
+      ("'P('x) |- 'x = 'x"),
+      ("'P('x) |- 'x = 'x; 'R('x)"),
+      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x"),
+    )
+
+    val incorrect = List(
+      (" |- "),
+      (" |- 'P('x)"),
+      (" |- 'x = 'y"),
+      ("'P('x) |- 'x = 'y"),
+      ("'P('x) |- 'x = 'y; 'R('x)"),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt) =>
+      RightRefl(stmt)
+    }
+  }
+
+  test("Tactic Tests: Right Refl - Explicit Parameters") {
+    val correct = List(
+      (" |- 'x = 'x", "'x = 'x"),
+      (" |- 'x = 'x; 'P('x)", "'x = 'x"),
+      ("'P('x) |- 'x = 'x", "'x = 'x"),
+      ("'P('x) |- 'x = 'x; 'R('x)", "'x = 'x"),
+      ("'P('x) |- 'x = 'y; 'R('x); 'x = 'x", "'x = 'x"),
+    )
+
+    val incorrect = List(
+      (" |- ", "'x = 'x"),
+      (" |- 'x = 'x", "'x = 'y"),
+      (" |- 'x = 'x; 'P('x)", "'y = 'x"),
+      ("'P('x) |- 'x = 'x", "'y = 'y"),
+      (" |- 'P('x)", "'x = 'x"),
+      (" |- 'x = 'y", "'x = 'x"),
+      (" |- 'x = 'y", "'x = 'y"),
+      ("'P('x) |- 'x = 'y", "'x = 'x"),
+      ("'P('x) |- 'x = 'y", "'x = 'y"),
+      ("'P('x) |- 'x = 'y; 'R('x)", "'x = 'x"),
+      ("'P('x) |- 'x = 'y; 'R('x)", "'x = 'y"),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt, form) =>
+      RightRefl.withParameters(FOLParser.parseFormula(form))(stmt)
+    }
+  }
 
   // left substeq
   // right substeq

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -608,6 +608,57 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightOr.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
         }
     }
+
+    //     right implies
+    test("Tactic Tests: Right Implies - Parameter Inference") {
+        val correct = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)"),
+            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
+            val prem = introduceSequent(stmt1)
+            RightImplies(prem)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right Implies - Explicit Parameters") {
+        val correct = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'P('x)"),
+            ("'Q('x) |- 'R('x)", " |- 'Q('x) ==> 'R('x)", "'P('x)", "'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'P('x)", "'S('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- !'Q('x) \\/ 'R('x)", "'R('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", " |- 'Q('x); 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) /\\ 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x) \\/ 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'S('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x) |- 'Q('x) ==> 'R('x)", "'Q('x)", "'R('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, form1, form2) =>
+            val prem = introduceSequent(stmt1)
+            RightImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -819,6 +819,68 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightForall.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
         }
     }
+
+    //     right exists
+    test("Tactic Tests: Right Exists - Parameter Inference") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'x"),
+            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'x"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'x"),
+            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
+            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'g('x, 'x)"),
+        )
+
+        val incorrect = List(
+            // TODO: fix these:
+            ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
+            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
+            ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
+            ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
+            // TODO: should this be allowed?
+            ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'y"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'z"),
+            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'x"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'x"),
+            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'x"),
+            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'g('x, 'x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, term) =>
+            val prem = introduceSequent(stmt1)
+            RightExists(FOLParser.parseTerm(term))(prem)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right Exists - Explicit Parameters") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('x)", "'R('x)", "y", "'x"),
+            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('y, 'x)", "'A('y, 'x)", "y", "'x"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) /\\ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x) /\\ 'Q('x)", "x", "'x"),
+            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'j, 'z, 'h))", "'R('f('x, 'j, 'z, 'h))", "x", "'g('x, 'x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'R('x)", "x", "'y"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'R('y)", "x", "'x"),
+            ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'R('z)", "y", "'z"),
+            (" |- 'R('x); 'A('x, 'x)", " |- 'R('x); ∃y. 'A('z, 'y)", "'A('z, 'y)", "y", "'x"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'T('x) |- ∃y. 'R('y)", "'R('y)", "y", "'x"),
+            ("'P('x) /\\ 'Q('x) |- 'R('x) /\\ 'Q('x)", "('P('x) \\/ 'Q('x)) |- ∃x. ('R('x) /\\ 'Q('x))", "'R('x)", "x", "'x"),
+            ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'P('f('g('x, 'y), 'z, 'h, 'j))|- ∃x. 'R('f('x, 'x, 'z, 'h))", "'R('x)", "x", "'g('x, 'x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable, term) =>
+            val prem = introduceSequent(stmt1)
+            RightExists.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1220,4 +1220,41 @@ class BasicTacticTest extends ProofTacticTestLib {
       InstFunSchema(termMap)(prem)(stmt2)
     }
   }
+
+  // instpredschema
+  test("Tactic Tests: InstPredSchema") {
+    val x = variable
+    val y = variable
+    val f = SchematicPredicateLabel("f", 1)
+    val h = SchematicPredicateLabel("h", 2)
+    val g = predicate(2)
+    val Y = LambdaTermFormula(Seq(x), x === x)
+    val Z = LambdaTermFormula(Seq(x, y), g(x, y))
+
+    val correct = List(
+      ("'P('x); 'f('x) |- 'R('y)", "'P('x); ('x = 'x) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](f -> Y)),
+      ("'P('x); 'Q('x) /\\ 'f('x) |- 'R('y)", "'P('x); 'Q('x) /\\ 'x = 'x |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](f -> Y)),
+      ("'P('x); 'h('x, 'y) |- 'R('y)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'h('y, 'y); 'h('x, 'y) |- 'R('y)", "'g('y, 'y); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'P('x); 'g('x, 'y) |- 'R('y)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 'x", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
+    )
+
+    val incorrect = List(
+      ("'P('x); 'f('x) = 'y |- 'R('y)", "'P('x); !('x = 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](f -> Y)),
+      ("'P('x); 'f('x) |- 'R('y)", "'P('x); 'Q('y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](f -> Y)),
+      ("'P('x); 'h('x, 'y) |- 'R('y)", "'P('x); 'h('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'h('y, 'y); 'h('x, 'y) |- 'R('y)", "'g('y, 'y); 'g('y, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'P('x); 'g('x, 'y) |- 'R('y)", "'P('x); 'h('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 't", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y); 'x = 'x", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z)),
+      ("'P('x); 'g('x, 'y) |- 'R('y); 'f('x)", "'P('x); 'g('x, 'y) |- 'R('y)", Map[SchematicVarOrPredLabel, LambdaTermFormula](h -> Z, f -> Y)),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, termMap) =>
+      val prem = introduceSequent(stmt1)
+      InstPredSchema(termMap)(prem)(stmt2)
+    }
+  }
+
 }

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -26,8 +26,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'Q('x) |- ")
     )
 
-    val testProof = generateTestProof()
-
     testTacticCases(correct, incorrect) {
       Hypothesis(_)
     }
@@ -46,8 +44,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
       ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) ")
     )
-
-    val testProof = generateTestProof()
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
       val prem = introduceSequent(stmt1)
@@ -71,8 +67,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
       ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)")
     )
-
-    val testProof = generateTestProof()
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2, stmt3) =>
       val prem1 = introduceSequent(stmt1)
@@ -270,7 +264,6 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX AND UNCOMMENT THESE TESTS
       ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
       ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)"),
       ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
@@ -315,13 +308,10 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX AND UNCOMMENT THESE TESTS
       ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
       ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)"),
       ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
       ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
-      // TODO: should this be allowed::
-      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
       ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)")
     )
 
@@ -371,8 +361,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
       ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
       ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
-      // TODO: should this be allowed?
-      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
       ("'P('x); 'Q('x) |- 'R('x)", "∀y. 'P('x); 'Q('y) |- 'R('x)", "'x"),
       ("'P('f('g('x, 'y), 'z, 'h, 'j)) |- 'R('f('g('x, 'x), 'j, 'z, 'h))", "∀x. 'P('x)|- 'R('f('g('x, 'x), 'j, 'z, 'h))", "'f('g('x, 'x), 'j, 'z, 'h)")
     )
@@ -420,11 +408,8 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX or kernel error
       ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
       ("'P('x) |- 'R('y)", "∃y. 'P('x) |- 'R('y)"),
-      // TODO: should we allow this? ::
-      ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
       ("'P('x) |- 'R('x)", "∃x. 'P('x) |- 'R('x)"),
       ("'A('y, 'x) |- 'R('x)", "∃x. 'A('y, 'x) |- 'R('x)"),
       ("'P('x); 'Q('x) |- 'R('x)", "∃z. 'P('z); 'Q('x) |- 'R('x)"),
@@ -476,7 +461,6 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX or KERNEL ERROR
       ("'P('x) |- 'R('y); 'Q('z)", "'P('x) |- 'R('y)"),
       ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('w) |- 'R('z)"),
       ("∃x.∀y. ('y = 'x <=> 'P('w)) |- 'R('y)", "∃!y. 'P('y) |- 'R('y)"),
@@ -520,8 +504,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)"),
       (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"), "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)"),
       (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'R('x); 'P('x) |- 'Q('x) /\\ 'S('x); 'Q('x)"),
-      // TODO: should this be allowed? ::
-      (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"), "'P('x) |- 'Q('x); 'S('x); 'E('x) \\/ 'T('x)"),
       (List("'P('x) |- 'S('x)"), "'P('x) |- 'S('x)")
     )
 
@@ -673,9 +655,6 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: asymmetric! shoud we allow this? ::
-      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) ==> 'S('x)"),
-      ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'S('x) ==> 'Q('x)"),
       ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)"),
       ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)")
     )
@@ -723,15 +702,11 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX AND UNCOMMENT THESE TESTS
       ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x); !'Q('x)"),
       ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'P('x); 'Q('x) <=> 'S('x)"),
       ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'Q('x) <=> 'T('x)"),
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
       ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)"),
-      // TODO: should this be allowed::
-      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
-      ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
@@ -775,11 +750,8 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX or kernel error
       ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
       ("∃y. 'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
-      // TODO: should we allow this? ::
-      ("'P('x) |- 'R('y)", "'P('x) |- 'R('y)"),
       ("'P('y) |- 'R('y)", "'P('y) |- ∀y. 'R('y)"),
       ("'P('x) |- 'R('y)", "'T('x) |- ∀y. 'R('y)"),
       ("'P('x) |- 'R('y)", "'P('x) |- "),
@@ -834,13 +806,10 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: fix these:
       ("'P('x) |- 'R('x)", "∀x. 'P('x) |- 'R('x)", "'x"),
       ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'x"),
       ("'P('x) |- 'R('x)", "∀y. 'P('y) |- 'R('y)", "'x"),
       ("'P('x) |- 'R('x)", "∀x. 'Q('x) |- 'R('x)", "'y"),
-      // TODO: should this be allowed?
-      ("'P('x) |- 'R('x)", "'P('x) |- 'R('x)", "'x"),
       ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('x)", "'y"),
       ("'P('x) |- 'R('x)", "'P('x) |- ∃x. 'R('y)", "'x"),
       ("'P('x) |- 'R('x)", "'P('x) |- ∃y. 'R('z)", "'z"),
@@ -892,7 +861,6 @@ class BasicTacticTest extends ProofTacticTestLib {
     )
 
     val incorrect = List(
-      // TODO: FIX or KERNEL ERROR
       ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
       ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
       ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)"),

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1,0 +1,424 @@
+package lisa.utils
+
+import lisa.utils.tactics.BasicStepTactic.*
+import lisa.utils.tactics.ProofTacticLib
+import lisa.kernel.proof.{SequentCalculus as SC}
+import lisa.utils.Library
+import scala.collection.immutable.LazyList
+import org.scalatest.funsuite.AnyFunSuite
+
+class BasicTacticTest extends AnyFunSuite with BasicMain {
+
+    export lisa.test.TestTheoryLibrary.{_, given}
+
+    // hypothesis
+    test("Tactic Tests: Hypothesis") {
+        val correct = List(
+            "'P('x) |- 'P('x)", 
+            "'P('x) |- 'P('x); 'Q('x)",
+            "'P('x); 'Q('x) |- 'P('x); 'Q('x)",
+            "'P('x); 'Q('x) |- 'P('x)"
+        )
+
+        val incorrect = List(
+            "'P('x) |- ",
+            " |- 'P('x)",
+            " |- 'P('x); 'Q('x)",
+            "'Q('x) |- "
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        given Proof = emptyProof
+
+        for (stmt <- correct) {
+            Hypothesis(stmt) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for (stmt <- incorrect) {
+            Hypothesis(stmt) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    // rewrite
+    // TODO: make this use equivalence checker tests
+    test("Tactic Tests: Rewrite") {
+        val correct = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) /\\ 'Q('x) |- 'R('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'R('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) ")
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        // so much jank
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmt1, stmt2) <- correct) {
+            val prem = introduceSequent(stmt1)
+            Rewrite(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmt1, stmt2) <- incorrect) {
+            val prem = introduceSequent(stmt1)
+            Rewrite(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    // cut
+    test("Tactic Tests: Cut - Parameter Inference") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+            // ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"), // can't infer params out of conjunctions yet
+            // ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+            ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)")
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)")
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmt1, stmt2, stmt3) <- correct) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            Cut(using emptyProof)(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmt1, stmt2, stmt3) <- incorrect) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            Cut(using emptyProof)(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    test("Tactic Tests: Cut - Explicit Parameters") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
+            ("'P('x) /\\ 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) /\\ 'R('x) |- 'Q('x)", "'R('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x); 'R('x)", "'P('x); 'R('x) |- 'Q('x); 'R('x)", "'R('x)")
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)", "'R('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'Q('x); 'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x)"),
+            ("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'P('x)"),
+            ("'P('x); 'R('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'P('x); 'R('x) |- 'Q('x)", "'R('x) /\\ 'P('x)"),
+            ("'P('x) |- 'R('x)", "'R('x); 'P('x) |- 'Q('x)", "'R('x) |- 'Q('x)", "'R('x)")
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmt1, stmt2, stmt3, form) <- correct) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            Cut.withParameters(using emptyProof)(FOLParser.parseFormula(form))(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmt1, stmt2, stmt3, form) <- incorrect) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            Cut.withParameters(using emptyProof)(FOLParser.parseFormula(form))(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    // left rules
+
+    //     left and
+    test("Tactic Tests: Left And - Parameter Inference") {
+        val correct = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x); 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmt1, stmt2) <- correct) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmt1, stmt2) <- incorrect) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    test("Tactic Tests: Left And - Explicit Parameters") {
+        val correct = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) \\/ 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'P('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x); 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) /\\ 'A('x) |- 'R('x)", "'Q('x)", "'S('x) /\\ 'A('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
+            ("'P('x); 'Q('x); 'S('x) |- 'R('x)", "'P('x); 'Q('x) /\\ 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
+            ("'P('x); 'Q('x); 'S('x) /\\ 'A('x) |- 'R('x)", "'P('x); 'Q('x) /\\ ('S('x) /\\ 'A('x)) |- 'R('x)", "'Q('x)", "'S('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmt1, stmt2, phi, psi) <- correct) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmt1, stmt2, phi, psi) <- incorrect) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    //     left or
+    test("Tactic Tests: Left Or - Parameter Inference") {
+        val correct = List(
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)"),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'E('x) \\/ 'T('x); 'P('x) |- 'Q('x); 'S('x)"),
+            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)"),
+        )
+
+        val incorrect = List(
+            (List(),  "'P('x) |- 'S('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'T('x); 'S('x)"),
+            (List("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)")),
+            (List("'P('x); 'T('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'T('x) |- 'Q('x); 'S('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmts: List[String], stmt2: String) <- correct) {
+            val prems = stmts.map(introduceSequent(_))
+            LeftOr(using emptyProof)(prems: _*)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmts: List[String], stmt2: String) <- incorrect) {
+            val prems = stmts.map(introduceSequent(_))
+            LeftOr(using emptyProof)(prems: _*)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    test("Tactic Tests: Left Or - Explicit Parameters") {
+        val correct = List(
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'P('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)", List("'P('x)")),
+        )
+
+        val incorrect = List(
+            (List(),  "'P('x) |- 'S('x)", List()),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)", "'Q('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'Q('x); 'S('x)", List("'P('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x); 'W('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x) \\/ 'R('x); 'O('x) |- 'Q('x); 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'P('x) |- 'Q('x); 'S('x)", List("'E('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'E('x) \\/ 'T('x) |- 'Q('x); 'S('x)", List("'E('x)", "'T('x)")),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        given Proof = emptyProof
+
+        for ((stmts, stmt2, forms) <- correct) {
+            val prems = stmts.map(introduceSequent(_))
+            LeftOr.withParameters(using emptyProof)(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => {showCurrentProof(); fail("Correct step failed!")}
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+
+        for ((stmts, stmt2, forms) <- incorrect) {
+            val prems = stmts.map(introduceSequent(_))
+            LeftOr.withParameters(using emptyProof)(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+                case _ => fail("Invalid result received from tactic!") 
+            }
+        }
+    }
+
+    //     left implies
+    //     left iff
+    //     left not
+    //     left forall
+    //     left exists
+    //     left existsone
+
+    // right rules
+    //     right and 
+    //     right or
+    //     right implies
+    //     right iff
+    //     right not 
+    //     right forall 
+    //     right exists
+    //     right existsone
+
+    // left refl
+    // right refl
+
+    // left substeq
+    // right substeq
+
+    // left substiff
+    // right substiff
+
+    // instfunschema
+    // instpredschema 
+
+    // subproof  
+}

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -881,14 +881,51 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightExists.withParameters(FOLParser.parseFormula(form), variable, FOLParser.parseTerm(term))(prem)(stmt2)
         }
     }
-    //     right and 
-    //     right or
-    //     right implies
-    //     right iff
-    //     right not 
-    //     right forall 
-    //     right exists
+
     //     right existsone
+    test("Tactic Tests: Right ExistsOne - Parameter Inference") {
+        val correct = List(
+            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('y))", "'R('z) |- ∃!y. 'P('y)"),
+            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
+            ("'R('z) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
+        )
+
+        val incorrect = List(
+            // TODO: FIX or KERNEL ERROR
+            ("'P('x); 'Q('z) |- 'R('y)", "'P('x) |- 'R('y)"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
+            val prem = introduceSequent(stmt1)
+            RightExistsOne(prem)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right ExistsOne - Explicit Parameters") {
+        val correct = List(
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('y) |- ∃!x. 'P('z)", "'P('z)", "x"),
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x"),
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('y) |- ∃!x. 'P('x)", "'P('x)", "x"),
+        )
+
+        val incorrect = List(
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('z))", "'R('w) |- ∃!x. 'P('z)", "'P('z)", "x"),
+            // TODO: this looks v broken::
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'T('y) |- ∃!x. 'P('x)", "'P('x)", "z"),
+            ("'R('y) |- ∃y.∀x.( ('x = 'y) <=> 'P('x))", "'R('z) |- ∃!x. 'P('z)", "'P('z)", "x"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('z) |- ∃!y. 'P('w)", "'P('w)", "w"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('w))", "'R('y) |- ∃!y. 'P('y)", "'P('y)", "y"),
+            ("'R('y) |- ∃x.∀y. ('y = 'x <=> 'P('x))", "'R('w) |- ∃!x. 'P('x)", "'P('x)", "x"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, form, variable) =>
+            val prem = introduceSequent(stmt1)
+            RightExistsOne.withParameters(FOLParser.parseFormula(form), variable)(prem)(stmt2)
+        }
+    }
 
     // left refl
     // right refl

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -561,6 +561,53 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightAnd.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
         }
     }
+
+    //     right or
+    test("Tactic Tests: Right Or - Parameter Inference") {
+        val correct = List(
+            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x); 'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))"),
+        )
+
+        val incorrect = List(
+            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x); 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
+            val prem = introduceSequent(stmt1)
+            RightOr(prem)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right Or - Explicit Parameters") {
+        val correct = List(
+            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x) \\/ 'A('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x) \\/ 'A('x)", "'Q('x)", "'S('x) \\/ 'A('x)"),
+        )
+
+        val incorrect = List(
+            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'P('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) /\\ 'S('x)", "'Q('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'Q('x)", "'P('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x)", "'R('x) |- 'P('x); 'Q('x) \\/ 'S('x)", "'P('x)", "'S('x)"),
+            ("'R('x) |- 'P('x); 'Q('x); 'S('x) \\/ 'A('x)", "'R('x) |- 'P('x); 'Q('x) \\/ ('S('x) \\/ 'A('x))", "'Q('x)", "'S('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, phi, psi) =>
+            val prem = introduceSequent(stmt1)
+            RightOr.withParameters(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -512,6 +512,55 @@ class BasicTacticTest extends ProofTacticTestLib {
     }
 
     // right rules
+
+    //     right and
+    test("Tactic Tests: Right And - Parameter Inference") {
+        val correct = List(
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)"),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'R('x); 'P('x) |- 'Q('x) /\\ 'S('x); 'Q('x)"),
+            // TODO: should this be allowed? ::
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) |- 'Q('x); 'S('x); 'E('x) \\/ 'T('x)"),
+            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)"),
+        )
+
+        val incorrect = List(
+            (List(),  "'P('x) |- 'S('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'T('x) |- 'Q('x) /\\'S('x)"),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x); 'T('x) |- 'Q('x) /\\ 'S('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmts, stmt2) =>
+            val prems = stmts.map(introduceSequent(_))
+            RightAnd(prems: _*)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right And - Explicit Parameters") {
+        val correct = List(
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'Q('x)", "'S('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'S('x)", "'Q('x)")),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'Q('x)", "'S('x)")),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'S('x)", "'Q('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x); 'S('x)", List("'Q('x)", "'S('x)")),
+            (List("'P('x) |- 'S('x)"),  "'P('x) |- 'S('x)", List("'P('x)")),
+        )
+
+        val incorrect = List(
+            (List(),  "'P('x) |- 'S('x)", List()),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)", "'Q('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'Q('x) /\\ 'S('x)", List("'P('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x); 'W('x) |- 'Q('x) /\\ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+            (List("'W('x); 'P('x) |- 'S('x)", "'R('x); 'O('x) |- 'Q('x); 'T('x)"),  "'P('x); 'R('x); 'O('x) |- 'Q('x) \\/ 'S('x); 'T('x)", List("'P('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'R('x); 'P('x) |- 'Q('x) \\/ 'S('x); 'S('x)", List("'E('x)", "'R('x)")),
+            (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x); 'R('x) |- 'E('x) \\/ 'T('x)", List("'E('x)", "'T('x)")),
+        )
+
+        testTacticCases(correct, incorrect){ (stmts, stmt2, forms) =>
+            val prems = stmts.map(introduceSequent(_))
+            RightAnd.withParameters(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1013,6 +1013,42 @@ class BasicTacticTest extends ProofTacticTestLib {
   }
 
   // left substeq
+  test("Tactic Tests: Left SubstEq") {
+    val q = variable
+    val w = variable
+    val e = variable
+    val r = variable
+    val t = variable
+    val y = variable
+    val Y = predicate(6)
+    val Y1 = LambdaTermFormula(Seq(q), Y(q, w, e, r, t, y))
+    val Y2 = LambdaTermFormula(Seq(q, w), Y(q, w, e, r, t, y))
+    val Y5 = LambdaTermFormula(Seq(q, w, e, r, t, y), Y(q, w, e, r, t, y))
+
+    val correct = List(
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 's = 'w; 'Y('a, 's, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q"), ("'s", "'w")), Y2),
+      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+    )
+
+    val incorrect = List(
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'w; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'S('x); 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'S('x); 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('x); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('x); 'a = 'q; 'Y('a, 'w, 'e, 'r, 't, 'y) |- 'S('x); 'R('x)", List(("'a", "'q")), Y1),
+      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
+      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 'y; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'t")), Y5),
+      ("'P('q); 'Y('q, 'w, 'e, 'r, 't, 'y) |- 'R('x)", "'P('q); 'a = 'q; 's = 'w; 'd = 'e; 'f = 'r; 'g = 't; 'h = 't; 'Y('a, 's, 'd, 'f, 'g, 'h) |- 'R('x)", List(("'a", "'q"), ("'s", "'w"), ("'d", "'e"), ("'f", "'r"), ("'g", "'t"), ("'h", "'y")), Y5),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
+      val prem = introduceSequent(stmt1)
+      LeftSubstEq(forms.map((a, b) => (FOLParser.parseTerm(a), FOLParser.parseTerm(b))), ltf)(prem)(stmt2)
+    }
+  }
   // right substeq
 
   // left substiff

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -31,21 +31,17 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
         val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
         val emptyProof = new BaseProof(placeholderTheorem)
 
-        given Proof = emptyProof
-
         for (stmt <- correct) {
-            Hypothesis(stmt) match {
+            Hypothesis(using emptyProof)(stmt) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
         for (stmt <- incorrect) {
-            Hypothesis(stmt) match {
+            Hypothesis(using emptyProof)(stmt) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -75,14 +71,11 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmt1, stmt2) <- correct) {
             val prem = introduceSequent(stmt1)
             Rewrite(using emptyProof)(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -91,7 +84,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             Rewrite(using emptyProof)(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -123,15 +115,12 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmt1, stmt2, stmt3) <- correct) {
             val prem1 = introduceSequent(stmt1)
             val prem2 = introduceSequent(stmt2)
             Cut(using emptyProof)(prem1, prem2)(stmt3) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -141,7 +130,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             Cut(using emptyProof)(prem1, prem2)(stmt3) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -172,15 +160,12 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmt1, stmt2, stmt3, form) <- correct) {
             val prem1 = introduceSequent(stmt1)
             val prem2 = introduceSequent(stmt2)
             Cut.withParameters(using emptyProof)(FOLParser.parseFormula(form))(prem1, prem2)(stmt3) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -190,7 +175,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             Cut.withParameters(using emptyProof)(FOLParser.parseFormula(form))(prem1, prem2)(stmt3) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -224,14 +208,11 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmt1, stmt2) <- correct) {
             val prem = introduceSequent(stmt1)
             LeftAnd(using emptyProof)(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -240,7 +221,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             LeftAnd(using emptyProof)(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -273,14 +253,11 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmt1, stmt2, phi, psi) <- correct) {
             val prem = introduceSequent(stmt1)
             LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -289,7 +266,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -307,8 +283,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
         val incorrect = List(
             (List(),  "'P('x) |- 'S('x)"),
             (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x) |- 'T('x); 'S('x)"),
-            (List("'P('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)")),
-            (List("'P('x); 'T('x) |- 'R('x)", "'R('x) |- 'Q('x)", "'R('x) |- 'R('x)")),
             (List("'P('x) |- 'S('x)", "'R('x) |- 'Q('x)"),  "'P('x) \\/ 'R('x); 'T('x) |- 'Q('x); 'S('x)"),
         )
 
@@ -322,14 +296,11 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmts: List[String], stmt2: String) <- correct) {
             val prems = stmts.map(introduceSequent(_))
             LeftOr(using emptyProof)(prems: _*)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => true
                 case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
 
@@ -338,7 +309,6 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             LeftOr(using emptyProof)(prems: _*)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
@@ -371,14 +341,11 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
                 )(using Hypothesis)
                 )
 
-        given Proof = emptyProof
-
         for ((stmts, stmt2, forms) <- correct) {
             val prems = stmts.map(introduceSequent(_))
             LeftOr.withParameters(using emptyProof)(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => true
-                case j: emptyProof.InvalidProofTactic => {showCurrentProof(); fail("Correct step failed!")}
-                case _ => fail("Invalid result received from tactic!") 
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
             }
         }
 
@@ -387,13 +354,199 @@ class BasicTacticTest extends AnyFunSuite with BasicMain {
             LeftOr.withParameters(using emptyProof)(forms.map(FOLParser.parseFormula(_)): _*)(prems: _*)(stmt2) match {
                 case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
                 case j: emptyProof.InvalidProofTactic => true
-                case _ => fail("Invalid result received from tactic!") 
             }
         }
     }
 
     //     left implies
+
+    test("Tactic Tests: Left Implies - Parameter Inference") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x) |- 'Q('x); 'R('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'P('x); 'S('x) |- 'Q('x); 'T('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        for ((stmt1, stmt2, stmt3) <- correct) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            LeftImplies(using emptyProof)(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+            }
+        }
+
+        for ((stmt1, stmt2, stmt3) <- incorrect) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            LeftImplies(using emptyProof)(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+            }
+        }
+    }
+
+    test("Tactic Tests: Left Implies - Explicit Parameters") {
+        val correct = List(
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'P('x)"),
+            ("'P('x) |- 'R('x); 'Q('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'P('x)", "'Q('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x); 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); (!'R('x)) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); !'R('x) \\/ 'S('x) |- 'Q('x)", "'P('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'T('x)", "'P('x); 'R('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'T('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'T('x) ==> 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) ==> 'S('x) |- 'T('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) \\/ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x); 'R('x) /\\ 'S('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+            ("'P('x) |- 'R('x)", "'S('x) |- 'Q('x)", "'P('x) |- 'Q('x)", "'R('x)", "'S('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        for ((stmt1, stmt2, stmt3, form1, form2) <- correct) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            LeftImplies.withParameters(using emptyProof)(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+            }
+        }
+
+        for ((stmt1, stmt2, stmt3, form1, form2) <- incorrect) {
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            LeftImplies.withParameters(using emptyProof)(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+            }
+        }
+    }
+
     //     left iff
+    test("Tactic Tests: Left Iff - Parameter Inference") {
+        val correct = List(
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        for ((stmt1, stmt2) <- correct) {
+            val prem = introduceSequent(stmt1)
+            LeftIff(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+            }
+        }
+
+        for ((stmt1, stmt2) <- incorrect) {
+            val prem = introduceSequent(stmt1)
+            LeftIff(using emptyProof)(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+            }
+        }
+    }
+
+    test("Tactic Tests: Left Iff - Explicit Parameters") {
+        val correct = List(
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'Q('x)", "'P('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'S('x) ==> 'Q('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'S('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x)", "'P('x)", "'R('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'S('x) |- 'R('x); 'P('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'S('x)"),
+            ("'P('x); 'Q('x) ==> 'S('x) |- 'R('x)", "'P('x); 'Q('x) <=> 'T('x) |- 'R('x)", "'Q('x)", "'T('x)"),
+        )
+
+        val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+        val emptyProof = new BaseProof(placeholderTheorem)
+
+        def introduceSequent(seq: String) = emptyProof.newProofStep(
+            emptyProof.ValidProofTactic(
+                Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+                Seq()
+                )(using Hypothesis)
+                )
+
+        for ((stmt1, stmt2, phi, psi) <- correct) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => true
+                case j: emptyProof.InvalidProofTactic => fail("Correct step failed!")
+            }
+        }
+
+        for ((stmt1, stmt2, phi, psi) <- incorrect) {
+            val prem = introduceSequent(stmt1)
+            LeftAnd.withParameters(using emptyProof)(FOLParser.parseFormula(phi), FOLParser.parseFormula(psi))(prem)(stmt2) match {
+                case j: emptyProof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: emptyProof.InvalidProofTactic => true
+            }
+        }
+    }
+
+
     //     left not
     //     left forall
     //     left exists

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1136,7 +1136,55 @@ class BasicTacticTest extends ProofTacticTestLib {
       LeftSubstIff(forms, ltf)(prem)(stmt2)
     }
   }
+
   // right substiff
+  test("Tactic Tests: Right SubstIff") {
+    val q = FOLParser.parseFormula("'Q('q)")
+    val w = FOLParser.parseFormula("'W('w)")
+    val e = FOLParser.parseFormula("'E('e)")
+    val r = FOLParser.parseFormula("'R('r)")
+    val t = FOLParser.parseFormula("'T('t)")
+    val y = FOLParser.parseFormula("'Y('y)")
+    val a = FOLParser.parseFormula("'A('a)")
+    val s = FOLParser.parseFormula("'S('s)")
+    val d = FOLParser.parseFormula("'D('d)")
+    val f = FOLParser.parseFormula("'F('f)")
+    val g = FOLParser.parseFormula("'G('g)")
+    val h = FOLParser.parseFormula("'H('h)")
+    val z = VariableFormulaLabel("z")
+    val x = VariableFormulaLabel("x")
+    val c = VariableFormulaLabel("c")
+    val v = VariableFormulaLabel("v")
+    val b = VariableFormulaLabel("b")
+    val n = VariableFormulaLabel("n")
+    val Y1 = LambdaFormulaFormula(Seq(z), z /\ w /\ e /\ r /\ t /\ y)
+    val Y2 = LambdaFormulaFormula(Seq(z, x), z /\ x /\ e /\ r /\ t /\ y)
+    val Y5 = LambdaFormulaFormula(Seq(z, x, c, v, b, n), z /\ x /\ c /\ v /\ b /\ n)
+
+    val correct = List(
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q), (s, w)), Y2),
+      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+    )
+
+    val incorrect = List(
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'W('w)) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)); 'S('x) |- 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('x) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('x); ('A('a) <=> 'Q('q)) |- 'S('x); 'R('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", List((a, q)), Y1),
+      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
+      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
+      ("'P('q) |- 'R('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y))", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
+      val prem = introduceSequent(stmt1)
+      RightSubstIff(forms, ltf)(prem)(stmt2)
+    }
+  }
 
   // instfunschema
   // instpredschema

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1187,7 +1187,37 @@ class BasicTacticTest extends ProofTacticTestLib {
   }
 
   // instfunschema
-  // instpredschema
+  test("Tactic Tests: InstFunSchema") {
+    val x = variable
+    val y = variable
+    val f = SchematicFunctionLabel("f", 1)
+    val h = SchematicFunctionLabel("h", 2)
+    val g = function(2)
+    val Y = LambdaTermTerm(Seq(x), x)
+    val Z = LambdaTermTerm(Seq(x, y), g(x, y))
 
-  // subproof
+    val correct = List(
+      ("'P('x); 'f('x) = 'y |- 'R('y)", "'P('x); ('x = 'y) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](f -> Y)),
+      ("'P('x); 'Q('f('x)) |- 'R('y)", "'P('x); 'Q('x) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](f -> Y)),
+      ("'P('x); 'Q('h('x, 'y)) |- 'R('y)", "'P('x); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('h('y, 'y)); 'Q('h('x, 'y)) |- 'R('y)", "'P('g('y, 'y)); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y)", "'P('x); 'Q('g('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z, f -> Y)),
+    )
+
+    val incorrect = List(
+      ("'P('x); 'f('x) = 'y |- 'R('y)", "'P('x); !('x = 'y) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](f -> Y)),
+      ("'P('x); 'Q('f('x)) |- 'R('y)", "'P('x); 'Q('y) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](f -> Y)),
+      ("'P('x); 'Q('h('x, 'y)) |- 'R('y)", "'P('x); 'Q('h('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('h('y, 'y)); 'Q('h('x, 'y)) |- 'R('y)", "'P('g('y, 'y)); 'Q('g('y, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y)", "'P('x); 'Q('h('x, 'y)) |- 'R('y)", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'z", Map[SchematicTermLabel, LambdaTermTerm](h -> Z, f -> Y)),
+      ("'P('x); 'Q('g('x, 'y)) |- 'R('y); 'f('x) = 'y", "'P('x); 'Q('g('x, 'y)) |- 'R('y); 'x = 'y", Map[SchematicTermLabel, LambdaTermTerm](h -> Z)),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, termMap) =>
+      val prem = introduceSequent(stmt1)
+      InstFunSchema(termMap)(prem)(stmt2)
+    }
+  }
 }

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -712,6 +712,55 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
         }
     }
+
+    //     right not
+    test("Tactic Tests: Right Not - Parameter Inference") {
+        val correct = List(
+            ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)"),
+            ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)"),
+            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)"),
+        )
+
+        val incorrect = List(
+            // TODO: FIX AND UNCOMMENT THESE TESTS
+            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x); !'Q('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'P('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'Q('x) <=> 'T('x)"),
+            ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'Q('x); 'R('x)"),
+            ("'P('x) |- 'R('x); !'Q('x)", "'P('x) |- 'Q('x); 'R('x)"),
+            // TODO: should this be allowed::
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x)"),
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2) =>
+            val prem = introduceSequent(stmt1)
+            RightNot(prem)(stmt2)
+        }
+    }
+
+    test("Tactic Tests: Right Not - Explicit Parameters") {
+        val correct = List(
+            ("'Q('x); 'P('x) |- 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
+            ("'Q('x); 'P('x) |- 'R('x); !'Q('x)", "'P('x)|- 'R('x); !'Q('x)", "'Q('x)"),
+            ("'Q('x); 'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); 'Q('x); !'Q('x)", "'Q('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); 'Q('x) |- 'R('x)", "'Q('x)"),
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x); !'Q('x)", "'Q('x)"),
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x) |- 'R('x)", "'Q('x)"),
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'P('x)"),
+            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
+            ("'P('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x)"),
+            ("'P('x); !'Q('x) |- 'Q('x); 'R('x)", "'P('x); !'Q('x) |- 'R('x)", "'R('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, form) =>
+            val prem = introduceSequent(stmt1)
+            RightNot.withParameters(FOLParser.parseFormula(form))(prem)(stmt2)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1089,6 +1089,53 @@ class BasicTacticTest extends ProofTacticTestLib {
   }
 
   // left substiff
+  test("Tactic Tests: Left SubstIff") {
+    val q = FOLParser.parseFormula("'Q('q)")
+    val w = FOLParser.parseFormula("'W('w)")
+    val e = FOLParser.parseFormula("'E('e)")
+    val r = FOLParser.parseFormula("'R('r)")
+    val t = FOLParser.parseFormula("'T('t)")
+    val y = FOLParser.parseFormula("'Y('y)")
+    val a = FOLParser.parseFormula("'A('a)")
+    val s = FOLParser.parseFormula("'S('s)")
+    val d = FOLParser.parseFormula("'D('d)")
+    val f = FOLParser.parseFormula("'F('f)")
+    val g = FOLParser.parseFormula("'G('g)")
+    val h = FOLParser.parseFormula("'H('h)")
+    val z = VariableFormulaLabel("z")
+    val x = VariableFormulaLabel("x")
+    val c = VariableFormulaLabel("c")
+    val v = VariableFormulaLabel("v")
+    val b = VariableFormulaLabel("b")
+    val n = VariableFormulaLabel("n")
+    val Y1 = LambdaFormulaFormula(Seq(z), z /\ w /\ e /\ r /\ t /\ y)
+    val Y2 = LambdaFormulaFormula(Seq(z, x), z /\ x /\ e /\ r /\ t /\ y)
+    val Y5 = LambdaFormulaFormula(Seq(z, x, c, v, b, n), z /\ x /\ c /\ v /\ b /\ n)
+
+    val correct = List(
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('A('a) /\\ 'S('s) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q), (s, w)), Y2),
+      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+    )
+
+    val incorrect = List(
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'W('w)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); 'S('x); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", List((a, q)), Y1),
+      ("'P('x); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('x); ('A('a) <=> 'Q('q)); ('A('a) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'S('x); 'R('x)", List((a, q)), Y1),
+      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
+      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, t)), Y5),
+      ("'P('q); ('Q('q) /\\ 'W('w) /\\ 'E('e) /\\ 'R('r) /\\ 'T('t) /\\ 'Y('y)) |- 'R('x)", "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'T('t)); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h)) |- 'R('x)", List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)), Y5),
+    )
+
+    testTacticCases(correct, incorrect) { (stmt1, stmt2, forms, ltf) =>
+      val prem = introduceSequent(stmt1)
+      LeftSubstIff(forms, ltf)(prem)(stmt2)
+    }
+  }
   // right substiff
 
   // instfunschema

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -659,6 +659,59 @@ class BasicTacticTest extends ProofTacticTestLib {
             RightImplies.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem)(stmt2)
         }
     }
+
+    //     right iff
+    test("Tactic Tests: Right Iff - Parameter Inference") {
+        val correct = List(
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)"),
+        )
+
+        val incorrect = List(
+            // TODO: asymmetric! shoud we allow this? ::
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) ==> 'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'S('x) ==> 'Q('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)"),
+            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3) =>
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            RightIff(prem1, prem2)(stmt3)
+        }
+    }
+
+    test("Tactic Tests: Right Iff - Explicit Parameters") {
+        val correct = List(
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+        )
+
+        val incorrect = List(
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'S('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'R('x)", "'R('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'T('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x); 'T('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'P('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'W('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'W('x); 'Q('x) <=> 'S('x)", "'T('x)", "'S('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'R('x); 'Q('x) <=> 'S('x)", "'W('x)", "'S('x)"),
+            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'T('x)"),
+            ("'P('x) |- 'R('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'R('x); 'S('x) ==> 'Q('x) ", "'P('x) |- 'T('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+            ("'P('x) |- 'S('x); 'Q('x) ==> 'S('x)", "'P('x) |- 'S('x); 'S('x) ==> 'Q('x) ", "'T('x) |- 'S('x); 'Q('x) <=> 'S('x)", "'Q('x)", "'S('x)"),
+        )
+
+        testTacticCases(correct, incorrect){ (stmt1, stmt2, stmt3, form1, form2) =>
+            val prem1 = introduceSequent(stmt1)
+            val prem2 = introduceSequent(stmt2)
+            RightIff.withParameters(FOLParser.parseFormula(form1), FOLParser.parseFormula(form2))(prem1, prem2)(stmt3)
+        }
+    }
     //     right and 
     //     right or
     //     right implies

--- a/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
@@ -10,43 +10,43 @@ import scala.collection.immutable.LazyList
 
 class ProofTacticTestLib extends AnyFunSuite with BasicMain {
 
-    export lisa.test.TestTheoryLibrary.{_, given}
+  export lisa.test.TestTheoryLibrary.{_, given}
 
-    // generate a placeholde theorem to take ownership of proofs for test
-    val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+  // generate a placeholde theorem to take ownership of proofs for test
+  val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") { have("'P('x) |- 'P('x)") by Hypothesis }
 
-    // generates an empty proof owned by the placeholder theorem for testing
-    def generateTestProof() = new BaseProof(placeholderTheorem)
+  // generates an empty proof owned by the placeholder theorem for testing
+  def generateTestProof() = new BaseProof(placeholderTheorem)
 
-    // introduces a 'proofless' step without verification into a given proof object
-    // the step cannot be passed through the kernel for verification in any way,
-    // but does allow for using them as premise to test tactics
-    // extreme jank :)
-    def introduceSequent(using proof: Proof)(seq: String) = proof.newProofStep(
-        proof.ValidProofTactic(
-            Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
-            Seq()
-            )(using Hypothesis)
-            )
-    
-    // given a list of test cases and a function to pass them through a tactic, simply checks them
-    def testTacticCases[A](using proof: Proof)(correct: List[A], incorrect: List[A])(t: A => proof.ProofTacticJudgement): Unit = {
-        for (testCase <- correct)
-            t(testCase) match {
-                case j: proof.ValidProofTactic => true
-                case j: proof.InvalidProofTactic => fail(s"Correct step failed! ${j.message}")
-            }
+  // introduces a 'proofless' step without verification into a given proof object
+  // the step cannot be passed through the kernel for verification in any way,
+  // but does allow for using them as premise to test tactics
+  // extreme jank :)
+  def introduceSequent(using proof: Proof)(seq: String) = proof.newProofStep(
+    proof.ValidProofTactic(
+      Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))),
+      Seq()
+    )(using Hypothesis)
+  )
 
-        for (testCase <- incorrect)
-            t(testCase) match {
-                case j: proof.ValidProofTactic => fail(s"Incorrect step passed!")
-                case j: proof.InvalidProofTactic => true
-            }
-    }
+  // given a list of test cases and a function to pass them through a tactic, simply checks them
+  def testTacticCases[A](using proof: Proof)(correct: List[A], incorrect: List[A])(t: A => proof.ProofTacticJudgement): Unit = {
+    for (testCase <- correct)
+      t(testCase) match {
+        case j: proof.ValidProofTactic => true
+        case j: proof.InvalidProofTactic => fail(s"Correct step failed! ${j.message}")
+      }
 
-    // proof object constructed 'out of context' for testing
-    // supports adding sequents for use as premises without verification
-    // see `introduceSequent`
-    val testProof = new BaseProof(placeholderTheorem)
-    given Proof = testProof 
+    for (testCase <- incorrect)
+      t(testCase) match {
+        case j: proof.ValidProofTactic => fail(s"Incorrect step passed!")
+        case j: proof.InvalidProofTactic => true
+      }
+  }
+
+  // proof object constructed 'out of context' for testing
+  // supports adding sequents for use as premises without verification
+  // see `introduceSequent`
+  val testProof = new BaseProof(placeholderTheorem)
+  given Proof = testProof
 }

--- a/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
@@ -1,0 +1,49 @@
+package lisa.utils
+
+import lisa.kernel.proof.{SequentCalculus as SC}
+import lisa.utils.Library
+import lisa.utils.tactics.BasicStepTactic.*
+import lisa.utils.tactics.ProofTacticLib
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.collection.immutable.LazyList
+
+class ProofTacticTestLib extends AnyFunSuite with BasicMain {
+
+    export lisa.test.TestTheoryLibrary.{_, given}
+
+    // generate a placeholde theorem to take ownership of proofs for test
+    val placeholderTheorem = makeTHM("'P('x) |- 'P('x)") {have("'P('x) |- 'P('x)") by Hypothesis}
+
+    // generates an empty proof owned by the placeholder theorem for testing
+    def generateTestProof() = new BaseProof(placeholderTheorem)
+
+    // introduces a 'proofless' step without verification into a given proof object
+    // the step cannot be passed through the kernel for verification in any way,
+    // but does allow for using them as premise to test tactics
+    // extreme jank :)
+    def introduceSequent(using proof: Proof)(seq: String) = proof.newProofStep(
+        proof.ValidProofTactic(
+            Seq(SC.Hypothesis(FOLParser.parseSequent(seq), FOLParser.parseFormula("'P('x)"))), 
+            Seq()
+            )(using Hypothesis)
+            )
+    
+    // given a list of test cases and a function to pass them through a tactic, simply checks them
+    def testTacticCases[A](using proof: Proof)(correct: List[A], incorrect: List[A])(t: A => proof.ProofTacticJudgement) = {
+        for (testCase <- correct)
+            t(testCase) match {
+                case j: proof.ValidProofTactic => true
+                case j: proof.InvalidProofTactic => fail("Correct step failed!")
+            }
+
+        for (testCase <- incorrect)
+            t(testCase) match {
+                case j: proof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: proof.InvalidProofTactic => true
+            }
+    }
+
+    val testProof = new BaseProof(placeholderTheorem)
+    given Proof = testProof 
+}

--- a/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/ProofTacticTestLib.scala
@@ -30,20 +30,23 @@ class ProofTacticTestLib extends AnyFunSuite with BasicMain {
             )
     
     // given a list of test cases and a function to pass them through a tactic, simply checks them
-    def testTacticCases[A](using proof: Proof)(correct: List[A], incorrect: List[A])(t: A => proof.ProofTacticJudgement) = {
+    def testTacticCases[A](using proof: Proof)(correct: List[A], incorrect: List[A])(t: A => proof.ProofTacticJudgement): Unit = {
         for (testCase <- correct)
             t(testCase) match {
                 case j: proof.ValidProofTactic => true
-                case j: proof.InvalidProofTactic => fail("Correct step failed!")
+                case j: proof.InvalidProofTactic => fail(s"Correct step failed! ${j.message}")
             }
 
         for (testCase <- incorrect)
             t(testCase) match {
-                case j: proof.ValidProofTactic => fail("Incorrect step passed!")
+                case j: proof.ValidProofTactic => fail(s"Incorrect step passed!")
                 case j: proof.InvalidProofTactic => true
             }
     }
 
+    // proof object constructed 'out of context' for testing
+    // supports adding sequents for use as premises without verification
+    // see `introduceSequent`
     val testProof = new BaseProof(placeholderTheorem)
     given Proof = testProof 
 }


### PR DESCRIPTION
Adding tests for proof tactics, since it seems we currently miss some errors during changes! 

Progress:
:heavy_check_mark: Hypo, Rewrite (WIP to use EqvChecker test functions),  Cut
:heavy_check_mark: Left rules
:heavy_check_mark: Right rules
:heavy_check_mark: Structural rules

Other changes to facilitate things:
:1st_place_medal: `unwrapTactic` utility to call other tactics safely

Issues: **The new tests in this PR will fail till I fix these (eventually)**
:heavy_check_mark: `LeftExists` checking
:heavy_check_mark: OCBSL/Weakening leniency
:heavy_check_mark: `InstantiateForall` not working due to argument type mismatch -> changed it to accept a sequent and check against it