### PR TITLE
Depend on Scallion and Silex via release JARs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Set up JDK 
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 17
       - name: Compile
         run: sbt compile

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,10 @@
 # Change List
 
 ## 2024-10-04
+Bump version to 0.7.
+Update sbt to 1.10.1.
+Move `scallion` and `silex` to depend on jars via GitHub releases instead of cloning and compiling locally.
+Tests now fork the jvm and use jvm options correctly, which also removes the relevant warning during testing.
 Repair two broken tests, small improvements to congruence tactic.
 
 ## 2024-10-03

--- a/build.sbt
+++ b/build.sbt
@@ -38,7 +38,8 @@ val commonSettings3 = commonSettings ++ Seq(
   javaOptions += "-Xmx10G",
   libraryDependencies += "org.scalatest" %% "scalatest" % "3.2.18" % "test",
   libraryDependencies += "com.lihaoyi" %% "sourcecode" % "0.4.1",
-  Test / parallelExecution := false
+  Test / parallelExecution := false,
+  Test / fork := true
 )
 
 def withTests(project: Project): ClasspathDependency =

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / version      := "0.6"
+ThisBuild / version      := "0.7"
 ThisBuild / homepage := Some(url("https://github.com/epfl-lara/lisa"))
 ThisBuild / startYear := Some(2021)
 ThisBuild / organization := "ch.epfl.lara"

--- a/build.sbt
+++ b/build.sbt
@@ -46,15 +46,7 @@ def withTests(project: Project): ClasspathDependency =
 
 def githubProject(repo: String, commitHash: String) = RootProject(uri(s"$repo#$commitHash"))
 
-lazy val scallion = githubProject("https://github.com/sankalpgambhir/scallion.git", "6434e21bd08872cf547c8f0efb67c963bfdf4190")
-
-lazy val silex = githubProject("https://github.com/epfl-lara/silex.git", "fc07a8670a5fa8ea2dd5649a00424710274a5d18")
 lazy val customTstpParser = githubProject("https://github.com/SimonGuilloud/scala-tptp-parser.git", "eae9c1b7a9546f74779d77ff50fa6e8a1654cfa0")
-
-scallion/scalacOptions ~= (_.filterNot(Set("-Wvalue-discard")))
-scallion/scalacOptions += "-Wconf:any:silent"
-
-silex/scalacOptions ~= (_.filterNot(Set("-Wvalue-discard")))
 
 lazy val root = Project(
     id = "lisa",
@@ -86,11 +78,11 @@ lazy val utils = Project(
   id = "lisa-utils",
   base = file("lisa-utils")
 )
-
-  .settings(commonSettings3)
+  .settings(commonSettings3 ++ Seq(
+    libraryDependencies += "ch.epfl.lara" %% "scallion" % "0.6" from "https://github.com/epfl-lara/scallion/releases/download/v0.6/scallion_3-0.6.jar",
+    libraryDependencies += "ch.epfl.lara" %% "silex" % "0.6" from "https://github.com/epfl-lara/silex/releases/download/v0.6/silex_3-0.6.jar",
+  ))
   .dependsOn(kernel)
-  .dependsOn(silex)
-  .dependsOn(scallion % "compile->compile")
   .dependsOn(customTstpParser)
   //.settings(libraryDependencies += "io.github.leoprover" % "scala-tptp-parser_2.13" % "1.4")
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,2 +1,2 @@
 
-sbt.version = 1.9.9
+sbt.version = 1.10.1


### PR DESCRIPTION
Complete changelist:

- Bump version to 0.7.
- Update sbt to 1.10.1.
- Move `scallion` and `silex` to depend on jars via GitHub releases instead of cloning and compiling locally.
- Tests now fork the jvm and use jvm options correctly, which also removes the relevant warning during testing.

Edit: also updated CI actions to recent versions