### PR TITLE
Minor fixes and faster apologies

### DIFF
--- a/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/Library.scala
@@ -44,7 +44,7 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
    * <pre> SCProof(steps(...), imports(...))</pre>
    * Must contains [[Justification]]'s, [[Formula]]'s or [[Sequent]], all of which are converted adequatly automatically.
    */
-  inline def imports(sqs: Sequentable*): IndexedSeq[Sequent] = sqs.map(sequantableToSequent).toIndexedSeq
+  inline def imports(sqs: Sequentable*): IndexedSeq[Sequent] = sqs.map(sequentableToSequent).toIndexedSeq
 
   // THEOREM Syntax
 
@@ -292,7 +292,7 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
   /**
    * Converts different class that have a natural interpretation as a Sequent
    */
-  private def sequantableToSequent(s: Sequentable): Sequent = s match {
+  private def sequentableToSequent(s: Sequentable): Sequent = s match {
     case j: theory.Justification => theory.sequentFromJustification(j)
     case f: Formula => () |- f
     case s: Sequent => s
@@ -300,7 +300,7 @@ abstract class Library extends lisa.prooflib.WithTheorems with lisa.prooflib.Pro
 
   given convJustSequent[C <: Iterable[Sequentable], D](using bf: scala.collection.BuildFrom[C, Sequent, D]): Conversion[C, D] = cc => {
     val builder = bf.newBuilder(cc)
-    cc.foreach(builder += sequantableToSequent(_))
+    cc.foreach(builder += sequentableToSequent(_))
     builder.result
   }
 

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -135,7 +135,7 @@ trait ProofsHelpers {
   def lastStep(using proof: library.Proof): proof.ProofStep = proof.mostRecentStep
 
   def showCurrentProof(using om: OutputManager, _proof: library.Proof)(): Unit = {
-    om.output("Current proof of " + _proof.owningTheorem.repr + ": ")
+    om.output("Current proof of " + _proof.owningTheorem.prettyGoal + ": ")
     om.output(
       ProofPrinter.prettyProof(_proof, 2)
     )

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -8,6 +8,7 @@ import lisa.kernel.proof.SCProofChecker
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus as SC
 import lisa.prooflib.ProofTacticLib.*
+import lisa.prooflib.BasicStepTactic.*
 import lisa.prooflib.SimpleDeducedSteps.*
 import lisa.prooflib.*
 import lisa.utils.{_, given}

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -7,8 +7,8 @@ import lisa.kernel.proof.SCProof
 import lisa.kernel.proof.SCProofChecker
 import lisa.kernel.proof.SequentCalculus.Sequent
 import lisa.kernel.proof.SequentCalculus as SC
-import lisa.prooflib.ProofTacticLib.*
 import lisa.prooflib.BasicStepTactic.*
+import lisa.prooflib.ProofTacticLib.*
 import lisa.prooflib.SimpleDeducedSteps.*
 import lisa.prooflib.*
 import lisa.utils.{_, given}

--- a/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/ProofsHelpers.scala
@@ -134,6 +134,8 @@ trait ProofsHelpers {
 
   def lastStep(using proof: library.Proof): proof.ProofStep = proof.mostRecentStep
 
+  def sorry(using proof: library.Proof): proof.ProofStep = have(thesis) by Sorry
+
   def showCurrentProof(using om: OutputManager, _proof: library.Proof)(): Unit = {
     om.output("Current proof of " + _proof.owningTheorem.prettyGoal + ": ")
     om.output(

--- a/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
@@ -22,6 +22,7 @@ object TheoriesHelpers {
   export lisa.utils.KernelHelpers.{_, given}
 
   extension (just: RunningTheory#Justification) {
+
     /**
      * Outputs, with an implicit om.output function, a readable representation of the Axiom, Theorem or Definition.
      */

--- a/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/TheoriesHelpers.scala
@@ -22,14 +22,20 @@ object TheoriesHelpers {
   export lisa.utils.KernelHelpers.{_, given}
 
   extension (just: RunningTheory#Justification) {
-
     /**
      * Outputs, with an implicit om.output function, a readable representation of the Axiom, Theorem or Definition.
      */
     def show(using om: OutputManager): just.type = {
-      om.output(just.repr, Console.GREEN)
+      just match {
+        case j: RunningTheory#Theorem =>
+          if (j.withSorry) om.output(j.repr, Console.YELLOW)
+          else om.output(j.repr, Console.GREEN)
+        case j: RunningTheory#FunctionDefinition =>
+          if (j.withSorry) om.output(j.repr, Console.YELLOW)
+          else om.output(j.repr, Console.GREEN)
+        case _ => om.output(just.repr, Console.GREEN)
+      }
       just
-
     }
   }
 


### PR DESCRIPTION
> *"Minor" in physical representation, "major" in spirit.*
> \- person coping with writing code after a while

Was adding a single word `sorry`, but discovered a few bugs on the way:
 ```scala
  val myCorrectTheorem = Theorem(() |- P(x)) {
    sorry
    showCurrentProof()
  }
  show
  ```
  
`sorry` simply expands to `have(thesis) by Sorry`, which is a handful to write when I'm washing my hands free of responsibility for a proof.
  
Fixes:
:pencil2: `sequantable` to `sequentable` because I saw it somewhere
:gear: calling `show` on theorems now checks for `sorry` usage and prints with a different colour, same as the default theorem printing
:gear: `showCurrentProof` was failing as it relied on `Theorem.repr`, which raises a `null` exception. Changed to use `prettyGoal` 
