### PR TITLE
Change weakening to use OL implication

### DIFF
--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -298,11 +298,9 @@ object SCProofChecker {
            *   Γ, Σ |- Δ
            */
           case Weakening(b, t1) =>
-            if (isSubset(ref(t1).left, b.left))
-              if (isSubset(ref(t1).right, b.right))
-                SCValidProof(SCProof(step))
-              else SCInvalidProof(SCProof(step), Nil, "Right-hand side of premise must be a subset of right-hand side of conclusion")
-            else SCInvalidProof(SCProof(step), Nil, "Left-hand side of premise must be a subset of left-hand side of conclusion")
+            if (isImplyingSequent(ref(t1), b))
+              SCValidProof(SCProof(step))
+            else SCInvalidProof(SCProof(step), Nil, "Conclusion cannot be trivially derived from premise.")
 
           // Equality Rules
           /*

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -38,6 +38,15 @@ object SequentCalculus {
   def isSameSequent(l: Sequent, r: Sequent): Boolean = isSame(sequentToFormula(l), sequentToFormula(r))
 
   /**
+   * Checks whether a given sequent implies another, with respect to [[latticeLEQ]].
+   *
+   * @param l the first sequent
+   * @param r the second sequent
+   * @return see [[latticeLEQ]]
+   */
+  def isImplyingSequent(l: Sequent, r: Sequent): Boolean = isImplying(sequentToFormula(l), sequentToFormula(r))
+
+  /**
    * The parent of all proof steps types.
    * A proof step is a deduction rule of sequent calculus, with the sequents forming the prerequisite and conclusion.
    * For easier linearisation of the proof, the prerequisite are represented with numbers showing the place in the proof of the sequent used.

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -848,10 +848,8 @@ object BasicStepTactic {
     def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       lazy val premiseSequent = proof.getSequent(premise)
 
-      if (!isSubset(premiseSequent.left, bot.left))
-        proof.InvalidProofTactic("Left-hand side of conclusion is not the same as left-hand side of premise.")
-      else if (!isSubset(premiseSequent.right, bot.right))
-        proof.InvalidProofTactic("Right-hand side of premise is not a subset of right-hand side of conclusion.")
+      if (!SC.isImplyingSequent(premiseSequent, bot))
+        proof.InvalidProofTactic("Conclusion cannot be trivially derived from premise.")
       else
         proof.ValidProofTactic(Seq(SC.Weakening(bot, -1)), Seq(premise))
     }

--- a/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/tactics/BasicStepTactic.scala
@@ -867,7 +867,7 @@ object BasicStepTactic {
     def withParameters(using proof: Library#Proof)(fa: Formula)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       lazy val premiseSequent = proof.getSequent(premise)
 
-      if (!isSameSet(bot.left + fa, premiseSequent.left))
+      if (!isSameSet(bot.left + fa, premiseSequent.left) || !premiseSequent.left.exists(_ == fa) || bot.left.exists(_ == fa))
         proof.InvalidProofTactic("Left-hand sides of the conclusion + φ is not the same as left-hand side of the premise.")
       else if (!isSameSet(bot.right, premiseSequent.right))
         proof.InvalidProofTactic("Right-hand side of the premise is not the same as the right-hand side of the conclusion.")
@@ -902,7 +902,7 @@ object BasicStepTactic {
    */
   object RightRefl extends ProofTactic with ParameterlessHave {
     def withParameters(using proof: Library#Proof)(fa: Formula)(bot: Sequent): proof.ProofTacticJudgement = {
-      if (!contains(bot.right, fa))
+      if (!bot.right.exists(_ == fa))
         proof.InvalidProofTactic("Right-hand side of conclusion does not contain φ.")
       else
         fa match {

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -903,7 +903,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x); 'Q('z)"),
       ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)"),
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) /\\ 'Q('x) |- 'R('x)"),
-      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)")
     )
 
     val incorrect = List(
@@ -914,7 +914,7 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'R('x)"),
       ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
-      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) "),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) ")
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -901,7 +901,9 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
       ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
       ("'P('x) |- 'R('x)", "'P('x); 'S('y) |- 'R('x); 'Q('z)"),
-      ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)")
+      ("'P('x) |- 'R('x)", "'P('x); 'S('y); 'Q('z) |- 'R('x); 'Q('z); 'S('k)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) /\\ 'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) \\/ 'Q('x)"),
     )
 
     val incorrect = List(
@@ -909,7 +911,10 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'P('x) |- 'R('x)", "'P('x) |- "),
       ("'P('x); 'S('y) |- 'R('x)", "'P('x) |- 'R('x); 'S('y)"),
       ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'S('y) |- 'R('x)"),
-      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)")
+      ("'P('x); 'Q('y) |- 'R('x)", "'P('x); 'Q('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) |- 'R('x)"),
+      ("'P('x); 'Q('x) |- 'R('x)", "'P('x) \\/ 'Q('x) |- 'R('x)"),
+      ("'P('x) |- 'R('x); 'Q('x)", "'P('x) |- 'R('x) /\\'Q('x) "),
     )
 
     testTacticCases(correct, incorrect) { (stmt1, stmt2) =>
@@ -948,7 +953,6 @@ class BasicTacticTest extends ProofTacticTestLib {
       ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'y"),
       ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z); 'y = 'y |- 'P('x)", "'y = 'y"),
       ("'R('z); 'x = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
-      ("'R('z); 'x = 'x; 'y = 'y |- 'P('x)", "'R('z) |- 'P('x)", "'x = 'x"),
       ("'R('z); 'x = 'x |- 'P('x)", "'R('z); 'x = 'y |- 'P('x)", "'x = 'x")
     )
 


### PR DESCRIPTION
<title />

`Rewrite` continues to use `isSameSequent` to preserve the logical consistency of the sequent. Other than that use case, `Weakening` should now strictly subsume `Rewrite`.