### PR TITLE
Instantiated Facts

### DIFF
--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -33,7 +33,7 @@ object SCProofChecker {
            * ------------
            *    Γ |- Δ
            */
-          case Rewrite(s, t1) =>
+          case Restate(s, t1) =>
             if (isSameSequent(s, ref(t1))) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The premise and the conclusion are not trivially equivalent.")
 
           /*
@@ -41,7 +41,7 @@ object SCProofChecker {
            * ------------
            *    Γ |- Γ
            */
-          case RewriteTrue(s) =>
+          case RestateTrue(s) =>
             val truth = Sequent(Set(), Set(PredicateFormula(top, Nil)))
             if (isSameSequent(s, truth)) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The desired conclusion is not a trivial tautology")
           /*

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -64,19 +64,19 @@ object SequentCalculus {
    * <pre>
    *    Γ |- Δ
    * ------------
-   *    Γ |- Δ  (OCBSL rewrite)
+   *    Γ |- Δ  (OL rewrite)
    * </pre>
    */
-  case class Rewrite(bot: Sequent, t1: Int) extends SCProofStep { val premises = Seq(t1) }
+  case class Restate(bot: Sequent, t1: Int) extends SCProofStep { val premises = Seq(t1) }
 
   /**
    * <pre>
    *
    * ------------
-   *    Γ |- Γ  (OCBSL tautology)
+   *    Γ |- Γ  (OL tautology)
    * </pre>
    */
-  case class RewriteTrue(bot: Sequent) extends SCProofStep { val premises = Seq() }
+  case class RestateTrue(bot: Sequent) extends SCProofStep { val premises = Seq() }
 
   /**
    * <pre>

--- a/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
@@ -15,7 +15,7 @@ import scala.collection.mutable.Stack as stack
  */
 abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.ProofsHelpers {
   val theory: RunningTheory
-  val library: Library = this
+  given library: this.type = this
   given RunningTheory = theory
   export lisa.kernel.fol.FOL.{Formula, *}
   val SC: SequentCalculus.type = lisa.kernel.proof.SequentCalculus
@@ -231,10 +231,10 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
     val xeb = x === body
     val y = VariableLabel(freshId(body.freeVariables.map(_.id) ++ vars.map(_.id) + out.id, "y"))
     val s0 = SC.RightRefl(() |- body === body, body === body)
-    val s1 = SC.Rewrite(() |- (xeb) <=> (xeb), 0)
+    val s1 = SC.Restate(() |- (xeb) <=> (xeb), 0)
     val s2 = SC.RightForall(() |- forall(x, (xeb) <=> (xeb)), 1, (xeb) <=> (xeb), x)
     val s3 = SC.RightExists(() |- exists(y, forall(x, (x === y) <=> (xeb))), 2, forall(x, (x === y) <=> (xeb)), y, body)
-    val s4 = SC.Rewrite(() |- existsOne(x, xeb), 3)
+    val s4 = SC.Restate(() |- existsOne(x, xeb), 3)
     val v = Vector(s0, s1, s2, s3, s4)
     SCProof(v)
   }

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofTacticLib.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofTacticLib.scala
@@ -24,18 +24,18 @@ object ProofTacticLib {
   }
 
   trait OnlyProofTactic {
-    def apply(using proof: Library#Proof): proof.ProofTacticJudgement
+    def apply(using lib: Library, proof: lib.Proof): proof.ProofTacticJudgement
   }
 
   trait ProofSequentTactic {
-    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement
+    def apply(using lib: Library, proof: lib.Proof)(bot: Sequent): proof.ProofTacticJudgement
   }
 
   trait ProofFactTactic {
-    def apply(using proof: Library#Proof)(premise: proof.Fact): proof.ProofTacticJudgement
+    def apply(using lib: Library, proof: lib.Proof)(premise: proof.Fact): proof.ProofTacticJudgement
   }
   trait ProofFactSequentTactic {
-    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement
+    def apply(using lib: Library, proof: lib.Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement
   }
 
   class UnapplicableProofTactic(val tactic: ProofTactic, proof: Library#Proof, errorMessage: String)(using sourcecode.Line, sourcecode.File) extends UserLisaException(errorMessage) {

--- a/lisa-utils/src/main/scala/lisa/prooflib/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/SimpleDeducedSteps.scala
@@ -6,7 +6,7 @@ import lisa.kernel.proof.SCProofChecker
 import lisa.kernel.proof.SequentCalculus.SCProofStep
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus as SC
-import lisa.prooflib.BasicStepTactic._
+import lisa.prooflib.BasicStepTactic.*
 import lisa.prooflib.ProofTacticLib.{_, given}
 import lisa.prooflib.*
 import lisa.utils.FOLParser
@@ -16,19 +16,22 @@ import lisa.utils.Printer
 object SimpleDeducedSteps {
 
   object Restate extends ProofTactic with ProofSequentTactic with ProofFactSequentTactic {
-    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement =
+    def apply(using lib: Library, proof: lib.Proof)(bot: Sequent): proof.ProofTacticJudgement =
       unwrapTactic(RewriteTrue(bot))("Attempted true rewrite during tactic Restate failed.")
 
     // (proof.ProofStep | proof.OutsideFact | Int)     is definitionally equal to proof.Fact, but for some reason
     // scala compiler doesn't resolve the overload with a type alias, dependant type and implicit parameter
 
-    def apply(using proof: Library#Proof)(premise: proof.ProofStep | proof.OutsideFact | Int)(bot: Sequent): proof.ProofTacticJudgement =
+    def apply(using lib: Library, proof: lib.Proof)(premise: proof.ProofStep | proof.OutsideFact | Int | proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
+      unwrapTactic(Rewrite(premise)(bot))("Attempted rewrite during tactic Restate failed.")
+
+    def apply2(using lib: Library, proof: lib.Proof)(premise: proof.ProofStep | proof.OutsideFact | Int | proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
       unwrapTactic(Rewrite(premise)(bot))("Attempted rewrite during tactic Restate failed.")
 
   }
 
   object Discharge extends ProofTactic {
-    def apply(using proof: Library#Proof)(premises: proof.Fact*)(premise: proof.Fact): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(premises: proof.Fact*)(premise: proof.Fact): proof.ProofTacticJudgement = {
       val seqs = premises map proof.getSequent
       if (!seqs.forall(_.right.size == 1))
         return proof.InvalidProofTactic("When discharging this way, the discharged sequent must have only a single formula on the right handside.")
@@ -64,13 +67,13 @@ object SimpleDeducedSteps {
    * Returns a subproof containing the instantiation steps
    */
   object InstantiateForall extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: FOL.Formula, t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(phi: FOL.Formula, t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val premiseSequent = proof.getSequent(premise)
       if (!premiseSequent.right.contains(phi)) {
         proof.InvalidProofTactic("Input formula was not found in the RHS of the premise sequent.")
       } else {
         val emptyProof = SCProof(IndexedSeq(), IndexedSeq(proof.getSequent(premise)))
-        val j = proof.ValidProofTactic(Seq(SC.Rewrite(premiseSequent, -1)), Seq(premise))
+        val j = proof.ValidProofTactic(Seq(SC.Restate(premiseSequent, -1)), Seq(premise))
         val res = t.foldLeft((emptyProof, phi, j: proof.ProofTacticJudgement)) { case ((p, f, j), t) =>
           j match {
             case proof.InvalidProofTactic(_) => (p, f, j) // propagate error
@@ -123,11 +126,11 @@ object SimpleDeducedSteps {
       }
     }
 
-    def apply(using proof: Library#Proof)(t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(t: FOL.Term*)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val prem = proof.getSequent(premise)
       if (prem.right.tail.isEmpty) {
         // well formed
-        apply(using proof)(prem.right.head, t*)(premise)(bot): proof.ProofTacticJudgement
+        apply(using lib, proof)(prem.right.head, t*)(premise)(bot): proof.ProofTacticJudgement
       } else proof.InvalidProofTactic("RHS of premise sequent is not a singleton.")
     }
   }
@@ -147,7 +150,7 @@ object SimpleDeducedSteps {
    * </pre>
    */
   object PartialCut extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: FOL.Formula, conjunction: FOL.Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(phi: FOL.Formula, conjunction: FOL.Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val leftSequent = proof.getSequent(prem1)
       val rightSequent = proof.getSequent(prem2)
 
@@ -166,7 +169,7 @@ object SimpleDeducedSteps {
                 val Sigma: Set[FOL.Formula] = rightSequent.left - phi
 
                 val p0 = SC.Weakening(rightSequent ++< (psi |- ()), -2)
-                val p1 = SC.RewriteTrue(psi |- psi)
+                val p1 = SC.RestateTrue(psi |- psi)
 
                 // TODO: can be abstracted into a RightAndAll step
                 val emptyProof = SCProof(IndexedSeq(), IndexedSeq(p0.bot, p1.bot))
@@ -175,7 +178,7 @@ object SimpleDeducedSteps {
                 }
 
                 val p2 = SC.SCSubproof(proofRightAndAll, Seq(0, 1))
-                val p3 = SC.Rewrite(Sigma + conjunction |- newConclusions, 2) // sanity check and correct form
+                val p3 = SC.Restate(Sigma + conjunction |- newConclusions, 2) // sanity check and correct form
                 val p4 = SC.Cut(bot, -1, 3, conjunction)
 
                 /**
@@ -215,7 +218,7 @@ object SimpleDeducedSteps {
   }
 
   object destructRightAnd extends ProofTactic {
-    def apply(using proof: Library#Proof)(a: FOL.Formula, b: FOL.Formula)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(a: FOL.Formula, b: FOL.Formula)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val conc = proof.getSequent(prem)
       val p0 = SC.Hypothesis(emptySeq +< a +> a, a)
       val p1 = SC.LeftAnd(emptySeq +< (a /\ b) +> a, 0, a, b)
@@ -224,7 +227,7 @@ object SimpleDeducedSteps {
     }
   }
   object destructRightOr extends ProofTactic {
-    def apply(using proof: Library#Proof)(a: FOL.Formula, b: FOL.Formula)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(a: FOL.Formula, b: FOL.Formula)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val conc = proof.getSequent(prem)
       val mat = conc.right.find(f => FOL.isSame(f, a \/ b))
       if (mat.nonEmpty) {
@@ -243,11 +246,11 @@ object SimpleDeducedSteps {
   }
 
   object GeneralizeToForall extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: FOL.Formula, t: FOL.VariableLabel*)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(phi: FOL.Formula, t: FOL.VariableLabel*)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val sequent = proof.getSequent(prem)
       if (sequent.right.contains(phi)) {
         val emptyProof = SCProof(IndexedSeq(), IndexedSeq(sequent))
-        val j = proof.ValidProofTactic(IndexedSeq(SC.Rewrite(sequent, proof.length - 1)), Seq[proof.Fact]())
+        val j = proof.ValidProofTactic(IndexedSeq(SC.Restate(sequent, proof.length - 1)), Seq[proof.Fact]())
 
         val res = t.foldRight(emptyProof: SCProof, phi: FOL.Formula, j: proof.ProofTacticJudgement) { case (x1, (p1: SCProof, phi1, j1)) =>
           j1 match {
@@ -268,7 +271,7 @@ object SimpleDeducedSteps {
 
         res._3 match {
           case proof.InvalidProofTactic(_) => res._3
-          case proof.ValidProofTactic(_, _) => proof.ValidProofTactic((res._1.steps appended SC.Rewrite(bot, res._1.length - 1)), Seq(prem))
+          case proof.ValidProofTactic(_, _) => proof.ValidProofTactic((res._1.steps appended SC.Restate(bot, res._1.length - 1)), Seq(prem))
         }
 
       } else proof.InvalidProofTactic("RHS of premise sequent contains not phi")
@@ -277,9 +280,9 @@ object SimpleDeducedSteps {
   }
 
   object GeneralizeToForallNoForm extends ProofTactic {
-    def apply(using proof: Library#Proof)(t: FOL.VariableLabel*)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(t: FOL.VariableLabel*)(prem: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       if (proof.getSequent(prem).right.tail.isEmpty)
-        GeneralizeToForall.apply(using proof)(proof.getSequent(prem).right.head, t*)(prem)(bot): proof.ProofTacticJudgement
+        GeneralizeToForall.apply(using lib, proof)(proof.getSequent(prem).right.head, t*)(prem)(bot): proof.ProofTacticJudgement
       else
         proof.InvalidProofTactic("RHS of premise sequent is not a singleton.")
     }
@@ -287,7 +290,7 @@ object SimpleDeducedSteps {
   }
 
   object ByCase extends ProofTactic {
-    def apply(using proof: Library#Proof)(phi: FOL.Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(phi: FOL.Formula)(prem1: proof.Fact, prem2: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement = {
       val nphi = !phi
 
       val pa = proof.getSequent(prem1)
@@ -296,7 +299,7 @@ object SimpleDeducedSteps {
       if (leftAphi.nonEmpty && leftBnphi.nonEmpty) {
         val p2 = SC.RightNot(pa -< leftAphi.get +> nphi, -1, phi)
         val p3 = SC.Cut(pa -< leftAphi.get ++ (pb -< leftBnphi.get), 0, -2, nphi)
-        val p4 = SC.Rewrite(bot, 1)
+        val p4 = SC.Restate(bot, 1)
         proof.ValidProofTactic(IndexedSeq(p2, p3, p4), IndexedSeq(prem1, prem2)) // TODO: Check pa/pb orDer
 
       } else {

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -11,6 +11,7 @@ import lisa.prooflib.ProofTacticLib.UnimplementedProof
 import lisa.prooflib.*
 import lisa.utils.LisaException
 import lisa.utils.UserLisaException
+import lisa.utils.parsing.UnreachableException
 
 import scala.annotation.nowarn
 import scala.collection.mutable.Buffer as mBuf
@@ -19,16 +20,44 @@ import scala.collection.mutable.Stack as stack
 
 trait WithTheorems {
   library: Library =>
+  /*
+  sealed trait InstantiatedFact {
+    val baseFormula: Sequent
+    val instsConn: Map[SchematicConnectorLabel, LambdaFormulaFormula]
+    val instsPred: Map[SchematicVarOrPredLabel, LambdaTermFormula]
+    val instsTerm: Map[SchematicTermLabel, LambdaTermTerm]
+    lazy val result: Sequent = instantiateSchemaInSequent(baseFormula, instsConn, instsPred, instsTerm)
+  }
+
+  case class InstantiatedJustification(
+                                        just: theory.Justification,
+                                        instsConn: Map[SchematicConnectorLabel, LambdaFormulaFormula],
+                                        instsPred: Map[SchematicVarOrPredLabel, LambdaTermFormula],
+                                        instsTerm: Map[SchematicTermLabel, LambdaTermTerm]) extends InstantiatedFact {
+    val baseFormula: Sequent = theory.sequentFromJustification(just)
+  }*/
 
   sealed abstract class Proof(assump: List[Formula]) {
     val possibleGoal: Option[Sequent]
     type SelfType = this.type
     type OutsideFact >: theory.Justification
+    type Fact = ProofStep | InstantiatedFact | OutsideFact | Int
 
-    val library: Library = WithTheorems.this.library
+    case class InstantiatedFact(
+        fact: Fact,
+        instsConn: Map[SchematicConnectorLabel, LambdaFormulaFormula],
+        instsPred: Map[SchematicVarOrPredLabel, LambdaTermFormula],
+        instsTerm: Map[SchematicTermLabel, LambdaTermTerm]
+    ) {
+      val baseFormula: Sequent = sequentOfFact(fact)
+      val result: Sequent = instantiateSchemaInSequent(baseFormula, instsConn, instsPred, instsTerm)
+    }
+
+    val library: WithTheorems.this.type = WithTheorems.this
 
     private var steps: List[ProofStep] = Nil
     private var imports: List[(OutsideFact, Sequent)] = Nil
+    private var instantiatedFacts: List[(InstantiatedFact, Int)] = Nil
     private var assumptions: List[Formula] = assump
     private var discharges: List[Fact] = Nil
 
@@ -36,6 +65,7 @@ trait WithTheorems {
 
     case class ProofStep private (judgement: ValidProofTactic, scps: SCProofStep, position: Int) {
       def bot: Sequent = scps.bot
+      val host: Proof.this.type = Proof.this
 
       def tactic: ProofTactic = judgement.tactic
 
@@ -55,11 +85,15 @@ trait WithTheorems {
     def newProofStep(judgement: ValidProofTactic): ProofStep =
       ProofStep.newProofStep(judgement)
 
-    type Fact = ProofStep | OutsideFact | Int
-
     private def addStep(ds: ProofStep): Unit = steps = ds :: steps
     private def addImport(imp: OutsideFact, seq: Sequent): Unit = {
       imports = (imp, seq) :: imports
+    }
+
+    private def addInstantiatedFact(instFact: InstantiatedFact): Unit = {
+      val (_, i) = sequentAndIntOfFact(instFact.fact)
+      newProofStep(BasicStepTactic.InstSchema(using library, this)(instFact.instsConn, instFact.instsPred, instFact.instsTerm)(i).asInstanceOf[ValidProofTactic])
+      instantiatedFacts = (instFact, steps.length - 1) :: instantiatedFacts
     }
 
     def addAssumption(f: Formula): Unit = {
@@ -95,7 +129,7 @@ trait WithTheorems {
     def getDischarges: List[Fact] = discharges
 
     def toSCProof: lisa.kernel.proof.SCProof = {
-      discharges.foreach(i => {
+      discharges.foreach(i => { // TODO probably remove
         val (s, t1) = sequentAndIntOfFact(i)
         SC.Cut((mostRecentStep.bot -< s.right.head) ++ (s -> s.right.head), t1, steps.length - 1, s.right.head)
       })
@@ -123,6 +157,12 @@ trait WithTheorems {
           i
         )
       case ds: ProofStep => (ds.bot, ds.position)
+      case instFact: InstantiatedFact =>
+        val r = instantiatedFacts.find(instFact == _._1)
+        r match {
+          case Some(value) => (instFact.result, value._2)
+          case None => addInstantiatedFact(instFact)(instFact.result, steps.length - 1)
+        }
       case of: OutsideFact @unchecked =>
         val r = imports.indexWhere(of == _._1)
         if (r != -1) {
@@ -145,6 +185,7 @@ trait WithTheorems {
           else imports(imports.length + i)._2
         }
       case ds: ProofStep => ds.bot
+      case instfact: InstantiatedFact => instfact.result
       case of: OutsideFact @unchecked =>
         val r = imports.find(of == _._1)
         if (r.nonEmpty) {
@@ -175,7 +216,7 @@ trait WithTheorems {
       val parent: Proof.this.type = Proof.this
       val owningTheorem: THM = parent.owningTheorem
       type OutsideFact = parent.Fact
-      override def asOutsideFact(j: theory.Justification): OutsideFact = parent.asOutsideFact(j)
+      override inline def asOutsideFact(j: theory.Justification): OutsideFact = parent.asOutsideFact(j)
 
       override def sequentOfOutsideFact(of: parent.Fact): Sequent = of match {
         case j: theory.Justification => theory.sequentFromJustification(j)
@@ -229,7 +270,7 @@ trait WithTheorems {
     val possibleGoal: Option[Sequent] = Some(owningTheorem.goal)
     val goal: Sequent = owningTheorem.goal
     type OutsideFact = theory.Justification
-    override def asOutsideFact(j: theory.Justification): OutsideFact = j
+    override inline def asOutsideFact(j: theory.Justification): OutsideFact = j
 
     override def sequentOfOutsideFact(of: theory.Justification): Sequent = theory.sequentFromJustification(of)
   }

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -318,7 +318,7 @@ object KernelHelpers {
      */
     def theorem(name: String, statement: Sequent, proof: SCProof, justifications: Seq[theory.Justification]): RunningTheoryJudgement[theory.Theorem] = {
       if (statement == proof.conclusion) theory.makeTheorem(name, statement, proof, justifications)
-      else if (isSameSequent(statement, proof.conclusion)) theory.makeTheorem(name, statement, proof.appended(Rewrite(statement, proof.length - 1)), justifications)
+      else if (isSameSequent(statement, proof.conclusion)) theory.makeTheorem(name, statement, proof.appended(Restate(statement, proof.length - 1)), justifications)
       else InvalidJustification(s"The proof proves ${FOLPrinter.prettySequent(proof.conclusion)} instead of claimed ${FOLPrinter.prettySequent(statement)}", None)
     }
 

--- a/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
@@ -129,8 +129,8 @@ class Printer(parser: Parser) {
             pretty("Subproof", sp.premises*) +: prettySCProofRecursive(sp.sp, level + 1, currentTree, (if (i == 0) topMostIndices else IndexedSeq.empty) :+ i)
           case other =>
             val line = other match {
-              case Rewrite(_, t1) => pretty("Rewrite", t1)
-              case RewriteTrue(_) => pretty("RewriteTrue")
+              case Restate(_, t1) => pretty("Rewrite", t1)
+              case RestateTrue(_) => pretty("RewriteTrue")
               case Hypothesis(_, _) => pretty("Hypo.")
               case Cut(_, t1, t2, _) => pretty("Cut", t1, t2)
               case LeftAnd(_, t1, _, _) => pretty("Left ∧", t1)

--- a/lisa-utils/src/test/scala/lisa/kernel/ProofTests.scala
+++ b/lisa-utils/src/test/scala/lisa/kernel/ProofTests.scala
@@ -57,7 +57,7 @@ class ProofTests extends AnyFunSuite {
     }
     val orig = subformulas.next().head
     val swapped = subformulasSwapped.next().head
-    val prf = SCProof(Vector(Hypothesis(Sequent(Set(orig), Set(orig)), orig), Rewrite(Sequent(Set(orig), Set(swapped)), 0)))
+    val prf = SCProof(Vector(Hypothesis(Sequent(Set(orig), Set(orig)), orig), Restate(Sequent(Set(orig), Set(swapped)), 0)))
     assert(predicateVerifier(prf).isValid)
   }
 }

--- a/src/main/scala/lisa/automation/kernel/OLPropositionalSolver.scala
+++ b/src/main/scala/lisa/automation/kernel/OLPropositionalSolver.scala
@@ -21,7 +21,7 @@ object OLPropositionalSolver {
      * @param proof The ongoing proof object in which the step happens.
      * @param bot The desired conclusion.
      */
-    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(bot: Sequent): proof.ProofTacticJudgement = {
       solveSequent(bot) match {
         case Left(value) => proof.ValidProofTactic(value.steps, Seq())
         case Right((msg, seq)) => proof.InvalidProofTactic(msg)
@@ -36,12 +36,12 @@ object OLPropositionalSolver {
      * @param premise A previously proven step necessary to reach the conclusion.
      * @param bot   The desired conclusion.
      */
-    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      from(using proof)(Seq(premise)*)(bot)
+    def apply(using lib: Library, proof: lib.Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
+      from(using lib, proof)(Seq(premise)*)(bot)
 
-    def from(using proof: Library#Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
+    def from(using lib: Library, proof: lib.Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
       val premsFormulas = premises.map(p => (p, sequentToFormula(proof.getSequent(p)))).zipWithIndex
-      val initProof = premsFormulas.map(s => Rewrite(() |- s._1._2, -(1 + s._2))).toList
+      val initProof = premsFormulas.map(s => Restate(() |- s._1._2, -(1 + s._2))).toList
       val sqToProve = bot ++< (premsFormulas.map(s => s._1._2).toSet |- ())
       solveSequent(sqToProve) match {
         case Left(value) =>
@@ -71,7 +71,7 @@ object OLPropositionalSolver {
 
     try {
       val steps = solveAugSequent(augSeq, 0)(using MaRvIn)
-      Left(SCProof((Rewrite(s, steps.length - 1) :: steps).reverse.toIndexedSeq))
+      Left(SCProof((Restate(s, steps.length - 1) :: steps).reverse.toIndexedSeq))
     } catch
       case e: NoProofFoundException =>
         Right(
@@ -124,7 +124,7 @@ object OLPropositionalSolver {
     val bestAtom = findBestAtom(s.formula)
     val redF = reducedForm(s.formula)
     if (redF == top()) {
-      List(RewriteTrue(s.decisions._1 ++ s.decisions._2.map((f: Formula) => Neg(f)) |- s.formula))
+      List(RestateTrue(s.decisions._1 ++ s.decisions._2.map((f: Formula) => Neg(f)) |- s.formula))
     } else if (bestAtom.isEmpty) {
       assert(redF == bot()) // sanity check; If the formula has no atom left in it and is reduced, it should be either ⊤ or ⊥.
       val res = s.decisions._1 |- redF :: s.decisions._2 // the branch that can't be closed
@@ -141,9 +141,9 @@ object OLPropositionalSolver {
       val seq2 = AugSequent((s.decisions._1, atom :: s.decisions._2), lambdaF(Seq(bot())))
       val proof2 = solveAugSequent(seq2, offset + proof1.length + 1)
       val subst2 = RightSubstIff(Neg(atom) :: s.decisions._1 ++ s.decisions._2.map((f: Formula) => Neg(f)) |- redF, offset + proof1.length + proof2.length - 1 + 1, List((atom, bot())), lambdaF)
-      val red2 = Rewrite(s.decisions._1 ++ s.decisions._2.map((f: Formula) => Neg(f)) |- (redF, atom), offset + proof1.length + proof2.length + 2 - 1)
+      val red2 = Restate(s.decisions._1 ++ s.decisions._2.map((f: Formula) => Neg(f)) |- (redF, atom), offset + proof1.length + proof2.length + 2 - 1)
       val cutStep = Cut(s.decisions._1 |- redF :: s.decisions._2, offset + proof1.length + proof2.length + 3 - 1, offset + proof1.length + 1 - 1, atom)
-      val redStep = Rewrite(s.decisions._1 |- s.formula :: s.decisions._2, offset + proof1.length + proof2.length + 4 - 1)
+      val redStep = Restate(s.decisions._1 |- s.formula :: s.decisions._2, offset + proof1.length + proof2.length + 4 - 1)
       redStep :: cutStep :: red2 :: subst2 :: proof2 ++ (subst1 :: proof1)
 
     }

--- a/src/main/scala/lisa/automation/kernel/SimplePropositionalSolver.scala
+++ b/src/main/scala/lisa/automation/kernel/SimplePropositionalSolver.scala
@@ -91,7 +91,7 @@ object SimplePropositionalSolver {
     } else if (left.ors.nonEmpty) {
       val f = left.ors.head
       if (f.args.isEmpty) {
-        List(RewriteTrue(s))
+        List(RestateTrue(s))
       } else if (f.args.length == 1) {
         val phi = f.args(0)
 
@@ -157,7 +157,7 @@ object SimplePropositionalSolver {
     } else if (right.ands.nonEmpty) {
       val f = right.ands.head
       if (f.args.isEmpty) {
-        List(RewriteTrue(s))
+        List(RestateTrue(s))
       } else if (f.args.length == 1) {
         val phi = f.args(0)
 
@@ -222,17 +222,17 @@ object SimplePropositionalSolver {
 
   object Trivial extends ProofTactic with ProofSequentTactic with ProofFactSequentTactic {
 
-    def apply(using proof: Library#Proof)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply(using lib: Library, proof: lib.Proof)(bot: Sequent): proof.ProofTacticJudgement = {
       proof.ValidProofTactic(solveSequent(bot).steps, Seq())
     }
 
-    def apply(using proof: Library#Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
-      apply2(using proof)(Seq(premise)*)(bot)
+    def apply(using lib: Library, proof: lib.Proof)(premise: proof.Fact)(bot: Sequent): proof.ProofTacticJudgement =
+      apply2(using lib, proof)(Seq(premise)*)(bot)
 
-    def apply2(using proof: Library#Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
+    def apply2(using lib: Library, proof: lib.Proof)(premises: proof.Fact*)(bot: Sequent): proof.ProofTacticJudgement = {
       val steps = {
         val premsFormulas = premises.map(p => (p, sequentToFormula(proof.getSequent(p)))).zipWithIndex
-        val initProof = premsFormulas.map(s => Rewrite(() |- s._1._2, -(1 + s._2))).toList
+        val initProof = premsFormulas.map(s => Restate(() |- s._1._2, -(1 + s._2))).toList
         val sqToProve = bot ++< (premsFormulas.map(s => s._1._2).toSet |- ())
         val subpr = SCSubproof(solveSequent(sqToProve))
         val stepsList = premsFormulas.foldLeft[List[SCProofStep]](List(subpr))((prev: List[SCProofStep], cur) => {

--- a/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
+++ b/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
@@ -102,7 +102,7 @@ object SimpleSimplifier {
   }
 
   object applySubst extends ProofTactic {
-    private def applyLeftRight(using proof: lisa.prooflib.Library#Proof)(phi: Formula)(premise: proof.Fact)(rightLeft: Boolean = false): proof.ProofTacticJudgement = {
+    private def applyLeftRight(using lib: lisa.prooflib.Library, proof: lib.Proof)(phi: Formula)(premise: proof.Fact)(rightLeft: Boolean = false): proof.ProofTacticJudgement = {
       val originSequent = proof.getSequent(premise)
       val leftOrigin = ConnectorFormula(And, originSequent.left.toSeq)
       val rightOrigin = ConnectorFormula(Or, originSequent.right.toSeq)
@@ -133,10 +133,10 @@ object SimpleSimplifier {
           val result2: Sequent = result1.left |- ConnectorFormula(And, newright.toSeq)
 
           val scproof = Seq(
-            Rewrite(leftOrigin |- rightOrigin, -1),
+            Restate(leftOrigin |- rightOrigin, -1),
             LeftSubstEq(result1, 0, List(left -> right), LambdaTermFormula(Seq(v), leftForm)),
             RightSubstEq(result2, 1, List(left -> right), LambdaTermFormula(Seq(v), rightForm)),
-            Rewrite(newleft |- newright, 2)
+            Restate(newleft |- newright, 2)
           )
           proof.ValidProofTactic(
             scproof,
@@ -166,10 +166,10 @@ object SimpleSimplifier {
           val result2: Sequent = result1.left |- ConnectorFormula(Or, newright.toSeq)
 
           val scproof = Seq(
-            Rewrite(leftOrigin |- rightOrigin, -1),
+            Restate(leftOrigin |- rightOrigin, -1),
             LeftSubstIff(result1, 0, List(left -> right), LambdaFormulaFormula(Seq(H), leftForm)),
             RightSubstIff(result2, 1, List(left -> right), LambdaFormulaFormula(Seq(H), rightForm)),
-            Rewrite(newleft |- newright, 2)
+            Restate(newleft |- newright, 2)
           )
           proof.ValidProofTactic(
             scproof,
@@ -181,7 +181,7 @@ object SimpleSimplifier {
     }
 
     @nowarn("msg=.*the type test for proof.Fact cannot be checked at runtime*")
-    def apply(using proof: lisa.prooflib.Library#Proof)(f: proof.Fact | Formula)(premise: proof.Fact): proof.ProofTacticJudgement = {
+    def apply(using lib: lisa.prooflib.Library, proof: lib.Proof)(f: proof.Fact | Formula)(premise: proof.Fact): proof.ProofTacticJudgement = {
       f match {
         case phi: Formula => applyLeftRight(phi)(premise)()
         case f: proof.Fact =>

--- a/src/main/scala/lisa/proven/mathematics/SetTheory.scala
+++ b/src/main/scala/lisa/proven/mathematics/SetTheory.scala
@@ -408,18 +408,9 @@ object SetTheory extends lisa.Main {
   show
 
   val unorderedPair_deconstruction = makeTHM("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ 'a = 'c ∧ 'b = 'd ∨ 'a = 'd ∧ 'b = 'c") {
-
-    val base = have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ ('z = 'a ∨ 'z = 'b) ⇔ ('z = 'c ∨ 'z = 'd)") subproof {
-      have("⊢ elem('z, unorderedPair('a, 'b)) ⇔ ('z = 'a ∨ 'z = 'b)") by InstFunSchema(Map(x -> a, y -> b))(pairAxiom)
-      val s1 = andThen(applySubst("unorderedPair('a, 'b) = unorderedPair('c, 'd)"))
-      have("⊢ elem('z, unorderedPair('c, 'd)) ⇔ ('z = 'c ∨ 'z = 'd)") by InstFunSchema(Map(x -> c, y -> d))(pairAxiom)
-      andThen(applySubst(s1))
-    }
-    val vx = have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ ('a = 'c ∨ 'a = 'd)") by InstFunSchema(Map(z -> a))(base)
-    val vy = have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ ('b = 'c ∨ 'b = 'd)") by InstFunSchema(Map(z -> b))(base)
-    val vx1 = have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ ('c = 'a ∨ 'c = 'b)") by InstFunSchema(Map(z -> c))(base)
-    val vy1 = have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ ('d = 'a ∨ 'd = 'b)") by InstFunSchema(Map(z -> d))(base)
-    have("unorderedPair('a, 'b) = unorderedPair('c, 'd) ⊢ 'a = 'c ∧ 'b = 'd ∨ 'a = 'd ∧ 'b = 'c") by Tautology.from(vx, vy, vx1, vy1)
+    val s1 = have(applySubst("unorderedPair('a, 'b) = unorderedPair('c, 'd)")(pairAxiom of (x -> a, y -> b)))
+    val base = have(applySubst(s1)(pairAxiom of (x -> c, y -> d)))
+    have(thesis) by Tautology.from(base of (z -> a), base of (z -> b), base of (z -> c), base of (z -> d))
   }
   show
 

--- a/src/main/scala/lisa/utilities/prooftransform/ProofUnconditionalizer.scala
+++ b/src/main/scala/lisa/utilities/prooftransform/ProofUnconditionalizer.scala
@@ -145,7 +145,7 @@ case class ProofInstantiationRemover(pr: SCProof) extends ProofTransformer(pr) {
     val mImps = imps.toMap
     val mSteps = pr.steps.zipWithIndex.map((s, j) =>
       s match {
-        case _ if isInst(s) => Rewrite(() |- sequentToFormulaNullable(s.bot), -pr.imports.length - mImps(j) - 1)
+        case _ if isInst(s) => Restate(() |- sequentToFormulaNullable(s.bot), -pr.imports.length - mImps(j) - 1)
         case _ => s
       }
     )
@@ -218,7 +218,7 @@ case class ProofUnconditionalizer(prOrig: SCProof) extends ProofTransformer(prOr
         h
       })
     val rewrites = hypothesis.zipWithIndex.map((h, i) => {
-      val r = Rewrite(h.bot.left |- (h.bot.right - sequentToFormulaNullable(premises(i))), i)
+      val r = Restate(h.bot.left |- (h.bot.right - sequentToFormulaNullable(premises(i))), i)
       r
     })
     // We must separate the case for subproofs for they need to use the modified version of the precedent
@@ -273,8 +273,8 @@ case class ProofUnconditionalizer(prOrig: SCProof) extends ProofTransformer(prOr
    * @return a proofstep where each function is applied to the corresponding
    */
   protected def mapStep(pS: SCProofStep, f: Set[Formula] => Set[Formula], fi: Seq[Int] => Seq[Int] = identity, fsub: Seq[Sequent] = Nil): SCProofStep = pS match {
-    case Rewrite(bot, t1) => Rewrite(f(bot.left) |- bot.right, fi(pS.premises).head)
-    case RewriteTrue(bot) => RewriteTrue(f(bot.left) |- bot.right)
+    case Restate(bot, t1) => Restate(f(bot.left) |- bot.right, fi(pS.premises).head)
+    case RestateTrue(bot) => RestateTrue(f(bot.left) |- bot.right)
     case LeftExists(bot, t1, phi, x) => LeftExists(f(bot.left) |- bot.right, fi(pS.premises).head, phi, x)
     case RightAnd(bot, t, cunjuncts) => RightAnd(f(bot.left) |- bot.right, fi(t), cunjuncts)
     case RightOr(bot, t1, phi, psi) => RightOr(f(bot.left) |- bot.right, fi(pS.premises).head, phi, psi)

--- a/src/test/scala/lisa/utilities/Transformations.scala
+++ b/src/test/scala/lisa/utilities/Transformations.scala
@@ -24,7 +24,7 @@ class Transformations extends ProofCheckerSuite {
     val phi = SchematicPredicateLabel("phi", 0)
 
     val intro = Hypothesis((phi()) |- (phi()), phi())
-    val outro = Rewrite((phi()) |- (phi()), 0)
+    val outro = Restate((phi()) |- (phi()), 0)
 
     val noImpProof = SCProof(IndexedSeq(intro, outro), IndexedSeq.empty)
     val transf = lisa.utilities.prooftransform.ProofUnconditionalizer(noImpProof)
@@ -36,7 +36,7 @@ class Transformations extends ProofCheckerSuite {
   test("A proof with imports is to be modified") {
     val phi = SchematicPredicateLabel("phi", 0)
 
-    val intro = Rewrite(() |- phi(), -1)
+    val intro = Restate(() |- phi(), -1)
     val outro = Weakening(intro.bot.right |- intro.bot.right, 0)
 
     val noImpProof = SCProof(IndexedSeq(intro, outro), IndexedSeq(intro.bot))
@@ -51,8 +51,8 @@ class Transformations extends ProofCheckerSuite {
     val phi = SchematicPredicateLabel("phi", 0)()
     val psi = SchematicPredicateLabel("psi", 0)()
 
-    val into1 = Rewrite(() |- phi, -2)
-    val into2 = Rewrite(() |- psi, -1)
+    val into1 = Restate(() |- phi, -2)
+    val into2 = Restate(() |- psi, -1)
     val merge = RightAnd(() |- ConnectorFormula(And, (into1.bot.right ++ into2.bot.right).toSeq), Seq(-2, 0), (into1.bot.right ++ into2.bot.right).toSeq)
 
     val noImpProof = SCProof(IndexedSeq(into2, merge), IndexedSeq(into2.bot, into1.bot))
@@ -65,7 +65,7 @@ class Transformations extends ProofCheckerSuite {
 
   test("A proof with imports and a subproof should be modified accordingly") {
     val phi = SchematicPredicateLabel("phi", 0)()
-    val intro = Rewrite(() |- phi, -1)
+    val intro = Restate(() |- phi, -1)
     val outro = SCSubproof(SCProof(IndexedSeq(Weakening(intro.bot.right |- intro.bot.right, -1)), IndexedSeq(intro.bot)), IndexedSeq(0))
     val noImpProof = SCProof(IndexedSeq(intro, outro), IndexedSeq(intro.bot))
     val transf = lisa.utilities.prooftransform.ProofUnconditionalizer(noImpProof).transform()
@@ -82,7 +82,7 @@ class Transformations extends ProofCheckerSuite {
     val x = VariableLabel("x")
     val y = VariableLabel("y")
 
-    val intro = Rewrite(() |- phi(), -1)
+    val intro = Restate(() |- phi(), -1)
     val outro = InstSchema(() |- psi(x, y), 0, Map.empty, Map((phi, LambdaTermFormula(Seq(), psi(x, y)))), Map.empty)
     val noImpProof = SCProof(IndexedSeq(intro, outro), IndexedSeq(intro.bot))
     val transf = lisa.utilities.prooftransform.ProofUnconditionalizer(noImpProof).transform()
@@ -99,7 +99,7 @@ class Transformations extends ProofCheckerSuite {
     val x = VariableLabel("x")
     val y = VariableLabel("y")
 
-    val intro = Rewrite(() |- phi(), -1)
+    val intro = Restate(() |- phi(), -1)
     val mid = InstSchema(() |- psi(x, y) <=> phi(), 0, Map.empty, Map((phi, LambdaTermFormula(Seq(), psi(x, y) <=> phi()))), Map.empty)
     val outro = InstSchema(() |- psi(x, y) <=> lambda(x, y), 1, Map.empty, Map((phi, LambdaTermFormula(Seq(), lambda(x, y)))), Map.empty)
     val weak = Weakening((psi(x, y)) |- psi(x, y) <=> lambda(x, y), 2)
@@ -117,7 +117,7 @@ class Transformations extends ProofCheckerSuite {
     val x = VariableLabel("x")
     val y = VariableLabel("y")
 
-    val intro = Rewrite(() |- phi(), -1)
+    val intro = Restate(() |- phi(), -1)
     val outro = InstSchema(() |- psi(x, y), 0, Map.empty, Map((phi, LambdaTermFormula(Seq(), psi(x, y)))), Map.empty)
     val noImpProof = SCProof(IndexedSeq(intro, outro), IndexedSeq(intro.bot))
     val transf = lisa.utilities.prooftransform.ProofInstantiationRemover(noImpProof).transform()


### PR DESCRIPTION
Facts in proofs can now be InstantiatedFacts. They can be used in premisces of proof step and are automatically computed from the base fact.

Removed use of projection types in multiple places, as it is apparently bad practice. More changes to accomodate the two previous ones.
Deconstruct Unordered Pair theorem went down to 3 lines, from the initial 120.