### PR TITLE
Fix: proper renaming of bound substitutions

### DIFF
--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1361,8 +1361,8 @@ class BasicTacticTest extends ProofTacticTestLib {
         Y5
       ),
       ( // check for appropriate renaming during substitution inside quantifiers
-        "|- ¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))",
-        "('z = 'y) |- ¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))",
+        "|- ¬¬∧(∀'y_1. ¬(∀'y. ¬('y = 'y_1)))",
+        "('z = 'y) |- ¬¬∧(∀'y_1. ¬(∀'y. ¬('y = 'y_1)))",
         List((FOLParser.parseFormula("'z = 'y"), top())),
         lambda(x, FOLParser.parseFormula("¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))"))
       )

--- a/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
+++ b/lisa-utils/src/test/scala/lisa/utils/BasicTacticTest.scala
@@ -1359,6 +1359,12 @@ class BasicTacticTest extends ProofTacticTestLib {
         "'P('q); ('A('a) <=> 'Q('q)); ('S('s) <=> 'W('w)); ('D('d) <=> 'E('e)); ('F('f) <=> 'R('r)); ('G('g) <=> 'T('t)); ('H('h) <=> 'Y('y)) |- 'R('x); ('A('a) /\\ 'S('s) /\\ 'D('d) /\\ 'F('f) /\\ 'G('g) /\\ 'H('h))",
         List((a, q), (s, w), (d, e), (f, r), (g, t), (h, y)),
         Y5
+      ),
+      ( // check for appropriate renaming during substitution inside quantifiers
+        "|- ¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))",
+        "('z = 'y) |- ¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))",
+        List((FOLParser.parseFormula("'z = 'y"), top())),
+        lambda(x, FOLParser.parseFormula("¬¬∧(∀'y_1. ¬(∀'y_2. ¬('y_2 = 'y_1)))"))
       )
     )
 


### PR DESCRIPTION
Added a fix for a bug discovered recently by usage of `Tautology`. 

When a substitution is made inside a formula with a binder, the bound variable is not taken into account for further recursive generation of new identifiers. This is now fixed by tracking a set of extra taken IDs.

It was failing in the following example (minified):

Substitute with formula variable `s`, `s -> (z = y)` (trivial substitution that does nothing here, but has a free variable `y`):

```
Original:
∧(∀'y_1. ¬(∀'y. ¬('y = 'y_1)))
Expected:
∧(∀'y_1. ¬(∀'y. ¬('y = 'y_1)))
Output:
∧(∀'y_1. ¬(∀'y_1. ¬('y_1 = 'y_1)))
```

Added this test case as well.