### PR TITLE
Fix: take assumptions into account for subproof statements

### DIFF
--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -32,7 +32,8 @@ trait ProofsHelpers {
     }
 
     inline infix def subproof(using proof: Library#Proof, om: OutputManager, line: sourcecode.Line, file: sourcecode.File)(tactic: proof.InnerProof ?=> Unit): proof.ProofStep = {
-      (new BasicStepTactic.SUBPROOF(using proof)(Some(bot))(tactic)).judgement.validate(line, file).asInstanceOf[proof.ProofStep]
+      val botWithAssumptions = HaveSequent.this.bot ++ (proof.getAssumptions |- ())
+      (new BasicStepTactic.SUBPROOF(using proof)(Some(botWithAssumptions))(tactic)).judgement.validate(line, file).asInstanceOf[proof.ProofStep]
     }
 
   }


### PR DESCRIPTION
Assumptions are currently not taken into account when checking that a subproof has succeeded in proving its goal at the top-level.

Example:
```scala
assume(C)
val ab = have(A |- B)

have(A |- B) subproof {
  have(thesis) by Restate.from(ab)
}
```

Will raise an error saying the subproof proved `C; A |- B`, instead of the expected sequent `A |- B`. So, `C` is being propagated into the subproof as expected, but the top-level correctness check fails to take this assumption into account.

This has been fixed by adding assumptions into the sequent the subproof uses for checking.