### PR TITLE
fix tableau incompleteness

### DIFF
--- a/lisa-sets/src/main/scala/lisa/automation/Tableau.scala
+++ b/lisa-sets/src/main/scala/lisa/automation/Tableau.scala
@@ -232,8 +232,6 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
    * When multiple substitutions are possible, the one with the smallest size is returned. (Maybe there is a better heuristic, like distance from the root?)
    */
   def close(branch: Branch): Option[(Substitution, Set[Formula])] = {
-    // println("close")
-    // println("maxIndex: " + branch.maxIndex)
     val newMap = branch.atoms._1
       .flatMap(pred => pred.freeVariables.filter(v => branch.unifiable.contains(v)))
       .map(v => v -> VariableLabel(Identifier(v.id.name, v.id.no + branch.maxIndex + 1)))
@@ -241,7 +239,6 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
     val newMapTerm = newMap.map((k, v) => k -> VariableTerm(v))
     val inverseNewMap = newMap.map((k, v) => v -> k).toMap
     val inverseNewMapTerm = inverseNewMap.map((k, v) => k -> VariableTerm(v))
-    // println("newMap: " + newMap)
     val pos = branch.atoms._1.map(pred => substituteVariablesInFormula(pred, newMapTerm, Seq())).asInstanceOf[List[PredicateFormula]].iterator
     var substitutions: List[(Substitution, Set[Formula])] = Nil
 
@@ -251,16 +248,13 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
       val neg = branch.atoms._2.iterator
       while (neg.hasNext) {
         val n = neg.next()
-        // println("unifying... " + prettyFormula(p) + "  " + prettyFormula(n))
         unifyPred(p, n, branch) match
           case None => ()
           case Some(unif) =>
-            // println("unif found: " + (prettySubst(unif) + "    " + prettyFormula(p) + " : " + prettyFormula(n)))
             substitutions = (unif, Set(p, !n)) :: substitutions
       }
     }
 
-    // println("Subst: " + substitutions.map((s, f) => prettySubst(s) + "     " + f.map(prettyFormula(_))))
 
     val cr1 = substitutions.map((sub, set) =>
       (
@@ -274,7 +268,6 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
         set.map(f => substituteVariablesInFormula(f, inverseNewMapTerm, Seq()))
       )
     )
-    // println("cr1: " + cr1.map((s, f) => prettySubst(s) + "     " + f.map(prettyFormula(_))))
 
     val cr = cr1.filterNot(s =>
       s._1.exists((x, t) =>
@@ -282,7 +275,6 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
         v
       )
     )
-    // println("cr: " + cr.map((s, f) => prettySubst(s)))
 
     cr.sortBy(_._1.size).headOption
 

--- a/lisa-sets/src/main/scala/lisa/automation/Tableau.scala
+++ b/lisa-sets/src/main/scala/lisa/automation/Tableau.scala
@@ -7,6 +7,7 @@ import lisa.utils.K.{_, given}
 import lisa.utils.parsing.FOLPrinter.prettyFormula
 import lisa.utils.parsing.FOLPrinter.prettySCProof
 import lisa.utils.parsing.FOLPrinter.prettyTerm
+import lisa.utils.parsing.FOLPrinter.prettySequent
 
 import scala.collection.immutable.HashMap
 import scala.collection.immutable.HashSet
@@ -21,6 +22,7 @@ import scala.collection.immutable.HashSet
  */
 
 object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequentTactic {
+
 
   def apply(using lib: Library, proof: lib.Proof)(bot: F.Sequent): proof.ProofTacticJudgement = {
     solve(bot) match {
@@ -63,12 +65,15 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
   inline def solve(sequent: F.Sequent): Option[SCProof] = solve(sequent.underlying)
 
   def solve(sequent: K.Sequent): Option[SCProof] = {
+    
     val f = K.ConnectorFormula(K.And, (sequent.left.toSeq ++ sequent.right.map(f => K.ConnectorFormula(K.Neg, List(f)))))
     val taken = f.schematicTermLabels
     val nextIdNow = if taken.isEmpty then 0 else taken.maxBy(_.id.no).id.no + 1
     val (fnamed, nextId, _) = makeVariableNamesUnique(f, nextIdNow, f.freeVariables)
+
     val nf = reducedNNFForm(fnamed)
-    val proof = decide(Branch.empty.prepended(nf))
+    val uv = VariableLabel(Identifier("§", nextId))
+    val proof = decide(Branch.empty(nextId+1, uv).prepended(nf))
 
     proof match
       case None => None
@@ -102,7 +107,9 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
       unifiable: Map[VariableLabel, BinderFormula], // map between metavariables and the original formula they came from
       skolemized: Set[VariableLabel], // set of variables that have been skolemized
       triedInstantiation: Map[VariableLabel, Set[Term]], // map between metavariables and the term they were already instantiated with
-      maxIndex: Int // the maximum index used for skolemization and metavariables
+      maxIndex: Int, // the maximum index used for skolemization and metavariables
+      varsOrder: Map[VariableLabel, Int], // the order in which variables were instantiated. In particular, if the branch contained the formula ∀x. ∀y. ... then x > y.
+      unusedVar:VariableLabel // a variable the is neither free nor bound in the original formula.
   ) {
     def pop(f: Formula): Branch = f match
       case f @ ConnectorFormula(Or, args) =>
@@ -138,12 +145,12 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
     override def toString(): String =
       val pretUnif = unifiable.map((x, f) => x.id + " -> " + prettyFormula(f)).mkString("Unif(", ", ", ")")
       // val pretTried = triedInstantiation.map((x, t) => x.id + " -> " + prettyTerm(t, true)).mkString("Tried(", ", ", ")")
-      s"Branch(${prettyIte(beta, "beta")}, ${prettyIte(delta, "delta")}, ${prettyIte(gamma, "gamma")}, ${prettyIte(atoms._1, "+")}, ${prettyIte(atoms._2, "-")}, $pretUnif, _, _)"
+      s"Branch(${prettyIte(alpha, "alpha")}, ${prettyIte(beta, "beta")}, ${prettyIte(delta, "delta")}, ${prettyIte(gamma, "gamma")}, ${prettyIte(atoms._1, "+")}, ${prettyIte(atoms._2, "-")}, $pretUnif, _, _)"
 
   }
   object Branch {
-    def empty = Branch(Nil, Nil, Nil, Nil, (Nil, Nil), Map.empty, Set.empty, Map.empty, 1)
-    def empty(n: Int) = Branch(Nil, Nil, Nil, Nil, (Nil, Nil), Map.empty, Set.empty, Map.empty, n)
+    def empty = Branch(Nil, Nil, Nil, Nil, (Nil, Nil), Map.empty, Set.empty, Map.empty, 1, Map.empty, VariableLabel(Identifier("§uv", 0)))
+    def empty(n: Int, uv: VariableLabel) = Branch(Nil, Nil, Nil, Nil, (Nil, Nil), Map.empty, Set.empty, Map.empty, n, Map.empty, uv)
     def prettyIte(l: Iterable[Formula], head: String): String = l match
       case Nil => "Nil"
       case _ => l.map(prettyFormula(_, true)).mkString(head + "(", ", ", ")")
@@ -170,21 +177,27 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
 
   type Substitution = Map[VariableLabel, Term]
   val Substitution = HashMap
+  def prettySubst(s: Substitution): String = s.map((x, t) => x.id + " -> " + prettyTerm(t, true)).mkString("Subst(", ", ", ")")
 
   /**
    * Detect if two terms can be unified, and if so, return a substitution that unifies them.
    */
   def unify(t1: Term, t2: Term, current: Substitution, br: Branch): Option[Substitution] = (t1, t2) match
-    case (VariableTerm(x), VariableTerm(y)) if br.unifiable.contains(x) && br.unifiable.contains(y) =>
-      if (x == y) Some(current) else Some(current + (x -> substituteVariablesInTerm(t2, current)))
-    case (VariableTerm(x), t2: Term) if br.unifiable.contains(x) =>
-      if t2.freeVariables.contains(x) then None
-      else if (current.contains(x)) unify(current(x), t2, current, br)
-      else Some(current + (x -> substituteVariablesInTerm(t2, current)))
-    case (t1: Term, VariableTerm(y)) if br.unifiable.contains(y) =>
-      if t1.freeVariables.contains(y) then None
-      else if (current.contains(y)) unify(t1, current(y), current, br)
-      else Some(current + (y -> substituteVariablesInTerm(t1, current)))
+    case (VariableTerm(x), VariableTerm(y)) if (br.unifiable.contains(x) || x.id.no > br.maxIndex) && (br.unifiable.contains(y)|| y.id.no > br.maxIndex) =>
+      if x == y then Some(current) 
+      else if current.contains(x) then unify(current(x), t2, current, br)
+      else if current.contains(y) then unify(t1, current(y), current, br)
+      else Some(current + (x -> y))
+    case (VariableTerm(x), t2: Term) if br.unifiable.contains(x) || x.id.no > br.maxIndex=>
+      val newt2 = substituteVariablesInTerm(t2, current)
+      if newt2.freeVariables.contains(x) then None
+      else if (current.contains(x)) unify(current(x), newt2, current, br)
+      else Some(current + (x -> newt2))
+    case (t1: Term, VariableTerm(y)) if br.unifiable.contains(y) || y.id.no > br.maxIndex =>
+      val newt1 = substituteVariablesInTerm(t1, current)
+      if newt1.freeVariables.contains(y) then None
+      else if (current.contains(y)) unify(newt1, current(y), current, br)
+      else Some(current + (y -> newt1))
     case (Term(label1, args1), Term(label2, args2)) =>
       if label1 == label2 && args1.size == args2.size then
         args1
@@ -220,7 +233,15 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
    * When multiple substitutions are possible, the one with the smallest size is returned. (Maybe there is a better heuristic, like distance from the root?)
    */
   def close(branch: Branch): Option[(Substitution, Set[Formula])] = {
-    val pos = branch.atoms._1.iterator
+    //println("close")
+    //println("maxIndex: " + branch.maxIndex)
+    val newMap = branch.atoms._1.flatMap(pred => pred.freeVariables.filter(v => branch.unifiable.contains(v)))
+                .map(v => v -> VariableLabel(Identifier(v.id.name, v.id.no+branch.maxIndex+1))).toMap
+    val newMapTerm = newMap.map((k, v) => k -> VariableTerm(v))
+    val inverseNewMap = newMap.map((k, v) => v -> k).toMap
+    val inverseNewMapTerm = inverseNewMap.map((k, v) => k -> VariableTerm(v))
+    //println("newMap: " + newMap)
+    val pos = branch.atoms._1.map(pred => substituteVariablesInFormula(pred, newMapTerm, Seq())).asInstanceOf[List[PredicateFormula]].iterator
     var substitutions: List[(Substitution, Set[Formula])] = Nil
 
     while (pos.hasNext) {
@@ -229,18 +250,42 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
       val neg = branch.atoms._2.iterator
       while (neg.hasNext) {
         val n = neg.next()
+        //println("unifying... " + prettyFormula(p) + "  " + prettyFormula(n))
         unifyPred(p, n, branch) match
           case None => ()
-          case Some(unif) => substitutions = (unif, Set(p, !n)) :: substitutions
+          case Some(unif) => 
+            //println("unif found: " + (prettySubst(unif) + "    " + prettyFormula(p) + " : " + prettyFormula(n)))
+            substitutions = (unif, Set(p, !n)) :: substitutions
       }
     }
-    val cr = substitutions.filterNot(s =>
+
+    //println("Subst: " + substitutions.map((s, f) => prettySubst(s) + "     " + f.map(prettyFormula(_))))
+
+    val cr1 = substitutions.map((sub, set) =>
+      (
+        sub.flatMap((v, t) => 
+          if v.id.no > branch.maxIndex then 
+            if t == inverseNewMapTerm(v) then None 
+            else Some(inverseNewMap(v) -> substituteVariablesInTerm(t, inverseNewMapTerm.map((v, t) => v -> substituteVariablesInTerm(t, sub))))
+          else 
+            if newMap.contains(v) && t == newMap(v) then None 
+            else Some(v -> substituteVariablesInTerm(t, inverseNewMapTerm))
+        ),
+        set.map(f => substituteVariablesInFormula(f, inverseNewMapTerm, Seq()))
+      )
+    )
+    //println("cr1: " + cr1.map((s, f) => prettySubst(s) + "     " + f.map(prettyFormula(_))))
+    
+    val cr = cr1.filterNot(s =>
       s._1.exists((x, t) =>
         val v = branch.triedInstantiation.contains(x) && branch.triedInstantiation(x).contains(t)
         v
       )
     )
+    //println("cr: " + cr.map((s, f) => prettySubst(s)))
+
     cr.sortBy(_._1.size).headOption
+
   }
 
   /**
@@ -294,7 +339,7 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
         val newBound = VariableLabel(Identifier(f.bound.id.name, branch.maxIndex))
         val newInner = substituteVariablesInFormula(f.inner, Map(f.bound -> newBound), Seq())
         (newInner, newBound)
-    val b1 = branch.copy(gamma = branch.gamma.tail, unifiable = branch.unifiable + (nb -> f), maxIndex = branch.maxIndex + 1)
+    val b1 = branch.copy(gamma = branch.gamma.tail, unifiable = branch.unifiable + (nb -> f), maxIndex = branch.maxIndex + 1, varsOrder = branch.varsOrder + (nb -> branch.varsOrder.size))
     (b1.prepended(ni), nb, ni)
   }
 
@@ -320,6 +365,8 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
    * The return integer is the size of the proof: Used to avoid computing the size every time in linear time.
    */
   def decide(branch: Branch): Option[(List[SCProofStep], Int)] = {
+    //println(" ")
+    //println("decide: " + branch)
     val closeSubst = close(branch)
     if (closeSubst.nonEmpty && closeSubst.get._1.isEmpty) // If branch can be closed without Instantiation (Hyp)
       Some((List(RestateTrue(Sequent(closeSubst.get._2, Set()))), 0))
@@ -378,7 +425,7 @@ object Tableau extends ProofTactic with ProofSequentTactic with ProofFactSequent
         else (proof, step)
       )
     else if (closeSubst.nonEmpty && closeSubst.get._1.nonEmpty) // If branch can be closed with Instantiation (LeftForall)
-      val (x, t) = closeSubst.get._1.head
+      val (x, t) = closeSubst.get._1.minBy((x, t) => branch.varsOrder(x))
       val (recBranch, instantiated) = applyInst(branch, x, t)
       val upperProof = decide(recBranch)
       upperProof.map((proof, step) =>

--- a/lisa-sets/src/test/scala/lisa/automation/TableauTest.scala
+++ b/lisa-sets/src/test/scala/lisa/automation/TableauTest.scala
@@ -57,13 +57,11 @@ object TableauTest {
   val g = function[1]
   val h = function[2]
 
-
   val D = predicate[1]
   val E = predicate[2]
   val P = predicate[1]
   val Q = predicate[1]
   val R = predicate[2]
-
 
   var doprint: Boolean = false
   def printif(s: Any) = if doprint then println(s) else ()
@@ -104,17 +102,21 @@ object TableauTest {
 
   // First Order Hard, from https://isabelle.in.tum.de/library/FOL/FOL-ex/Quantifiers_Cla.html
 
-
-
   val a1 = forall(x, forall(y, forall(z, ((E(x, y) /\ E(y, z)) ==> E(x, z)))))
   val a2 = forall(x, forall(y, (E(x, y) ==> E(f(x), f(y)))))
   val a3 = forall(x, E(f(g(x)), g(f(x))))
-  val biga = forall(x, forall(y, forall(z, 
-    ((E(x, y) /\ E(y, z)) ==> E(x, z)) /\
-    (E(x, y) ==> E(f(x), f(y))) /\
-    E(f(g(x)), g(f(x)))
-  )))
-
+  val biga = forall(
+    x,
+    forall(
+      y,
+      forall(
+        z,
+        ((E(x, y) /\ E(y, z)) ==> E(x, z)) /\
+          (E(x, y) ==> E(f(x), f(y))) /\
+          E(f(g(x)), g(f(x)))
+      )
+    )
+  )
 
   val poshard = List(
     forall(x, P(x) ==> Q(x)) ==> (forall(x, P(x)) ==> forall(x, Q(x))),
@@ -142,16 +144,15 @@ object TableauTest {
     forall(x, P(x)) ==> P(y),
     !forall(x, D(x) /\ !D(f(x))),
     !forall(x, (D(x) /\ !D(f(x))) \/ (D(x) /\ !D(x))),
-    forall(x, forall(y, (E(x, y) ==> E(f(x), f(y)) ) /\ E( f(g(x)), g(f(x))) ))  ==> E(f(f(g(u))), f(g(f(u)))),
+    forall(x, forall(y, (E(x, y) ==> E(f(x), f(y))) /\ E(f(g(x)), g(f(x))))) ==> E(f(f(g(u))), f(g(f(u)))),
     !(forall(x, !((E(f(x), x)))) /\ forall(x, forall(y, !(E(x, y)) /\ E(f(x), g(x))))),
     a1 /\ a2 /\ a3 ==> E(f(f(g(u))), f(g(f(u)))),
     a1 /\ a2 /\ a3 ==> E(f(g(f(u))), g(f(f(u)))),
     biga ==> E(f(f(g(u))), f(g(f(u)))),
-    biga ==> E(f(g(f(u))), g(f(f(u)))),
+    biga ==> E(f(g(f(u))), g(f(f(u))))
   ).zipWithIndex.map(f =>
     val res = solve(() |- f._1)
     (f._2, f._1, res.nonEmpty, res, res.map(checkSCProof))
   )
-
 
 }

--- a/lisa-sets/src/test/scala/lisa/automation/TableauTest.scala
+++ b/lisa-sets/src/test/scala/lisa/automation/TableauTest.scala
@@ -41,6 +41,7 @@ class TableauTest extends AnyFunSuite {
 }
 object TableauTest {
 
+  val u = variable
   val w = variable
   val x = variable
   val y = variable
@@ -56,9 +57,13 @@ object TableauTest {
   val g = function[1]
   val h = function[2]
 
+
+  val D = predicate[1]
+  val E = predicate[2]
   val P = predicate[1]
   val Q = predicate[1]
   val R = predicate[2]
+
 
   var doprint: Boolean = false
   def printif(s: Any) = if doprint then println(s) else ()
@@ -99,6 +104,18 @@ object TableauTest {
 
   // First Order Hard, from https://isabelle.in.tum.de/library/FOL/FOL-ex/Quantifiers_Cla.html
 
+
+
+  val a1 = forall(x, forall(y, forall(z, ((E(x, y) /\ E(y, z)) ==> E(x, z)))))
+  val a2 = forall(x, forall(y, (E(x, y) ==> E(f(x), f(y)))))
+  val a3 = forall(x, E(f(g(x)), g(f(x))))
+  val biga = forall(x, forall(y, forall(z, 
+    ((E(x, y) /\ E(y, z)) ==> E(x, z)) /\
+    (E(x, y) ==> E(f(x), f(y))) /\
+    E(f(g(x)), g(f(x)))
+  )))
+
+
   val poshard = List(
     forall(x, P(x) ==> Q(x)) ==> (forall(x, P(x)) ==> forall(x, Q(x))),
     forall(x, forall(y, R(x, y))) ==> forall(y, forall(x, R(x, y))),
@@ -122,10 +139,19 @@ object TableauTest {
     (exists(x, P(x) /\ exists(y, R(x, y)))) ==> exists(x, exists(y, P(x) /\ R(x, y))),
     exists(x, exists(y, P(x) /\ R(x, y))) <=> (exists(x, P(x) /\ exists(y, R(x, y)))),
     exists(y, forall(x, P(x) ==> R(x, y))) ==> (forall(x, P(x)) ==> exists(y, R(x, y))),
-    forall(x, P(x)) ==> P(y)
+    forall(x, P(x)) ==> P(y),
+    !forall(x, D(x) /\ !D(f(x))),
+    !forall(x, (D(x) /\ !D(f(x))) \/ (D(x) /\ !D(x))),
+    forall(x, forall(y, (E(x, y) ==> E(f(x), f(y)) ) /\ E( f(g(x)), g(f(x))) ))  ==> E(f(f(g(u))), f(g(f(u)))),
+    !(forall(x, !((E(f(x), x)))) /\ forall(x, forall(y, !(E(x, y)) /\ E(f(x), g(x))))),
+    a1 /\ a2 /\ a3 ==> E(f(f(g(u))), f(g(f(u)))),
+    a1 /\ a2 /\ a3 ==> E(f(g(f(u))), g(f(f(u)))),
+    biga ==> E(f(f(g(u))), f(g(f(u)))),
+    biga ==> E(f(g(f(u))), g(f(f(u)))),
   ).zipWithIndex.map(f =>
     val res = solve(() |- f._1)
     (f._2, f._1, res.nonEmpty, res, res.map(checkSCProof))
   )
+
 
 }


### PR DESCRIPTION
Occur check in unification in the tableau prover made it impossible to solve formulas such as 
$$
\forall x. D(x) \land \neg D(f(x))
$$
A workarround is used where variables in positive literals are renamed before unification, and maped back after.

A further issue was that when a found substitution substitutes more than one variable, an arbitrary order of substitution might not work; it is necessary to instantiate the most outer quantifier first. This is now tracked.

The PR also includes additional test cases that rely on these behaviours.