### PR TITLE
Upgrade scala version to 3.2.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ inThisBuild(
 )
 
 val scala2 = "2.13.8"
-val scala3 = "3.2.1-RC1-bin-20220619-4cb967f-NIGHTLY"
+val scala3 = "3.2.2"
 
 fork := true
 


### PR DESCRIPTION
Upgraded Scala version to `3.2.2` for builds. For the nightly version we had been using, Metals tags are not available on Maven and so all IDE features refuse to work. This should solve all of that (please). 

Tested with internal tests as well as new theorems from #115 . 

Unfortunately does not fix our type resolution errors yet #119 , #120 . 

Compilation with a newer `3.3.0-RC2` either raises dotty errors or seems to go into an infinite loop somewhere, so _settling_ for a stable version :) 