### PR TITLE
Better Feedback for Failed Substitutions

### DIFF
--- a/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
+++ b/src/main/scala/lisa/automation/kernel/SimpleSimplifier.scala
@@ -411,10 +411,13 @@ object SimpleSimplifier {
       lazy val rightPairs = premiseSequent.right zip premiseSequent.right.map(x => bot.right.find(y => UnificationUtils.canReachOneStep(x, y, iffs, eqs).isDefined))
       lazy val leftPairs = filteredPrem zip filteredPrem.map(x => filteredBot.find(y => UnificationUtils.canReachOneStep(x, y, iffs, eqs).isDefined))
 
-      if (leftPairs.exists(_._2.isEmpty))
-        proof.InvalidProofTactic("Could not rewrite LHS of premise into conclusion with given substitutions.")
-      else if (rightPairs.exists(_._2.isEmpty))
-        proof.InvalidProofTactic("Could not rewrite RHS of premise into conclusion with given substitutions.")
+      lazy val violatingFormulaLeft = leftPairs.find(_._2.isEmpty)
+      lazy val violatingFormulaRight = rightPairs.find(_._2.isEmpty)
+
+      if (violatingFormulaLeft.isDefined)
+        proof.InvalidProofTactic(s"Could not rewrite LHS of premise into conclusion with given substitutions.\nViolating Formula: ${FOLPrinter.prettyFormula(violatingFormulaLeft.get._1)}")
+      else if (violatingFormulaRight.isDefined)
+        proof.InvalidProofTactic(s"Could not rewrite RHS of premise into conclusion with given substitutions.\nViolating Formula: ${FOLPrinter.prettyFormula(violatingFormulaRight.get._1)}")
       else {
         // actually construct proof
         try {


### PR DESCRIPTION
Failed substitutions now print the formula which could not be substituted. Minor change, but I find myself looking for what failed often.

Old
```
[info]               thenHave(fun(t1, y1) /\ fun(t2, y1)) by Substitution.apply2(false, y1 === y2)
[info]    Proof tactic Substitution used in.(Recursion.scala:463) did not succeed:
[info]    Could not rewrite RHS of premise into conclusion with given substitutions.
```

New
```
[info]               thenHave(fun(t1, y1) /\ fun(t2, y1)) by Substitution.apply2(false, y1 === y2)
[info]    Proof tactic Substitution used in.(Recursion.scala:463) did not succeed:
[info]    Could not rewrite RHS of premise into conclusion with given substitutions.
[info] Formula: functionalOver('t1, initialSegment('p, 'y1)) 
```

Not necessarily intended to be merged immediately. If you have suggestions for how we can make the feedback better, we can add it to this PR as well.