### PR TITLE
Cut rule of ProofTactic allows you to "prove" any theorem

### DIFF
--- a/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
+++ b/lisa-kernel/src/main/scala/lisa/kernel/fol/EquivalenceChecker.scala
@@ -58,6 +58,10 @@ private[fol] trait EquivalenceChecker extends FormulaDefinitions {
     s.exists(g => isSame(f, g))
   }
 
+  def remove(s: Set[Formula], f: Formula): Set[Formula] = {
+    s.filter(g => !isSame(g, f))
+  }
+
   private var totPolarFormula = 0
   sealed abstract class SimpleFormula {
     val uniqueKey: Int = totPolarFormula

--- a/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/BasicStepTactic.scala
@@ -68,9 +68,9 @@ object BasicStepTactic {
         proof.InvalidProofTactic("Right-hand side of first premise does not contain φ as claimed.")
       else if (!K.contains(rightSequent.left, phiK))
         proof.InvalidProofTactic("Left-hand side of second premise does not contain φ as claimed.")
-      else if (!K.isSameSet(botK.left + phiK, leftSequent.left ++ rightSequent.left))
+      else if (!K.isSameSet(botK.left, (K.remove(rightSequent.left, phiK)) ++ leftSequent.left))
         proof.InvalidProofTactic("Left-hand side of conclusion + φ is not the union of the left-hand sides of the premises.")
-      else if (!K.isSameSet(botK.right + phiK, leftSequent.right ++ rightSequent.right))
+      else if (!K.isSameSet(botK.right, (K.remove(leftSequent.right, phiK)) ++ rightSequent.right))
         proof.InvalidProofTactic("Right-hand side of conclusion + φ is not the union of the right-hand sides of the premises.")
       else
         proof.ValidProofTactic(bot, Seq(K.Cut(botK, -1, -2, phiK)), Seq(prem1, prem2))


### PR DESCRIPTION
Cut rule of ProofTactic allows you to "prove" any theorem.
For instance:
```
val thm1 = Theorem(Q(x) /\ !Q(x) |- ()) {
  var l = have((Q(x) /\ !Q(x)) |- (Q(x) /\ !Q(x))) by Restate
  have(thesis) by Cut(l, l)
}
val thm2 = Theorem(() |- Q(x) /\ !Q(x)) {
  var l = have(!(Q(x) /\ !Q(x)) |- !(Q(x) /\ !Q(x))) by Restate
  val l2 = have(!(Q(x) /\ !Q(x)) |- ()) by Cut(l, l)
  have(thesis) by Tautology.from(l2)
}
val thm3 = Theorem(!(Q(x) /\ !Q(x)) |- ()) {
  var l = have(!((Q(x) /\ !Q(x))) |- !((Q(x) /\ !Q(x)))) by Restate
  have(thesis) by Cut(l, l)
}
val thm4 = Theorem(Q(x) |- !Q(x)) {
  var l = have((Q(x), Q(x)) |- (Q(x), Q(x))) by Restate
  val l2 = have((Q(x), Q(x)) |- ()) by Cut(l, l)
  have(thesis) by Tautology.from(l2)
}
```

The issue arises whenever you use cut with the right part as `()`.
The method `withParameters` of `Cut` has internally 4 variables: `leftSequent`,`rightSequent`,`botK`,`phiK`.
The wrong checks that allow the unwanted behavior are: 
- `!K.isSameSet(botK.left + phiK, leftSequent.left ++ rightSequent.left)`
- `!K.isSameSet(botK.right + phiK, leftSequent.right ++ rightSequent.right)`

For instance in `thm1` we would have:
- `leftSequent`:= `(Q(x) /\ !Q(x)) |- (Q(x) /\ !Q(x))`
- `rightSequent`:= `(Q(x) /\ !Q(x)) |- (Q(x) /\ !Q(x))`
- `botK`:= `Q(x) /\ !Q(x) |- ()`
- `phiK`:= `(Q(x) /\ !Q(x))`
So:
- `botK.right + phiK` := `(Q(x) /\ !Q(x))`
- `leftSequent.left ++ rightSequent.left` :=  `(Q(x) /\ !Q(x)) , (Q(x) /\ !Q(x))`

Therefore it passes the check.
