### PR TITLE
Theory Modification: Stronger Version of Replacement Schema

### DIFF
--- a/src/main/scala/lisa/settheory/SetTheoryZFAxioms.scala
+++ b/src/main/scala/lisa/settheory/SetTheoryZFAxioms.scala
@@ -12,14 +12,14 @@ private[settheory] trait SetTheoryZFAxioms extends SetTheoryZAxioms {
   private final val sPsi = SchematicPredicateLabel("P", 3)
 
   /**
-   * Replacement Schema --- If a predicate `Ψ` is 'functional' over `a`, i.e.,
-   * given `x ∈ a`, there is a unique `y` such that `Ψ(a, x, y)`, then the
-   * 'image' of `a` in Ψ exists and is a set. It contains exactly the `y`'s that
-   * satisfy `Ψ` for each `x ∈ a`.
+   * Replacement Schema --- If a predicate `Ψ` is 'functional' over `x`, i.e.,
+   * given `a ∈ x`, there is a unique `b` such that `Ψ(x, a, b)`, then the
+   * 'image' of `x` in Ψ exists and is a set. It contains exactly the `b`'s that
+   * satisfy `Ψ` for each `a ∈ x`.
    */
   final val replacementSchema: runningSetTheory.Axiom = runningSetTheory.makeAxiom(
-    forall(x, (in(x, a)) ==> existsOne(y, sPsi(a, x, y))) ==>
-      exists(b, forall(x, in(x, a) ==> exists(y, in(y, b) /\ sPsi(a, x, y))))
+    forall(a, in(a, x) ==> existsOne(b, sPsi(x, a, b))) ==>
+      exists(y, forall(b, in(b, y) <=> exists(a, in(a, x) /\ sPsi(x, a, b))))
   )
 
   override def axioms: Set[(String, runningSetTheory.Axiom)] = super.axioms + (("replacementSchema", replacementSchema))


### PR DESCRIPTION
The replacement schema has been changed to use the stronger version. This is supported by Jech's Set Theory, page 166, 

![replacement-jech](https://i.imgur.com/J7SWXGB.png)

Our older version purported that there existed a set `Y` that contained these elements (but not precisely these). The stronger version is provable from the weaker one with a single application of the Comprehension schema, but is closer to Jech's version of the axioms, and is also generally the version that would be used in practice. 

Old:
```scala
forall(x, (in(x, a)) ==> existsOne(y, sPsi(a, x, y))) ==>
      exists(b, forall(x, in(x, a) ==> exists(y, in(y, b) /\ sPsi(a, x, y))))
```
New:
```scala
forall(a, in(a, x) ==> existsOne(b, sPsi(x, a, b))) ==>
      exists(y, forall(b, in(b, y) <=> exists(a, in(a, x) /\ sPsi(x, a, b))))
```

Our version differs from Jech in that we ask that `\phi` be functional only on the set we are applying replacement to, and consequently guarantee the existence of its image, and not for an arbitrary set. I believe this is more usable within our system. The two forms are equivalent (this PR guarantees no proof).

Funnily (no, it was my fault) our documentation already corresponds to the new version, since the author (definitely still me) wrote it with Jech as the reference more than the formula in code. I have checked the rest of the axioms in light of this, and we don't seem to have another one like this, partly because everything else corresponds to Jech exactly.

The replacement schema has not seen any use till now (but should in #156), so it is fine to change it right now.