### PR TITLE
Kernel: Cut Proof Checking Fix

### DIFF
--- a/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/proof/SCProofChecker.scala
@@ -57,11 +57,11 @@ object SCProofChecker {
           /*
            *  Γ |- Δ, φ    φ, Σ |- Π
            * ------------------------
-           *       Γ, Σ |-Δ, Π
+           *       Γ, Σ |- Δ, Π
            */
           case Cut(b, t1, t2, phi) =>
-            if (isSameSet(b.left, ref(t1).left union ref(t2).left.filterNot(isSame(_, phi))))
-              if (isSameSet(b.right, ref(t2).right union ref(t1).right.filterNot(isSame(_, phi))))
+            if (isSameSet(b.left + phi, ref(t1).left union ref(t2).left))
+              if (isSameSet(b.right + phi, ref(t2).right union ref(t1).right))
                 if (contains(ref(t2).left, phi))
                   if (contains(ref(t1).right, phi))
                     SCValidProof(SCProof(step))

--- a/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
@@ -56,7 +56,7 @@ object BasicStepTactic {
    * <pre>
    *  Γ |- Δ, φ    φ, Σ |- Π
    * ------------------------
-   *       Γ, Σ |-Δ, Π
+   *       Γ, Σ |- Δ, Π
    * </pre>
    */
   object Cut extends ProofTactic {
@@ -68,9 +68,9 @@ object BasicStepTactic {
         proof.InvalidProofTactic("Right-hand side of first premise does not contain φ as claimed.")
       else if (!contains(rightSequent.left, phi))
         proof.InvalidProofTactic("Left-hand side of second premise does not contain φ as claimed.")
-      else if (!isSameSet(bot.left, leftSequent.left ++ rightSequent.left.filterNot(isSame(_, phi))))
+      else if (!isSameSet(bot.left + phi, leftSequent.left ++ rightSequent.left))
         proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the union of the left-hand sides of the premises.")
-      else if (!isSameSet(bot.right, leftSequent.right.filterNot(isSame(_, phi)) ++ rightSequent.right))
+      else if (!isSameSet(bot.right + phi, leftSequent.right ++ rightSequent.right))
         proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the union of the right-hand sides of the premises.")
       else
         proof.ValidProofTactic(Seq(SC.Cut(bot, -1, -2, phi)), Seq(prem1, prem2))


### PR DESCRIPTION
Fixes a soundness bug in the kernel in the proof checking for the Cut proof step

Consider the following instance of Cut:

```
S1: A |- B, C     S2: C, D |- E
-------------------------------- Cut: wrt C
       S3: A, D |- B, E
```

where `C ~ D`, and `A !~ D` in ortholattices.

The (previous) Cut implementation would attempt the following check:

```scala
isSameSetUnderOL(
     {A, D} // from the conclusion: S3.LHS
     {A} union {C, D}.filterNot(_ ~ C) // from the premises:  S1.LHS U (S2.RHS / cutPivot)
)
```

However, `{C, D}.filterNot(_ ~ C) = {}`, so it is checking whether `{A, D} = {A}` under OL, but a counterpart for `D` is not found on the right. This filtering is too excessive. 

We now perform a more permissive check:

```scala
isSameSetUnderOL(
     {A, D} + C // from the conclusion: S3.LHS + cutPivot
     {A} union {C, D} // from the premises:  S1.LHS U S2.RHS
)
```

which performs the 'correct' check, but the duplication `C`-equivalent formulas in the conclusion. However, this is still supported by our interpretation of sequent calculus.