### PR TITLE
Upgrade to Scala 3.3.1

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,11 @@
 # Change List
 
+## 2023-12-06
+Upgrade to Scala 3.3.1
+
+- the `Proof` class has been temporarily unsealed, till [lampepfl/dotty#19031](https://github.com/lampepfl/dotty/issues/19031) / [epfl-lara/lisa#190](https://github.com/epfl-lara/lisa/issues/190) is fixed
+- minor fixes to address compilation errors, mostly involving explicitly specifying types or implicits in some places.
+
 ## 2023-12-02
 Creation of the present Change Liste, going back to October 2023
 

--- a/build.sbt
+++ b/build.sbt
@@ -94,7 +94,15 @@ lazy val utils = Project(
   .dependsOn(scallion % "compile->compile")
   .settings(libraryDependencies += "io.github.leoprover" % "scala-tptp-parser_2.13" % "1.4")
 
-
+ThisBuild / assemblyMergeStrategy := {
+  case PathList("module-info.class") => MergeStrategy.discard
+  case x if x.endsWith("/module-info.class") => MergeStrategy.discard
+  case x if x.endsWith(".class") => MergeStrategy.first
+  case x if x.endsWith(".tasty") => MergeStrategy.first
+  case x =>
+    val oldStrategy = (ThisBuild / assemblyMergeStrategy).value
+    oldStrategy(x)
+}
 
 
 lazy val examples = Project(

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val commonSettings = Seq(
 
 
 val scala2 = "2.13.8"
-val scala3 = "3.2.2"
+val scala3 = "3.3.1"
 
 val commonSettings2 = commonSettings ++ Seq(
   scalaVersion := scala2,

--- a/lisa-sets/src/main/scala/lisa/automation/CommonTactics.scala
+++ b/lisa-sets/src/main/scala/lisa/automation/CommonTactics.scala
@@ -145,11 +145,11 @@ object CommonTactics {
       }
       val method: (F.ConstantFunctionLabel[?], proof.Fact) => Seq[F.Term] => F.Sequent => proof.ProofTacticJudgement = 
         expr.f.substituteUnsafe(expr.vars.zip(xs).toMap) match {
-          case F.ConnectorFormula(
+          case F.AppliedConnector(
                 F.And,
                 Seq(
-                  F.ConnectorFormula(F.Implies, Seq(a, _)),
-                  F.ConnectorFormula(F.Implies, Seq(b, _))
+                  F.AppliedConnector(F.Implies, Seq(a, _)),
+                  F.AppliedConnector(F.Implies, Seq(b, _))
                 )
               ) if F.isSame(F.Neg(a), b) =>
             conditional(using lib, proof)

--- a/lisa-sets/src/main/scala/lisa/automation/CommonTactics.scala
+++ b/lisa-sets/src/main/scala/lisa/automation/CommonTactics.scala
@@ -143,18 +143,19 @@ object CommonTactics {
         case Some(value: lib.FunctionDefinition[?]) => value
         case _ => return proof.InvalidProofTactic("Could not get definition of function.")
       }
-      val method = expr.f.substituteUnsafe(expr.vars.zip(xs).toMap) match {
-        case F.AppliedConnector(
-              F.And,
-              Seq(
-                F.AppliedConnector(F.Implies, Seq(a, _)),
-                F.AppliedConnector(F.Implies, Seq(b, _))
-              )
-            ) if F.isSame(F.Neg(a), b) =>
-          conditional
+      val method: (F.ConstantFunctionLabel[?], proof.Fact) => Seq[F.Term] => F.Sequent => proof.ProofTacticJudgement = 
+        expr.f.substituteUnsafe(expr.vars.zip(xs).toMap) match {
+          case F.ConnectorFormula(
+                F.And,
+                Seq(
+                  F.ConnectorFormula(F.Implies, Seq(a, _)),
+                  F.ConnectorFormula(F.Implies, Seq(b, _))
+                )
+              ) if F.isSame(F.Neg(a), b) =>
+            conditional(using lib, proof)
 
-        case _ => unconditional
-      }
+          case _ => unconditional(using lib, proof)
+        }
       method(f, uniqueness)(xs)(bot)
     }
 

--- a/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Induction.scala
+++ b/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Induction.scala
@@ -4,7 +4,7 @@ import lisa.automation.settheory.SetTheoryTactics.*
 import lisa.maths.Quantifiers.*
 import lisa.maths.settheory.SetTheory.*
 import lisa.maths.settheory.orderings.InclusionOrders.*
-import lisa.maths.settheory.orderings.Ordinals.*
+import Ordinals.*
 import lisa.maths.settheory.orderings.PartialOrders.*
 import lisa.maths.settheory.orderings.Segments.*
 import lisa.maths.settheory.orderings.WellOrders.*

--- a/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Recursion.scala
+++ b/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Recursion.scala
@@ -5,7 +5,7 @@ import lisa.maths.Quantifiers.*
 import lisa.maths.settheory.SetTheory.*
 import lisa.maths.settheory.orderings.InclusionOrders.*
 import lisa.maths.settheory.orderings.Induction.*
-import lisa.maths.settheory.orderings.Ordinals.*
+import Ordinals.*
 import lisa.maths.settheory.orderings.PartialOrders.*
 import lisa.maths.settheory.orderings.Segments.*
 import lisa.maths.settheory.orderings.WellOrders.*

--- a/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Segments.scala
+++ b/lisa-sets/src/main/scala/lisa/maths/settheory/orderings/Segments.scala
@@ -4,7 +4,7 @@ import lisa.automation.settheory.SetTheoryTactics.*
 import lisa.maths.Quantifiers.*
 import lisa.maths.settheory.SetTheory.*
 import lisa.maths.settheory.orderings.InclusionOrders.*
-import lisa.maths.settheory.orderings.Ordinals.*
+import Ordinals.*
 import lisa.maths.settheory.orderings.PartialOrders.*
 import lisa.maths.settheory.orderings.WellOrders.*
 

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -262,11 +262,11 @@ trait WithTheorems {
      */
     def asOutsideFact(j: JUSTIFICATION): OutsideFact
 
-    def depth: Int = 
-    (this: @unchecked) match {
-      case p: Proof#InnerProof => 1 + p.parent.depth
-      case _: BaseProof => 0
-    }
+    def depth: Int =
+      (this: @unchecked) match {
+        case p: Proof#InnerProof => 1 + p.parent.depth
+        case _: BaseProof => 0
+      }
 
     /**
      * Create a subproof inside the current proof. The subproof will have the same assumptions as the current proof.

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -25,7 +25,7 @@ trait WithTheorems {
    *
    * @param assump list of starting assumptions, usually propagated from outer proofs.
    */
-  sealed abstract class Proof(assump: List[F.Formula]) {
+  abstract class Proof(assump: List[F.Formula]) {
     val possibleGoal: Option[F.Sequent]
     type SelfType = this.type
     type OutsideFact >: JUSTIFICATION
@@ -259,8 +259,8 @@ trait WithTheorems {
      */
     def asOutsideFact(j: JUSTIFICATION): OutsideFact
 
-    @nowarn("msg=.*It would fail on pattern case: _: InnerProof.*")
-    def depth: Int = this match {
+    def depth: Int = 
+    (this: @unchecked) match {
       case p: Proof#InnerProof => 1 + p.parent.depth
       case _: BaseProof => 0
     }

--- a/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
+++ b/lisa-utils/src/main/scala/lisa/prooflib/WithTheorems.scala
@@ -25,6 +25,9 @@ trait WithTheorems {
    *
    * @param assump list of starting assumptions, usually propagated from outer proofs.
    */
+  // TODO: reseal this class
+  // see https://github.com/lampepfl/dotty/issues/19031
+  // and https://github.com/epfl-lara/lisa/issues/190
   abstract class Proof(assump: List[F.Formula]) {
     val possibleGoal: Option[F.Sequent]
     type SelfType = this.type


### PR DESCRIPTION
As filed in `CHANGES.md`:

Upgrade to Scala 3.3.1

- the `Proof` class has been temporarily unsealed, till dotty #19031 / lisa #190 is fixed (not linked here to avoid spamming everyone on those issues)
- minor fixes to address compilation errors, mostly involving explicitly specifying types or implicits in some places.