### PR TITLE
Weakening message fix

### DIFF
--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -851,7 +851,7 @@ object BasicStepTactic {
       if (!isSubset(premiseSequent.left, bot.left))
         proof.InvalidProofTactic("Left-hand side of conclusion is not the same as left-hand side of premise.")
       else if (!isSubset(premiseSequent.right, bot.right))
-        proof.InvalidProofTactic("Left-hand side of premise is not a subset of left-hand side of conclusion.")
+        proof.InvalidProofTactic("Right-hand side of premise is not a subset of right-hand side of conclusion.")
       else
         proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premise))
     }


### PR DESCRIPTION
Changed weakening saying there is a mismatch in the LHS when the issue is in the RHS.

_DEFINITELY not something I spent a while confused by trying to fix my proof with._