### PR TITLE
Readd failed substitution reporting

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,8 @@
 # Change List
 
+## 2023-12-06
+Re-added discovery of formulas which could not be substituted for error reporting to `Substitution.ApplyRules`
+
 ## 2023-12-02
 Creation of the present Change Liste, going back to October 2023
 

--- a/lisa-sets/src/main/scala/lisa/automation/Substitution.scala
+++ b/lisa-sets/src/main/scala/lisa/automation/Substitution.scala
@@ -36,8 +36,6 @@ object Substitution {
     def apply(using lib: lisa.prooflib.Library, proof: lib.Proof)(substitutions: (proof.Fact | F.Formula | lib.JUSTIFICATION)*)(
         premise: proof.Fact
     )(bot: F.Sequent): proof.ProofTacticJudgement = {
-      // lazy val substitutionsK = substitutions.map()
-
       // figure out instantiations for rules
       // takes a premise
       val premiseSequent: F.Sequent = proof.getSequent(premise)
@@ -156,8 +154,30 @@ object Substitution {
           takenFormulaVars
         )
 
-        lazy val violatingFormulaLeft: Option[Formula] = Some(top) // TODO
-        lazy val violatingFormulaRight: Option[Formula] = Some(top) // TODO
+        lazy val rightPairs = premiseSequent.right zip premiseSequent.right.map(x => bot.right.find(y => UnificationUtils.getContextFormula(
+          x,
+          y,
+          freeEqualities,
+          freeIffs,
+          confinedEqualities,
+          takenTermVars,
+          confinedIffs,
+          takenFormulaVars
+        ).isDefined))
+
+        lazy val leftPairs = filteredPrem zip filteredPrem.map(x => filteredBot.find(y => UnificationUtils.getContextFormula(
+          x,
+          y,
+          freeEqualities,
+          freeIffs,
+          confinedEqualities,
+          takenTermVars,
+          confinedIffs,
+          takenFormulaVars
+        ).isDefined))
+
+        lazy val violatingFormulaLeft = leftPairs.find(_._2.isEmpty)
+        lazy val violatingFormulaRight = rightPairs.find(_._2.isEmpty)
 
         if (leftContextsOpt.isEmpty)
           proof.InvalidProofTactic(s"Could not rewrite LHS of premise into conclusion with given substitutions.\nViolating Formula: ${violatingFormulaLeft.get}")


### PR DESCRIPTION
As title says. 

The error reporting was removed and replaced with a TODO in one of the older types PRs. I've added it back, this time with the new unification API. 