### PR TITLE
Allow `InstantiateForall` to weaken sequents

### DIFF
--- a/lisa-utils/src/main/scala/lisa/prooflib/SimpleDeducedSteps.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/SimpleDeducedSteps.scala
@@ -118,8 +118,8 @@ object SimpleDeducedSteps {
         res._3 match {
           case proof.InvalidProofTactic(_) => res._3
           case proof.ValidProofTactic(_, _) => {
-            if (SC.isSameSequent(res._1.conclusion, bot))
-              proof.ValidProofTactic(Seq(SC.SCSubproof(res._1.withNewSteps(IndexedSeq(SC.Restate(bot, res._1.length - 1))), Seq(-1))), Seq(premise))
+            if (SC.isImplyingSequent(res._1.conclusion, bot))
+              proof.ValidProofTactic(Seq(SC.SCSubproof(res._1.withNewSteps(IndexedSeq(SC.Weakening(bot, res._1.length - 1))), Seq(-1))), Seq(premise))
             else
               proof.InvalidProofTactic(s"InstantiateForall proved \n\t${FOLParser.printSequent(res._1.conclusion)}\ninstead of input sequent\n\t${FOLParser.printSequent(bot)}")
           }


### PR DESCRIPTION
<insert title />

This is particularly to fix issues when using instantiation in the presence of assumptions. This is partial progress (and one of the major issues in) #161.