### PR TITLE
Printing: Sorry SC Step

### DIFF
--- a/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
@@ -158,7 +158,6 @@ class Printer(parser: Parser) {
               case RightSubstIff(_, t1, _, _) => pretty("R. SubstIff", t1)
               case InstSchema(_, t1, _, _, _) => pretty("Schema Instantiation", t1)
               case Sorry(_) => pretty("Sorry")
-              case other => throw new Exception(s"No available method to print this proof step, consider updating Printer.scala\n$other")
             }
             Seq(line)
         }

--- a/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
+++ b/lisa-utils/src/main/scala/lisa/utils/parsing/Printer.scala
@@ -157,6 +157,7 @@ class Printer(parser: Parser) {
               case LeftSubstIff(_, t1, _, _) => pretty("L. SubstIff", t1)
               case RightSubstIff(_, t1, _, _) => pretty("R. SubstIff", t1)
               case InstSchema(_, t1, _, _, _) => pretty("Schema Instantiation", t1)
+              case Sorry(_) => pretty("Sorry")
               case other => throw new Exception(s"No available method to print this proof step, consider updating Printer.scala\n$other")
             }
             Seq(line)


### PR DESCRIPTION
Filled out the case in the printer for the new `Sorry` step.

I think this was not caught as a pattern match exhaustion warning due to the following line at the end of the match:

```scala
case other => throw new Exception(s"No available method to print this proof step, consider updating Printer.scala\n$other")
```

It's a tradeoff between better error messages for printing and hiding warnings when we expect them to help.

However, it is unlikely that we have users facing kernel level printing errors, of all things, so I would suggest the removal of this line. I think it would help the maintenance of the system in the future. It would raise a failed pattern match exception with the right line and file at runtime anyway if this unlikely scenario did happen. 

Edit: The catchall is gone, shredded to atoms.
