### PR TITLE
Minor Helpers Improvements

### DIFF
--- a/lisa-utils/src/main/scala/lisa/prooflib/OutputManager.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/OutputManager.scala
@@ -10,7 +10,7 @@ abstract class OutputManager {
   given OutputManager = this
 
   def output(s: String): Unit = stringWriter.write(s + "\n")
-  def output(s: String, color: String): Unit = stringWriter.write(color + s + "\n" + Console.BLACK)
+  def output(s: String, color: String): Unit = stringWriter.write(Console.RESET + color + s + "\n" + Console.RESET)
   val stringWriter: StringWriter
 
   def finishOutput(exception: Exception): Nothing
@@ -33,8 +33,8 @@ abstract class OutputManager {
     }
 
   def log(e: Exception): Unit = {
-    stringWriter.write("\n[" + Console.RED + "Error" + Console.BLACK + "]")
+    stringWriter.write("\n[" + Console.RED + "Error" + Console.RESET + "] ")
     e.printStackTrace(PrintWriter(stringWriter))
-    output(Console.BLACK)
+    output(Console.RESET)
   }
 }

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -116,6 +116,10 @@ trait ProofsHelpers {
     val f = lisa.utils.FOLParser.parseFormula(fstring)
     assume(f)
   }
+  def assume(using proof: library.Proof)(fs: Iterable[Formula]): proof.ProofStep = {
+    fs.foreach(f => proof.addAssumption(f))
+    have(() |- fs.toSet) by BasicStepTactic.Hypothesis
+  }
   /*
   /**
    * Store the given import and use it to discharge the proof of one of its assumption at the very end.
@@ -129,7 +133,7 @@ trait ProofsHelpers {
   def goal(using proof: library.Proof): Sequent = proof.possibleGoal.get
 
   def showCurrentProof(using om: OutputManager, _proof: library.Proof)(): Unit = {
-    om.output("Current proof of" + _proof.owningTheorem.repr + ": ")
+    om.output("Current proof of " + _proof.owningTheorem.repr + ": ")
     om.output(
       ProofPrinter.prettyProof(_proof, 2)
     )


### PR DESCRIPTION
Small changes:

- `assume` now accepts an `Iterable[Formula]` instead of a single `Formula` (change coming from branch funcprog).
- Fixed the issues with our console colours, changing every instance of `BLACK` to `RESET`. 
- Added a couple spaces in the printing where they were clearly missing