### PR TITLE
Partial def

### DIFF
--- a/lisa-examples/src/main/scala/Example.scala
+++ b/lisa-examples/src/main/scala/Example.scala
@@ -26,7 +26,6 @@ object Example {
 
   }
 
-
   /**
    * An example of how to use the simple propositional solver.
    * The solver is complete (for propositional logic) but naive and won't succede on large formulas.

--- a/lisa-examples/src/main/scala/Exercise.scala
+++ b/lisa-examples/src/main/scala/Exercise.scala
@@ -7,15 +7,14 @@ object Exercise extends lisa.Main {
 
   val x = variable
   val y = variable
+  val z = variable
   val P = predicate(1)
   val f = function(1)
-
 
   val testThm = makeTHM("'P('x) ⇒ 'P('f('x)) ⊢ 'P('x) ⇒ 'P('f('x))") {
     val i1 = have(P(x) ==> P(f(x)) |- P(x) ==> P(f(x))) by Restate;
   }
   show
-  
 
   val fixedPointDoubleApplication = makeTHM(seq"∀'x. 'P('x) ⇒ 'P('f('x)) ⊢ 'P('x) ⇒ 'P('f('f('x)))") {
     assume("∀'x. 'P('x) ⇒ 'P('f('x))")
@@ -27,6 +26,22 @@ object Exercise extends lisa.Main {
     }
     showCurrentProof()
   }
+  show
+
+  val defineNonEmptySet = makeTHM(" |- ∃!'x. !('x=emptySet) ∧ 'x=unorderedPair(emptySet, emptySet)") {
+    val subst = have("|- False <=> elem(emptySet, emptySet)") by Rewrite(emptySetAxiom of (x -> emptySet()))
+    have(" elem(emptySet, unorderedPair(emptySet, emptySet))<=>False |- ") by Rewrite(pairAxiom of (x -> emptySet(), y -> emptySet(), z -> emptySet()))
+    andThen(applySubst(subst))
+    thenHave(" ∀'z. elem('z, unorderedPair(emptySet, emptySet)) ⇔ elem('z, emptySet) |- ") by LeftForall(emptySet())
+    andThen(applySubst(extensionalityAxiom of (x -> unorderedPair(emptySet(), emptySet()), y -> emptySet())))
+    andThen(applySubst(x === unorderedPair(emptySet(), emptySet())))
+    thenHave(" |- (!('x=emptySet) ∧ 'x=unorderedPair(emptySet, emptySet)) <=> ('x=unorderedPair(emptySet, emptySet))") by Tautology
+    thenHave(" |- ∀'x. ('x=unorderedPair(emptySet, emptySet)) <=> (!('x=emptySet) ∧ 'x=unorderedPair(emptySet, emptySet))") by RightForall
+    thenHave(" |- ∃'y. ∀'x. ('x='y) <=> (!('x=emptySet) ∧ 'x=unorderedPair(emptySet, emptySet))") by RightExists(unorderedPair(emptySet(), emptySet()))
+  }
+  show
+
+  val nonEmpty = DEF() --> The(x, !(x === emptySet()))(defineNonEmptySet)
   show
 
 }

--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -38,6 +38,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
     val nf2 = computeNormalForm(simplify(formula2))
     latticesEQ(nf1, nf2)
   }
+
+  /**
+   * returns true if the first argument implies the second by the laws of ortholattices.
+   */
   def isImplying(formula1: Formula, formula2: Formula): Boolean = {
     val nf1 = computeNormalForm(simplify(formula1))
     val nf2 = computeNormalForm(simplify(formula2))

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -131,8 +131,8 @@ class RunningTheory {
    * @param label          The desired label.
    * @param expression     The functional term defining the function symbol.
    * @param out            The variable representing the function's result in the formula
-   * @param proven         A formula possibly stronger than "expression" that the proof proves. It is always correct if it is the same as "expression", but
-   *                       if "expression" is less strong, this allows to make underspecifid definitions.
+   * @param proven         A formula possibly stronger than `expression` that the proof proves. It is always correct if it is the same as "expression", but
+   *                       if `expression` is less strong, this allows to make underspecified definitions.
    * @return A definition object if the parameters are correct,
    */
   def makeFunctionDefinition(

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -142,7 +142,8 @@ class RunningTheory {
       out: VariableLabel,
       expression: LambdaTermFormula,
       proven: Formula
-  ): RunningTheoryJudgement[this.FunctionDefinition] = {
+  ): RunningTheoryJudgement[this.FunctionDefinition] =
+  {
     val LambdaTermFormula(vars, body) = expression
     if (vars.length == label.arity) {
       if (belongsToTheory(body)) {

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -141,32 +141,32 @@ class RunningTheory {
       expression: LambdaTermFormula
   ): RunningTheoryJudgement[this.FunctionDefinition] = {
     val LambdaTermFormula(vars, body) = expression
-    if (belongsToTheory(body))
-      if (isAvailable(label)) {
-        if (body.freeSchematicTermLabels.subsetOf((vars appended out).toSet) && body.schematicFormulaLabels.isEmpty) {
-          if (proof.imports.forall(i => justifications.exists(j => isSameSequent(i, sequentFromJustification(j))))) {
-            val r = SCProofChecker.checkSCProof(proof)
-            r match {
-              case SCProofCheckerJudgement.SCValidProof(_) =>
-                proof.conclusion match {
-                  case Sequent(l, r) if l.isEmpty && r.size == 1 =>
-                    val subst = BinderFormula(ExistsOne, out, body)
-                    if (isSame(r.head, subst)) {
-                      val newDef = FunctionDefinition(label, out, expression)
-                      funDefinitions.update(label, Some(newDef))
-                      knownSymbols.update(label.id, label)
-                      RunningTheoryJudgement.ValidJustification(newDef)
-                    } else InvalidJustification("The proof is correct but its conclusion does not correspond to a definition for the formula phi.", None)
-                  case _ => InvalidJustification("The conclusion of the proof must have an empty left hand side, and a single formula on the right hand side.", None)
-                }
-              case r @ SCProofCheckerJudgement.SCInvalidProof(_, path, message) => InvalidJustification("The given proof is incorrect: " + message, Some(r))
-            }
-          } else InvalidJustification("Not all imports of the proof are correctly justified.", None)
-        } else {
-          InvalidJustification("The definition is not allowed to contain schematic symbols or free variables.", None)
-        }
-      } else InvalidJustification("The specified symbol id is already part of the theory and can't be redefined.", None)
-    else InvalidJustification("All symbols in the conclusion of the proof must belong to the theory. You need to add missing symbols to the theory.", None)
+    if (vars.length==label.arity) {
+      if (belongsToTheory(body)) {
+        if (isAvailable(label)) {
+          if (body.freeSchematicTermLabels.subsetOf((vars appended out).toSet) && body.schematicFormulaLabels.isEmpty) {
+            if (proof.imports.forall(i => justifications.exists(j => isSameSequent(i, sequentFromJustification(j))))) {
+              val r = SCProofChecker.checkSCProof(proof)
+              r match {
+                case SCProofCheckerJudgement.SCValidProof(_) =>
+                  proof.conclusion match {
+                    case Sequent(l, r) if l.isEmpty && r.size == 1 =>
+                      val subst = BinderFormula(ExistsOne, out, body)
+                      if (isSameSet(r.head, subst)) {
+                        val newDef = FunctionDefinition(label, out, expression)
+                        funDefinitions.update(label, Some(newDef))
+                        knownSymbols.update(label.id, label)
+                        RunningTheoryJudgement.ValidJustification(newDef)
+                      } else InvalidJustification("The proof is correct but its conclusion does not correspond to a definition for the formula phi.", None)
+                    case _ => InvalidJustification("The conclusion of the proof must have an empty left hand side, and a single formula on the right hand side.", None)
+                  }
+                case r@SCProofCheckerJudgement.SCInvalidProof(_, path, message) => InvalidJustification("The given proof is incorrect: " + message, Some(r))
+              }
+            } else InvalidJustification("Not all imports of the proof are correctly justified.", None)
+          } else InvalidJustification("The definition is not allowed to contain schematic symbols or free variables.", None)
+        } else InvalidJustification("The specified symbol id is already part of the theory and can't be redefined.", None)
+      } else InvalidJustification("All symbols in the conclusion of the proof must belong to the theory. You need to add missing symbols to the theory.", None)
+    } else InvalidJustification("The arity of the label must be equal to the number of parameters in the definition.", None)
   }
 
   def sequentFromJustification(j: Justification): Sequent = j match {

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -144,7 +144,7 @@ class RunningTheory {
       proven: Formula
   ): RunningTheoryJudgement[this.FunctionDefinition] = {
     val LambdaTermFormula(vars, body) = expression
-    if (vars.length==label.arity) {
+    if (vars.length == label.arity) {
       if (belongsToTheory(body)) {
         if (isAvailable(label)) {
           if (body.freeSchematicTermLabels.subsetOf((vars appended out).toSet) && body.schematicFormulaLabels.isEmpty) {
@@ -166,7 +166,7 @@ class RunningTheory {
 
                     case _ => InvalidJustification("The conclusion of the proof must have an empty left hand side, and a single formula on the right hand side.", None)
                   }
-                case r@SCProofCheckerJudgement.SCInvalidProof(_, path, message) => InvalidJustification("The given proof is incorrect: " + message, Some(r))
+                case r @ SCProofCheckerJudgement.SCInvalidProof(_, path, message) => InvalidJustification("The given proof is incorrect: " + message, Some(r))
               }
             } else InvalidJustification("Not all imports of the proof are correctly justified.", None)
           } else InvalidJustification("The definition is not allowed to contain schematic symbols or free variables.", None)

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -142,8 +142,7 @@ class RunningTheory {
       out: VariableLabel,
       expression: LambdaTermFormula,
       proven: Formula
-  ): RunningTheoryJudgement[this.FunctionDefinition] =
-  {
+  ): RunningTheoryJudgement[this.FunctionDefinition] = {
     val LambdaTermFormula(vars, body) = expression
     if (vars.length == label.arity) {
       if (belongsToTheory(body)) {

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -34,7 +34,7 @@ object SCProofChecker {
            *    Γ |- Δ
            */
           case Restate(s, t1) =>
-            if (isImplyingSequent(ref(t1), s)) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The premise does not trivially imply the conclusion.")
+            if (isSameSequent(ref(t1), s)) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The premise does not trivially imply the conclusion.")
 
           /*
            *

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -34,7 +34,7 @@ object SCProofChecker {
            *    Γ |- Δ
            */
           case Restate(s, t1) =>
-            if (isSameSequent(s, ref(t1))) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The premise and the conclusion are not trivially equivalent.")
+            if (isImplyingSequent(ref(t1), s)) SCValidProof(SCProof(step)) else SCInvalidProof(SCProof(step), Nil, s"The premise does not trivially imply the conclusion.")
 
           /*
            *

--- a/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
@@ -115,15 +115,7 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
 
     val out: VariableLabel = VariableLabel(freshId((vars.map(_.id) ++ body.schematicTermLabels.map(_.id)).toSet, "y"))
     val proof: SCProof = simpleFunctionDefinition(expression, out)
-    theory.functionDefinition(symbol, LambdaTermFormula(vars, out === body), out, proof, Nil)
-  }
-
-  /**
-   * Allows to create a definition by existential uniqueness of a function symbol:
-   */
-  def complexDefinition(symbol: String, vars: Seq[VariableLabel], v: VariableLabel, f: Formula, proof: SCProof, just: Seq[theory.Justification]): Judgement[theory.FunctionDefinition] = {
-    theory.functionDefinition(symbol, LambdaTermFormula(vars, f), v, proof, just)
-    // theory.functionDefinition(symbol, LambdaTermFormula(vars, instantiateTermSchemas(f, Map(v -> LambdaTermTerm(Nil, out)))), out, proof, just)
+    theory.functionDefinition(symbol, LambdaTermFormula(vars, out === body), out, proof, out === body, Nil)
   }
 
   /**
@@ -131,6 +123,9 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
    */
   def simpleDefinition(symbol: String, expression: LambdaTermFormula): Judgement[theory.PredicateDefinition] =
     theory.predicateDefinition(symbol, expression)
+
+  /*
+
 
   /**
    * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
@@ -221,7 +216,7 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
    * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
    */
   def DEFINE(symbol: String, vars: VariableLabel*): FunSymbolDefine = FunSymbolDefine(symbol, vars)
-
+   */
   /**
    * For a definition of the type f(x) := term, construct the required proof ?!y. y = term.
    */

--- a/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
@@ -135,8 +135,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
   case class FunSymbolDefine(symbol: String, vars: Seq[VariableLabel]) {
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
+   */
     infix def as(t: Term)(using om: OutputManager): ConstantFunctionLabel = {
       val definition = simpleDefinition(symbol, LambdaTermTerm(vars, t)) match {
         case Judgement.ValidJustification(just) =>
@@ -148,8 +148,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
     }
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) as "definition" </pre>
+   */
     infix def as(f: Formula)(using om: OutputManager): ConstantPredicateLabel = {
       val definition = simpleDefinition(symbol, LambdaTermFormula(vars, f)) match {
         case Judgement.ValidJustification(just) =>
@@ -161,8 +161,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
     }
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
+   */
     infix def asThe(out: VariableLabel): DefinitionNameAndOut = DefinitionNameAndOut(symbol, vars, out)
   }
 
@@ -172,8 +172,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
   case class DefinitionNameAndOut(symbol: String, vars: Seq[VariableLabel], out: VariableLabel) {
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
+   */
     infix def suchThat(f: Formula): DefinitionWaitingProof = DefinitionWaitingProof(symbol, vars, out, f)
   }
 
@@ -183,8 +183,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
   case class DefinitionWaitingProof(symbol: String, vars: Seq[VariableLabel], out: VariableLabel, f: Formula) {
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
+   */
     infix def PROOF(proof: SCProof): DefinitionWithProof = DefinitionWithProof(symbol, vars, out, f, proof)
   }
 
@@ -194,8 +194,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
   case class DefinitionWithProof(symbol: String, vars: Seq[VariableLabel], out: VariableLabel, f: Formula, proof: SCProof) {
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
+   */
     infix def using(justifications: theory.Justification*)(using om: OutputManager): ConstantFunctionLabel = {
       val definition = complexDefinition(symbol, vars, out, f, proof, justifications) match {
         case Judgement.ValidJustification(just) =>
@@ -207,8 +207,8 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
     }
 
     /**
-     * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
-     */
+   * Syntax: <pre> DEFINE("symbol", arguments) asThe x suchThat P(x) PROOF { the proof } using (assumptions) </pre>
+   */
     infix def using(u: Unit)(using om: OutputManager): ConstantFunctionLabel = using()
   }
 

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -75,6 +75,10 @@ trait ProofsHelpers {
     have(theory.sequentFromJustification(just)).by(using _proof, om, line, file)(Restate(using library, _proof)(just: _proof.OutsideFact))
   }
 
+  def have3(using line: sourcecode.Line, file: sourcecode.File)(using om: OutputManager, _proof: library.Proof)(fact: _proof.Fact): _proof.ProofStep = {
+    have(_proof.sequentOfFact(fact)).by(using _proof, om, line, file)(Restate(using library, _proof)(fact))
+  }
+
   def have(using proof: library.Proof, line: sourcecode.Line, file: sourcecode.File)(tactic: proof.ProofTacticJudgement): proof.ProofStep = {
     tactic.validate(line, file)
   }
@@ -317,7 +321,7 @@ trait ProofsHelpers {
         if (!theory.isAvailable(label)) {
           om.lisaThrow(UserInvalidDefinitionException(name.value, s"The symbol ${name.value} has already been defined and can't be redefined."))
         }
-        if (!(f.freeSchematicTermLabels.subsetOf(vars.toSet) && f.schematicFormulaLabels.isEmpty)) {
+        if (!(f.freeSchematicTermLabels.subsetOf(vars.toSet+out) && f.schematicFormulaLabels.isEmpty)) {
           om.lisaThrow(
             UserInvalidDefinitionException(
               name.value,
@@ -326,7 +330,7 @@ trait ProofsHelpers {
             )
           )
         }
-        if (!(conclusion.left.isEmpty && (conclusion.right.size == 1) && isSame(conclusion.right.head, BinderFormula(ExistsOne, out, f)))) {
+        if (!(conclusion.left.isEmpty && (conclusion.right.size == 1) && isImplying(conclusion.right.head, BinderFormula(ExistsOne, out, f)))) {
           om.lisaThrow(
             UserInvalidDefinitionException(
               name.value,

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -304,7 +304,7 @@ trait ProofsHelpers {
       case ax: theory.Axiom => () |- ax.ax
     }
     val pr: SCProof = SCProof(IndexedSeq(SC.Restate(conclusion, -1)), IndexedSeq(conclusion))
-    if (!(conclusion.left.isEmpty && (conclusion.right.size == 1) )) {
+    if (!(conclusion.left.isEmpty && (conclusion.right.size == 1))) {
       om.lisaThrow(
         UserInvalidDefinitionException(
           name.value,
@@ -316,8 +316,8 @@ trait ProofsHelpers {
     }
     val proven = conclusion.right.head match {
       case BinderFormula(ExistsOne, bound, inner) => inner
-      case BinderFormula(Exists, x, BinderFormula(Forall, y, ConnectorFormula(Iff, Seq(l, r)))) if isSame(l, x===y) => r
-      case BinderFormula(Exists, x, BinderFormula(Forall, y, ConnectorFormula(Iff, Seq(l, r)))) if isSame(r, x===y) => l
+      case BinderFormula(Exists, x, BinderFormula(Forall, y, ConnectorFormula(Iff, Seq(l, r)))) if isSame(l, x === y) => r
+      case BinderFormula(Exists, x, BinderFormula(Forall, y, ConnectorFormula(Iff, Seq(l, r)))) if isSame(r, x === y) => l
       case _ =>
         om.lisaThrow(
           UserInvalidDefinitionException(
@@ -345,7 +345,7 @@ trait ProofsHelpers {
         if (!theory.isAvailable(label)) {
           om.lisaThrow(UserInvalidDefinitionException(name.value, s"The symbol ${name.value} has already been defined and can't be redefined."))
         }
-        if (!(f.freeSchematicTermLabels.subsetOf(vars.toSet+out) && f.schematicFormulaLabels.isEmpty)) {
+        if (!(f.freeSchematicTermLabels.subsetOf(vars.toSet + out) && f.schematicFormulaLabels.isEmpty)) {
           om.lisaThrow(
             UserInvalidDefinitionException(
               name.value,

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -68,12 +68,7 @@ trait ProofsHelpers {
    */
   def have(using proof: library.Proof)(res: String): HaveSequent = HaveSequent(lisa.utils.FOLParser.parseSequent(res))
 
-  /**
-   * Claim the given known Theorem, Definition or Axiom as a Sequent.
-   */
-  def have(using line: sourcecode.Line, file: sourcecode.File)(using _proof: library.Proof)(just: theory.Justification): _proof.ProofStep = {
-    have(theory.sequentFromJustification(just)).by(using _proof, line, file)(Restate(using library, _proof)(just: _proof.OutsideFact))
-  }
+
 
   def have(using line: sourcecode.Line, file: sourcecode.File)(using proof: library.Proof)(v: proof.Fact | proof.ProofTacticJudgement) = v match {
     case judg:proof.ProofTacticJudgement => judg.validate(line, file)

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -22,11 +22,11 @@ trait ProofsHelpers {
   given Library = library
 
   class HaveSequent private[ProofsHelpers] (bot: Sequent) {
-    inline infix def by(using proof: library.Proof,  line: sourcecode.Line, file: sourcecode.File): By { val _proof: proof.type } = By(proof,  line, file).asInstanceOf
+    inline infix def by(using proof: library.Proof, line: sourcecode.Line, file: sourcecode.File): By { val _proof: proof.type } = By(proof, line, file).asInstanceOf
 
     class By(val _proof: library.Proof, line: sourcecode.Line, file: sourcecode.File) {
       private val bot = HaveSequent.this.bot ++ (_proof.getAssumptions |- ())
-      inline infix def apply(tactic: Sequent => _proof.ProofTacticJudgement): _proof.ProofStep & _proof.Fact= {
+      inline infix def apply(tactic: Sequent => _proof.ProofTacticJudgement): _proof.ProofStep & _proof.Fact = {
         tactic(bot).validate(line, file)
       }
       inline infix def apply(tactic: ProofSequentTactic): _proof.ProofStep = {
@@ -68,10 +68,8 @@ trait ProofsHelpers {
    */
   def have(using proof: library.Proof)(res: String): HaveSequent = HaveSequent(lisa.utils.FOLParser.parseSequent(res))
 
-
-
   def have(using line: sourcecode.Line, file: sourcecode.File)(using proof: library.Proof)(v: proof.Fact | proof.ProofTacticJudgement) = v match {
-    case judg:proof.ProofTacticJudgement => judg.validate(line, file)
+    case judg: proof.ProofTacticJudgement => judg.validate(line, file)
     case fact: proof.Fact @unchecked => HaveSequent(proof.sequentOfFact(fact)).by(using proof, line, file)(Restate(using library, proof)(fact))
   }
 

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -289,12 +289,7 @@ trait WithTheorems {
     val proof: BaseProof = new BaseProof(this)
     val innerThm: theory.Theorem = show(computeProof)
 
-    def repr: String = (
-      " Theorem " + name + " := " + (statement match {
-        case s: Sequent => lisa.utils.FOLPrinter.prettySequent(s)
-        case s: String => s
-      })
-    )
+    def repr: String = lisa.utils.FOLPrinter.prettySequent(goal)
 
     def show(computeProof: Proof ?=> Unit): theory.Theorem = {
       try {

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -327,15 +327,16 @@ object KernelHelpers {
      * of the theorem to have more explicit writing and for sanity check. See [[lisa.kernel.proof.RunningTheory.makeFunctionDefinition]]
      */
     def functionDefinition(
-        symbol: String,
-        expression: LambdaTermFormula,
-        out: VariableLabel,
-        proof: SCProof,
-        justifications: Seq[theory.Justification]
-    ): RunningTheoryJudgement[theory.FunctionDefinition] = {
+                            symbol: String,
+                            expression: LambdaTermFormula,
+                            out: VariableLabel,
+                            proof: SCProof,
+                            justifications: Seq[theory.Justification]
+                          ): RunningTheoryJudgement[theory.FunctionDefinition] = {
       val label = ConstantFunctionLabel(symbol, expression.vars.size)
       theory.makeFunctionDefinition(proof, justifications, label, out, expression)
     }
+
 
     /**
      * Make a predicate definition in the theory, but only ask for the identifier of the new symbol; Arity is inferred

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -327,17 +327,16 @@ object KernelHelpers {
      * of the theorem to have more explicit writing and for sanity check. See [[lisa.kernel.proof.RunningTheory.makeFunctionDefinition]]
      */
     def functionDefinition(
-                            symbol: String,
-                            expression: LambdaTermFormula,
-                            out: VariableLabel,
-                            proof: SCProof,
-                            proven:Formula,
-                            justifications: Seq[theory.Justification]
-                          ): RunningTheoryJudgement[theory.FunctionDefinition] ={
+        symbol: String,
+        expression: LambdaTermFormula,
+        out: VariableLabel,
+        proof: SCProof,
+        proven: Formula,
+        justifications: Seq[theory.Justification]
+    ): RunningTheoryJudgement[theory.FunctionDefinition] = {
       val label = ConstantFunctionLabel(symbol, expression.vars.size)
       theory.makeFunctionDefinition(proof, justifications, label, out, expression, proven)
     }
-
 
     /**
      * Make a predicate definition in the theory, but only ask for the identifier of the new symbol; Arity is inferred

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -331,10 +331,11 @@ object KernelHelpers {
                             expression: LambdaTermFormula,
                             out: VariableLabel,
                             proof: SCProof,
+                            proven:Formula,
                             justifications: Seq[theory.Justification]
-                          ): RunningTheoryJudgement[theory.FunctionDefinition] = {
+                          ): RunningTheoryJudgement[theory.FunctionDefinition] ={
       val label = ConstantFunctionLabel(symbol, expression.vars.size)
-      theory.makeFunctionDefinition(proof, justifications, label, out, expression)
+      theory.makeFunctionDefinition(proof, justifications, label, out, expression, proven)
     }
 
 

--- a/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
+++ b/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
@@ -189,7 +189,7 @@ object SimpleSimplifier {
           val phi = seq.right.head
           val sp = new BasicStepTactic.SUBPROOF(using proof)(None)({
             val x = applyLeftRight(phi)(premise)()
-            proof.library.have2(x)
+            proof.library.have(x)
             proof.library.andThen(SimpleDeducedSteps.Discharge(f))
           })
 

--- a/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
+++ b/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
@@ -127,16 +127,16 @@ object SimpleSimplifier {
 
           val leftForm = ConnectorFormula(And, isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
           val rightForm = ConnectorFormula(Or, isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
-          val newleft = isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right))) + phi
+          val newleft = isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right)))
           val newright = isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right)))
           val result1: Sequent = (ConnectorFormula(And, newleft.toSeq), phi) |- rightOrigin
-          val result2: Sequent = result1.left |- ConnectorFormula(And, newright.toSeq)
+          val result2: Sequent = result1.left |- ConnectorFormula(Or, newright.toSeq)
 
           val scproof = Seq(
             Restate(leftOrigin |- rightOrigin, -1),
             LeftSubstEq(result1, 0, List(left -> right), LambdaTermFormula(Seq(v), leftForm)),
             RightSubstEq(result2, 1, List(left -> right), LambdaTermFormula(Seq(v), rightForm)),
-            Restate(newleft |- newright, 2)
+            Restate(newleft + phi |- newright, 2)
           )
           proof.ValidProofTactic(
             scproof,
@@ -160,7 +160,7 @@ object SimpleSimplifier {
 
           val leftForm = ConnectorFormula(And, isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
           val rightForm = ConnectorFormula(Or, isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get.body).toSeq)
-          val newleft = isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right))) + phi
+          val newleft = isolatedLeft.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right)))
           val newright = isolatedRight.map((f, ltf) => if (ltf.isEmpty) f else ltf.get(Seq(right)))
           val result1: Sequent = (ConnectorFormula(And, newleft.toSeq), phi) |- rightOrigin
           val result2: Sequent = result1.left |- ConnectorFormula(Or, newright.toSeq)
@@ -169,7 +169,7 @@ object SimpleSimplifier {
             Restate(leftOrigin |- rightOrigin, -1),
             LeftSubstIff(result1, 0, List(left -> right), LambdaFormulaFormula(Seq(H), leftForm)),
             RightSubstIff(result2, 1, List(left -> right), LambdaFormulaFormula(Seq(H), rightForm)),
-            Restate(newleft |- newright, 2)
+            Restate(newleft + phi |- newright, 2)
           )
           proof.ValidProofTactic(
             scproof,
@@ -193,7 +193,7 @@ object SimpleSimplifier {
             proof.library.andThen(SimpleDeducedSteps.Discharge(f))
           })
 
-          BasicStepTactic.unwrapTactic(sp.judgement.asInstanceOf[proof.ProofTacticJudgement])("Subproof for unique comprehension failed.")
+          BasicStepTactic.unwrapTactic(sp.judgement.asInstanceOf[proof.ProofTacticJudgement])("Subproof substitution fail.")
       }
 
     }


### PR DESCRIPTION
Ability to do sub-specified definitions.
If you want an object with propriety P(x), you can feed a proof of unique existence of Q(x) as long as Q is OL-smaller than P (so in particular it holds if Q=P/\S).
There is an example with a non-empty set in Exercise.scala.