### PR TITLE
Issue with top and bot constants in EqChecker

### DIFF
--- a/lisa-examples/src/main/scala/Exercise.scala
+++ b/lisa-examples/src/main/scala/Exercise.scala
@@ -1,5 +1,6 @@
 import lisa.automation.kernel.SimplePropositionalSolver.*
 import lisa.automation.kernel.SimpleSimplifier.*
+import lisa.kernel.proof.SequentCalculus.*
 import lisa.utils.Library
 import lisa.utils.Printer
 
@@ -9,10 +10,9 @@ object Exercise extends lisa.Main {
   val P = predicate(1)
   val f = function(1)
 
+
   val testThm = makeTHM("'P('x) ⇒ 'P('f('x)) ⊢ 'P('x) ⇒ 'P('f('x))") {
     val i1 = have(P(x) ==> P(f(x)) |- P(x) ==> P(f(x))) by Restate;
-    have(P(x) ==> P(f(x)) |- P(x) ==> P(f(x))) by Restate(i1)
-    // andThen(P(x) ==> P(f(x)) |- P(x) ==> P(f(x))) by Restate
   }
   show
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -197,7 +197,9 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
     } else {
       val r = f match {
         case PredicateFormula(label, args) =>
-          SimplePredicate(label, args, polarity, f)
+          if (label == top) SimpleLiteral(polarity)
+          else if (label == bot) SimpleLiteral(!polarity)
+          else SimplePredicate(label, args, polarity, f)
         case ConnectorFormula(label, args) =>
           label match {
             case cl: ConstantConnectorLabel =>


### PR DESCRIPTION
The special handling for the top and bot predicate labels were missing, they are now take into account.