### PR TITLE
Sorry

### DIFF
--- a/lisa-examples/src/main/scala/Example.scala
+++ b/lisa-examples/src/main/scala/Example.scala
@@ -84,16 +84,16 @@ object ExampleDSL extends lisa.Main {
   val inductiveSet = DEF(x) --> in(∅, x) /\ forall(y, in(y, x) ==> in(succ(y), x))
   show
 
-  val defineNonEmptySet = Lemma( ∃!(x, !(x === ∅) /\ (x===unorderedPair(∅, ∅))) ) {
+  val defineNonEmptySet = Lemma(∃!(x, !(x === ∅) /\ (x === unorderedPair(∅, ∅)))) {
     val subst = have(False <=> in(∅, ∅)) by Rewrite(emptySetAxiom of (x -> ∅()))
-    have( in(∅, unorderedPair(∅, ∅))<=>False |- () ) by Rewrite(pairAxiom of (x -> ∅(), y -> ∅(), z -> ∅()))
+    have(in(∅, unorderedPair(∅, ∅)) <=> False |- ()) by Rewrite(pairAxiom of (x -> ∅(), y -> ∅(), z -> ∅()))
     andThen(applySubst(subst))
-    thenHave( ∀(z, in(z, unorderedPair(∅, ∅)) <=> in(z, ∅)) |- () ) by LeftForall
+    thenHave(∀(z, in(z, unorderedPair(∅, ∅)) <=> in(z, ∅)) |- ()) by LeftForall
     andThen(applySubst(extensionalityAxiom of (x -> unorderedPair(∅(), ∅()), y -> ∅())))
     andThen(applySubst(x === unorderedPair(∅(), ∅())))
-    thenHave( (!(x === ∅) /\ (x === unorderedPair(∅, ∅))) <=> (x===unorderedPair(∅, ∅)) ) by Tautology
-    thenHave( ∀(x, (x === unorderedPair(∅, ∅)) <=> (!(x === ∅) /\ (x === unorderedPair(∅, ∅)))) ) by RightForall
-    thenHave( ∃(y, ∀(x, (x === y) <=> (!(x === ∅) /\ (x === unorderedPair(∅, ∅))) )) ) by RightExists
+    thenHave((!(x === ∅) /\ (x === unorderedPair(∅, ∅))) <=> (x === unorderedPair(∅, ∅))) by Tautology
+    thenHave(∀(x, (x === unorderedPair(∅, ∅)) <=> (!(x === ∅) /\ (x === unorderedPair(∅, ∅))))) by RightForall
+    thenHave(∃(y, ∀(x, (x === y) <=> (!(x === ∅) /\ (x === unorderedPair(∅, ∅)))))) by RightExists
   }
   show
 

--- a/lisa-examples/src/main/scala/MapProofTest.scala
+++ b/lisa-examples/src/main/scala/MapProofTest.scala
@@ -9,15 +9,15 @@ import lisa.prooflib.BasicStepTactic.*
 import lisa.prooflib.ProofTacticLib.*
 import lisa.utils.FOLPrinter.*
 import lisa.utils.KernelHelpers.checkProof
-import lisa.utils.unification.UnificationUtils.*
 import lisa.utils.parsing.FOLPrinter
+import lisa.utils.unification.UnificationUtils.*
 
 /**
-  * A set of proofs from a functional programming exam about equivalence between
-  * `map` and a tail-recursive version of it, `mapTr`.
-  * 
-  * An example of really domain specific proofs using infix extensions.
-  */
+ * A set of proofs from a functional programming exam about equivalence between
+ * `map` and a tail-recursive version of it, `mapTr`.
+ *
+ * An example of really domain specific proofs using infix extensions.
+ */
 object MapProofTest extends lisa.Main {
   val Nil = variable
   val Cons = function(2)
@@ -33,8 +33,8 @@ object MapProofTest extends lisa.Main {
 
   // some more DSL
   extension (t1: Term) {
-    infix def :: (t2: Term) = Cons(t1, t2)
-    infix def ++ (t2: Term) = append(t1, t2)
+    infix def ::(t2: Term) = Cons(t1, t2)
+    infix def ++(t2: Term) = append(t1, t2)
     def map(t2: Term) = map_(t1, t2)
     def mapTr(t2: Term, t3: Term) = mapTr_(t1, t2, t3)
   }
@@ -51,7 +51,7 @@ object MapProofTest extends lisa.Main {
     MapTrNil |- Nil.mapTr(f, (x :: xs)) === (x :: Nil.mapTr(f, xs))
   ) {
     assume(MapTrNil)
-    
+
     // apply MapTrNil
     have(Nil.mapTr(f, (x :: xs)) === (x :: xs)) by InstantiateForall
 
@@ -74,19 +74,19 @@ object MapProofTest extends lisa.Main {
     // apply MapTrCons
     have(MapTrCons) by Restate
     val appYYs = thenHave((x :: xs).mapTr(f, (y :: ys)) === xs.mapTr(f, append((y :: ys), (app(f, x) :: Nil)))) by InstantiateForall(x, xs, (y :: ys))
-    
+
     // apply ConsAppend
     have(ConsAppend) by Restate
     thenHave(append((y :: ys), (app(f, x) :: Nil)) === (y :: (ys ++ (app(f, x) :: Nil)))) by InstantiateForall(y, ys, (app(f, x) :: Nil))
-  
+
     val consYYs = have((x :: xs).mapTr(f, (y :: ys)) === xs.mapTr(f, (y :: (ys ++ (app(f, x) :: Nil))))) by Substitution.apply2(false, lastStep)(appYYs)
-  
+
     // apply IH1
     have(IH1) by Restate
     thenHave(xs.mapTr(f, (y :: (ys ++ (app(f, x) :: Nil)))) === (y :: xs.mapTr(f, (ys ++ (app(f, x) :: Nil))))) by InstantiateForall(y, (ys ++ (app(f, x) :: Nil)))
- 
+
     val consYXs = have((x :: xs).mapTr(f, (y :: ys)) === (y :: xs.mapTr(f, (ys ++ (app(f, x) :: Nil))))) by Substitution.apply2(false, lastStep)(consYYs)
-    
+
     // apply MapTrCons again
     have(MapTrCons) by Restate
     thenHave((x :: xs).mapTr(f, ys) === xs.mapTr(f, (ys ++ (app(f, x) :: Nil)))) by InstantiateForall(x, xs, ys)

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/Judgement.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/Judgement.scala
@@ -26,7 +26,7 @@ object SCProofCheckerJudgement {
   /**
    * A positive judgement.
    */
-  case class SCValidProof(proof: SCProof) extends SCProofCheckerJudgement
+  case class SCValidProof(proof: SCProof, val usesSorry:Boolean=false) extends SCProofCheckerJudgement
 
   /**
    * A negative judgement.

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/Judgement.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/Judgement.scala
@@ -26,7 +26,7 @@ object SCProofCheckerJudgement {
   /**
    * A positive judgement.
    */
-  case class SCValidProof(proof: SCProof, val usesSorry:Boolean=false) extends SCProofCheckerJudgement
+  case class SCValidProof(proof: SCProof, val usesSorry: Boolean = false) extends SCProofCheckerJudgement
 
   /**
    * A negative judgement.

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/RunningTheory.scala
@@ -29,7 +29,7 @@ class RunningTheory {
   /**
    * A theorem encapsulate a sequent and assert that this sequent has been correctly proven and may be used safely in further proofs.
    */
-  sealed case class Theorem private[RunningTheory] (name: String, proposition: Sequent, withSorry:Boolean=false) extends Justification
+  sealed case class Theorem private[RunningTheory] (name: String, proposition: Sequent, withSorry: Boolean) extends Justification
 
   /**
    * An axiom is any formula that is assumed and considered true within the theory. It can freely be used later in any proof.
@@ -58,11 +58,7 @@ class RunningTheory {
    * @param out   The variable representing the result of the function in phi
    * @param expression   The formula, with term parameters, defining the function.
    */
-  sealed case class FunctionDefinition private[RunningTheory] (label: ConstantFunctionLabel,
-                                                               out: VariableLabel,
-                                                               expression: LambdaTermFormula,
-                                                               withSorry: Boolean = false
-                                                              ) extends Definition
+  sealed case class FunctionDefinition private[RunningTheory] (label: ConstantFunctionLabel, out: VariableLabel, expression: LambdaTermFormula, withSorry: Boolean) extends Definition
 
   private[proof] val theoryAxioms: mMap[String, Axiom] = mMap.empty
   private[proof] val theorems: mMap[String, Theorem] = mMap.empty
@@ -95,10 +91,11 @@ class RunningTheory {
             val usesSorry = sorry || justifications.exists(_ match {
               case Theorem(name, proposition, withSorry) => withSorry
               case Axiom(name, ax) => false
-              case d: Definition => d match {
-                case PredicateDefinition(label, expression) => false
-                case FunctionDefinition(label, out, expression, withSorry) => withSorry
-              }
+              case d: Definition =>
+                d match {
+                  case PredicateDefinition(label, expression) => false
+                  case FunctionDefinition(label, out, expression, withSorry) => withSorry
+                }
             })
             val thm = Theorem(name, proof.conclusion, usesSorry)
             theorems.update(name, thm)
@@ -172,10 +169,11 @@ class RunningTheory {
                           val usesSorry = sorry || justifications.exists(_ match {
                             case Theorem(name, proposition, withSorry) => withSorry
                             case Axiom(name, ax) => false
-                            case d: Definition => d match {
-                              case PredicateDefinition(label, expression) => false
-                              case FunctionDefinition(label, out, expression, withSorry) => withSorry
-                            }
+                            case d: Definition =>
+                              d match {
+                                case PredicateDefinition(label, expression) => false
+                                case FunctionDefinition(label, out, expression, withSorry) => withSorry
+                              }
                           })
                           val newDef = FunctionDefinition(label, out, expression, usesSorry)
                           funDefinitions.update(label, Some(newDef))

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -462,11 +462,11 @@ object SCProofChecker {
                 )
             } else SCInvalidProof(SCProof(step), Nil, "Number of premises and imports don't match: " + premises.size + " " + sp.imports.size)
 
-         /*
-         *
-         * --------------
-         *     |- s=s
-         */
+          /*
+           *
+           * --------------
+           *     |- s=s
+           */
           case Sorry(b) =>
             SCValidProof(SCProof(step), usesSorry = true)
 
@@ -483,15 +483,18 @@ object SCProofChecker {
    *         and an explanation.
    */
   def checkSCProof(proof: SCProof): SCProofCheckerJudgement = {
+    var isSorry = false
     val possibleError = proof.steps.view.zipWithIndex
       .map { case (step, no) =>
         checkSingleSCStep(no, step, (i: Int) => proof.getSequent(i), Some(proof.imports.size)) match {
           case SCInvalidProof(_, path, message) => SCInvalidProof(proof, no +: path, message)
-          case SCValidProof(_, sorry) => SCValidProof(proof, sorry)
+          case SCValidProof(_, sorry) =>
+            isSorry = isSorry || sorry
+            SCValidProof(proof, sorry)
         }
       }
       .find(j => !j.isValid)
-    if (possibleError.isEmpty) SCValidProof(proof)
+    if (possibleError.isEmpty) SCValidProof(proof, isSorry)
     else possibleError.get
   }
 

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -462,6 +462,14 @@ object SCProofChecker {
                 )
             } else SCInvalidProof(SCProof(step), Nil, "Number of premises and imports don't match: " + premises.size + " " + sp.imports.size)
 
+         /*
+         *
+         * --------------
+         *     |- s=s
+         */
+          case Sorry(b) =>
+            SCValidProof(SCProof(step), usesSorry = true)
+
         }
     r
   }
@@ -479,7 +487,7 @@ object SCProofChecker {
       .map { case (step, no) =>
         checkSingleSCStep(no, step, (i: Int) => proof.getSequent(i), Some(proof.imports.size)) match {
           case SCInvalidProof(_, path, message) => SCInvalidProof(proof, no +: path, message)
-          case SCValidProof(_) => SCValidProof(proof)
+          case SCValidProof(_, sorry) => SCValidProof(proof, sorry)
         }
       }
       .find(j => !j.isValid)

--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SequentCalculus.scala
@@ -335,4 +335,13 @@ object SequentCalculus {
     val bot: Sequent = sp.conclusion
   }
 
+  /**
+   * <pre>
+   *
+   * --------------
+   *   Γ  |- Δ
+   * </pre>
+   */
+  case class Sorry(bot: Sequent) extends SCProofStep { val premises = Seq() }
+
 }

--- a/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
@@ -1215,6 +1215,12 @@ object BasicStepTactic {
     }
   }
 
+  object Sorry extends ProofTactic with ProofSequentTactic {
+    def apply(using lib: Library, proof: lib.Proof)(bot: Sequent): proof.ProofTacticJudgement = {
+      proof.ValidProofTactic(Seq(SC.Sorry(bot)), Seq())
+    }
+  }
+
   // TODO make specific support for subproofs written inside tactics.
 
   def TacticSubproof(using proof: Library#Proof)(computeProof: proof.InnerProof ?=> Unit) =

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -177,7 +177,12 @@ trait ProofsHelpers {
      * @return The theorem, if proof is valid. Otherwise will terminate.
      */
     def apply(using om: OutputManager, name: sourcecode.Name, line: sourcecode.Line, file: sourcecode.File)(statement: Sequent | String)(computeProof: Proof ?=> Unit): THM = {
-      new THM(statement, name.value, line.value, file.value, tk)(computeProof) {}
+      val thm = new THM(statement, name.value, line.value, file.value, tk)(computeProof) {}
+      if (tk == Theorem) {
+        if (thm.withSorry) om.output(thm.repr, Console.YELLOW)
+        else om.output(thm.repr, Console.GREEN)
+      }
+      thm
     }
   }
 

--- a/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
@@ -69,7 +69,7 @@ object TheoriesHelpers {
      */
     def showAndGet(using om: OutputManager): SCProof = {
       proofJudgement match {
-        case SCProofCheckerJudgement.SCValidProof(proof) =>
+        case SCProofCheckerJudgement.SCValidProof(proof, _) =>
           om.output(FOLPrinter.prettySCProof(proofJudgement))
           proof
         case ip @ SCProofCheckerJudgement.SCInvalidProof(proof, path, message) =>

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -278,7 +278,9 @@ trait WithTheorems {
     override def sequentOfOutsideFact(of: theory.Justification): Sequent = theory.sequentFromJustification(of)
   }
 
-  sealed abstract class DefOrThm(using om: OutputManager)(val line: Int, val file: String)
+  sealed abstract class DefOrThm(using om: OutputManager)(val line: Int, val file: String) {
+    def repr:String
+  }
   class THM(using om: OutputManager)(statement: Sequent | String, val fullName: String, line: Int, file: String, val kind: TheoremKind)(computeProof: Proof ?=> Unit)
       extends DefOrThm(using om)(line, file) {
 
@@ -290,8 +292,9 @@ trait WithTheorems {
 
     val proof: BaseProof = new BaseProof(this)
     val innerThm: theory.Theorem = show(computeProof)
+    val withSorry = innerThm.withSorry
 
-    def repr: String = lisa.utils.FOLPrinter.prettySequent(goal)
+    def repr: String = innerThm.repr
 
     def show(computeProof: Proof ?=> Unit): theory.Theorem = {
       try {

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -279,7 +279,7 @@ trait WithTheorems {
   }
 
   sealed abstract class DefOrThm(using om: OutputManager)(val line: Int, val file: String) {
-    def repr:String
+    def repr: String
   }
   class THM(using om: OutputManager)(statement: Sequent | String, val fullName: String, line: Int, file: String, val kind: TheoremKind)(computeProof: Proof ?=> Unit)
       extends DefOrThm(using om)(line, file) {

--- a/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/KernelHelpers.scala
@@ -434,7 +434,7 @@ object KernelHelpers {
 
   extension (just: RunningTheory#Justification) {
     def repr: String = just match {
-      case thm: RunningTheory#Theorem => s" Theorem ${thm.name} := ${FOLPrinter.prettySequent(thm.proposition)}\n"
+      case thm: RunningTheory#Theorem => s" Theorem ${thm.name} := ${FOLPrinter.prettySequent(thm.proposition)}${if (thm.withSorry) " (!! Relies on Sorry)" else ""}\n"
       case axiom: RunningTheory#Axiom => s" Axiom ${axiom.name} := ${FOLPrinter.prettyFormula(axiom.ax)}\n"
       case d: RunningTheory#Definition =>
         d match {
@@ -442,7 +442,7 @@ object KernelHelpers {
             s" Definition of predicate symbol ${pd.label.id} := ${FOLPrinter.prettyFormula(pd.label(pd.expression.vars.map(VariableTerm.apply)*) <=> pd.expression.body)}\n"
           case fd: RunningTheory#FunctionDefinition =>
             s" Definition of function symbol ${FOLPrinter.prettyTerm(fd.label(fd.expression.vars.map(VariableTerm.apply)*))} := the ${fd.out.id} such that ${FOLPrinter
-                .prettyFormula((fd.out === fd.label(fd.expression.vars.map(VariableTerm.apply)*)) <=> fd.expression.body)})\n"
+                .prettyFormula((fd.out === fd.label(fd.expression.vars.map(VariableTerm.apply)*)) <=> fd.expression.body)})${if (fd.withSorry) " (!! Relies on Sorry)" else ""}\n"
         }
     }
   }

--- a/lisa-utils/src/main/scala/lisa/utils/ProofsShrink.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/ProofsShrink.scala
@@ -73,6 +73,7 @@ object ProofsShrink {
     case s: RightSubstIff => s.copy(t1 = mapping(s.t1))
     case s: SCSubproof => s.copy(premises = s.premises.map(mapping))
     case s: InstSchema => s.copy(t1 = mapping(s.t1))
+    case s: Sorry => s
   }
 
   /**

--- a/src/main/scala/lisa/automation/Containers.scala
+++ b/src/main/scala/lisa/automation/Containers.scala
@@ -1,0 +1,33 @@
+package lisa.automation
+
+import lisa.automation.kernel.SimplePropositionalSolver.*
+import lisa.automation.kernel.SimpleSimplifier.*
+import lisa.kernel.proof.SequentCalculus as SC
+import lisa.mathematics.SetTheory
+import lisa.prooflib.BasicStepTactic.*
+import lisa.prooflib.Library
+import lisa.prooflib.ProofTacticLib.{*, given}
+import lisa.prooflib.*
+import lisa.settheory.SetTheoryLibrary
+import lisa.utils.KernelHelpers.*
+import lisa.utils.Printer
+
+object Containers {
+  import lisa.settheory.SetTheoryLibrary.{_, given}
+
+  case class Value(name:String, property:LambdaTermFormula){
+    require(property.vars.sie == 1)
+  }
+
+  def defineContainer(using om: OutputManager)(name:String, values:Seq[Value]): ConstantFunctionLabel = {
+    val funl = ConstantFunctionLabel(name, values.length)
+
+    //THM(using om: OutputManager)(statement: Sequent | String, val fullName: String, line: Int, file: String, val kind: TheoremKind)(computeProof: Proof ?=> Unit)
+
+    val variables = values.map(_.property.vars.head)
+    val statement = existsOne(z)
+    val funlExistsThm = Theorem.apply()
+
+  }
+
+}

--- a/src/main/scala/lisa/automation/Containers.scala
+++ b/src/main/scala/lisa/automation/Containers.scala
@@ -13,6 +13,7 @@ import lisa.utils.KernelHelpers.*
 import lisa.utils.Printer
 
 object Containers {
+  /*
   import lisa.settheory.SetTheoryLibrary.{_, given}
 
   case class Value(name:String, property:LambdaTermFormula){
@@ -29,5 +30,5 @@ object Containers {
     val funlExistsThm = Theorem.apply()
 
   }
-
+*/
 }

--- a/src/main/scala/lisa/automation/Containers.scala
+++ b/src/main/scala/lisa/automation/Containers.scala
@@ -6,7 +6,7 @@ import lisa.kernel.proof.SequentCalculus as SC
 import lisa.mathematics.SetTheory
 import lisa.prooflib.BasicStepTactic.*
 import lisa.prooflib.Library
-import lisa.prooflib.ProofTacticLib.{*, given}
+import lisa.prooflib.ProofTacticLib.{_, given}
 import lisa.prooflib.*
 import lisa.settheory.SetTheoryLibrary
 import lisa.utils.KernelHelpers.*
@@ -30,5 +30,5 @@ object Containers {
     val funlExistsThm = Theorem.apply()
 
   }
-*/
+   */
 }


### PR DESCRIPTION
Add a "Sorry" proof step that can justify any conclusion, but marks theorems using it as untrustworthy.

Proven Theorems (but not Lemmas and Corollaries) get automatically printed. If a theorem is untrustworthy, it is shown in yellow with a warning.